### PR TITLE
Fixed bug in hadling of surface_geometries with multiple  surface_dat…

### DIFF
--- a/src/org/citydb/modules/kml/database/CityFurniture.java
+++ b/src/org/citydb/modules/kml/database/CityFurniture.java
@@ -529,7 +529,7 @@ public class CityFurniture extends KmlGenericObject{
 								addX3dMaterial(surfaceId, x3dMaterial);
 							}
 							else if (theme == null) { // no theme for this parent surface
-								if (getX3dMaterial(parentId) != null) { // material for parent's parent known
+								if (getX3dMaterial(parentId) != null && getX3dMaterial(surfaceId) == null) { // material for parent's parent known
 									addX3dMaterial(surfaceId, getX3dMaterial(parentId));
 								}
 							}
@@ -542,16 +542,20 @@ public class CityFurniture extends KmlGenericObject{
 						String texImageUri = null;
 						StringTokenizer texCoordsTokenized = null;
 
-						if (selectedTheme.equals(KmlExporter.THEME_NONE))
-							addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+						if (selectedTheme.equals(KmlExporter.THEME_NONE)) {
+							if (getX3dMaterial(surfaceId) == null)
+								addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+						}
 						else {
 							if (!selectedTheme.equalsIgnoreCase(theme) && !selectedTheme.equalsIgnoreCase("<unknown>")) { // no surface data for this surface and theme
-								if (getX3dMaterial(parentId) != null) // material for parent surface known
-									addX3dMaterial(surfaceId, getX3dMaterial(parentId));
-								else if (getX3dMaterial(rootId) != null) // material for root surface known
-									addX3dMaterial(surfaceId, getX3dMaterial(rootId));
-								else
-									addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+								if (getX3dMaterial(surfaceId) == null) {
+									if (getX3dMaterial(parentId) != null) // material for parent surface known
+										addX3dMaterial(surfaceId, getX3dMaterial(parentId));
+									else if (getX3dMaterial(rootId) != null) // material for root surface known
+										addX3dMaterial(surfaceId, getX3dMaterial(rootId));
+									else
+										addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+								}
 							}
 							else {
 								texImageUri = rs2.getString("tex_image_uri");
@@ -612,8 +616,12 @@ public class CityFurniture extends KmlGenericObject{
 									// x3dMaterial will only added if not all x3dMaterial members are null
 									addX3dMaterial(surfaceId, x3dMaterial);
 									if (getX3dMaterial(surfaceId) == null) {
-										// untextured surface and no x3dMaterial -> default x3dMaterial (gray)
-										addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+										if (getX3dMaterial(parentId) != null) // material for parent surface known
+											addX3dMaterial(surfaceId, getX3dMaterial(parentId));
+										else if (getX3dMaterial(rootId) != null) // material for root surface known
+											addX3dMaterial(surfaceId, getX3dMaterial(rootId));
+										else // untextured surface and no x3dMaterial -> default x3dMaterial (gray)
+											addX3dMaterial(surfaceId, x3dSurfaceMaterial);
 									}
 								}
 							}

--- a/src/org/citydb/modules/kml/database/GenericCityObject.java
+++ b/src/org/citydb/modules/kml/database/GenericCityObject.java
@@ -577,7 +577,7 @@ public class GenericCityObject extends KmlGenericObject{
 								addX3dMaterial(surfaceId, x3dMaterial);
 							}
 							else if (theme == null) { // no theme for this parent surface
-								if (getX3dMaterial(parentId) != null) { // material for parent's parent known
+								if (getX3dMaterial(parentId) != null && getX3dMaterial(surfaceId) == null) { // material for parent's parent known
 									addX3dMaterial(surfaceId, getX3dMaterial(parentId));
 								}
 							}
@@ -590,16 +590,20 @@ public class GenericCityObject extends KmlGenericObject{
 						String texImageUri = null;
 						StringTokenizer texCoordsTokenized = null;
 
-						if (selectedTheme.equals(KmlExporter.THEME_NONE))
-							addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+						if (selectedTheme.equals(KmlExporter.THEME_NONE)) {
+							if (getX3dMaterial(surfaceId) == null)
+								addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+						}
 						else {
 							if (!selectedTheme.equalsIgnoreCase(theme) && !selectedTheme.equalsIgnoreCase("<unknown>")) { // no surface data for this surface and theme
-								if (getX3dMaterial(parentId) != null) // material for parent surface known
-									addX3dMaterial(surfaceId, getX3dMaterial(parentId));
-								else if (getX3dMaterial(rootId) != null) // material for root surface known
-									addX3dMaterial(surfaceId, getX3dMaterial(rootId));
-								else
-									addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+								if (getX3dMaterial(surfaceId) == null) {
+									if (getX3dMaterial(parentId) != null) // material for parent surface known
+										addX3dMaterial(surfaceId, getX3dMaterial(parentId));
+									else if (getX3dMaterial(rootId) != null) // material for root surface known
+										addX3dMaterial(surfaceId, getX3dMaterial(rootId));
+									else
+										addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+								}
 							}
 							else {
 								texImageUri = rs2.getString("tex_image_uri");
@@ -660,8 +664,12 @@ public class GenericCityObject extends KmlGenericObject{
 									// x3dMaterial will only added if not all x3dMaterial members are null
 									addX3dMaterial(surfaceId, x3dMaterial);
 									if (getX3dMaterial(surfaceId) == null) {
-										// untextured surface and no x3dMaterial -> default x3dMaterial (gray)
-										addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+										if (getX3dMaterial(parentId) != null) // material for parent surface known
+											addX3dMaterial(surfaceId, getX3dMaterial(parentId));
+										else if (getX3dMaterial(rootId) != null) // material for root surface known
+											addX3dMaterial(surfaceId, getX3dMaterial(rootId));
+										else // untextured surface and no x3dMaterial -> default x3dMaterial (gray)
+											addX3dMaterial(surfaceId, x3dSurfaceMaterial);
 									}
 								}
 							}

--- a/src/org/citydb/modules/kml/database/KmlGenericObject.java
+++ b/src/org/citydb/modules/kml/database/KmlGenericObject.java
@@ -1733,7 +1733,7 @@ public abstract class KmlGenericObject {
 								addX3dMaterial(surfaceId, x3dMaterial);
 							}
 							else if (theme == null) { // no theme for this parent surface
-								if (getX3dMaterial(parentId) != null) { // material for parent's parent known
+								if (getX3dMaterial(parentId) != null && getX3dMaterial(surfaceId) == null) { // material for parent's parent known
 									addX3dMaterial(surfaceId, getX3dMaterial(parentId));
 								}
 							}
@@ -1758,33 +1758,37 @@ public abstract class KmlGenericObject {
 						StringTokenizer texCoordsTokenized = null;
 						
 						if (selectedTheme.equals(KmlExporter.THEME_NONE)) {
-							if (surfaceTypeID != 0){
-								if (Util.classId2cityObject(surfaceTypeID)==CityGMLClass.BUILDING_WALL_SURFACE ||
-										Util.classId2cityObject(surfaceTypeID)==CityGMLClass.BRIDGE_WALL_SURFACE ||
-										Util.classId2cityObject(surfaceTypeID)==CityGMLClass.TUNNEL_WALL_SURFACE){
-									addX3dMaterial(surfaceId, x3dWallMaterial);
-								}
-								else if (Util.classId2cityObject(surfaceTypeID)==CityGMLClass.BUILDING_ROOF_SURFACE ||
-										Util.classId2cityObject(surfaceTypeID)==CityGMLClass.BRIDGE_ROOF_SURFACE ||
-										Util.classId2cityObject(surfaceTypeID)==CityGMLClass.TUNNEL_ROOF_SURFACE) {						
-									addX3dMaterial(surfaceId, x3dRoofMaterial);
-								}
-								else {
-									addX3dMaterial(surfaceId, x3dWallMaterial);
-								}
-							}
-							else {
-								addX3dMaterial(surfaceId, x3dWallMaterial);
-							}
+							if (getX3dMaterial(surfaceId) == null) {
+                                if (surfaceTypeID != 0) {
+                                    if (Util.classId2cityObject(surfaceTypeID) == CityGMLClass.BUILDING_WALL_SURFACE ||
+                                            Util.classId2cityObject(surfaceTypeID) == CityGMLClass.BRIDGE_WALL_SURFACE ||
+                                            Util.classId2cityObject(surfaceTypeID) == CityGMLClass.TUNNEL_WALL_SURFACE) {
+                                        addX3dMaterial(surfaceId, x3dWallMaterial);
+                                    }
+                                    else if (Util.classId2cityObject(surfaceTypeID) == CityGMLClass.BUILDING_ROOF_SURFACE ||
+                                            Util.classId2cityObject(surfaceTypeID) == CityGMLClass.BRIDGE_ROOF_SURFACE ||
+                                            Util.classId2cityObject(surfaceTypeID) == CityGMLClass.TUNNEL_ROOF_SURFACE) {
+                                        addX3dMaterial(surfaceId, x3dRoofMaterial);
+                                    }
+                                    else {
+                                        addX3dMaterial(surfaceId, x3dWallMaterial);
+                                    }
+                                }
+                                else {
+                                    addX3dMaterial(surfaceId, x3dWallMaterial);
+                                }
+                            }
 						}
 						else {
 							if (!selectedTheme.equalsIgnoreCase(theme) && !selectedTheme.equalsIgnoreCase("<unknown>")) { // no surface data for this surface and theme
-								if (getX3dMaterial(parentId) != null) // material for parent surface known
-									addX3dMaterial(surfaceId, getX3dMaterial(parentId));
-								else if (getX3dMaterial(rootId) != null) // material for root surface known
-									addX3dMaterial(surfaceId, getX3dMaterial(rootId));
-								else
-									addX3dMaterial(surfaceId, x3dWallMaterial);
+                                if (getX3dMaterial(surfaceId) == null) {
+                                    if (getX3dMaterial(parentId) != null) // material for parent surface known
+                                        addX3dMaterial(surfaceId, getX3dMaterial(parentId));
+                                    else if (getX3dMaterial(rootId) != null) // material for root surface known
+                                        addX3dMaterial(surfaceId, getX3dMaterial(rootId));
+                                    else
+                                        addX3dMaterial(surfaceId, x3dWallMaterial);
+                                }
 							}
 							else {
 								texImageUri = rs2.getString("tex_image_uri");
@@ -1847,8 +1851,13 @@ public abstract class KmlGenericObject {
 									// x3dMaterial will only added if not all x3dMaterial members are null
 									addX3dMaterial(surfaceId, x3dMaterial);
 									if (getX3dMaterial(surfaceId) == null) {
-										// untextured surface and no x3dMaterial -> default x3dMaterial (gray)
-										addX3dMaterial(surfaceId, x3dWallMaterial);
+                                        if (getX3dMaterial(parentId) != null) // material for parent surface known
+                                            addX3dMaterial(surfaceId, getX3dMaterial(parentId));
+                                        else if (getX3dMaterial(rootId) != null) // material for root surface known
+                                            addX3dMaterial(surfaceId, getX3dMaterial(rootId));
+                                        else
+                                            // untextured surface and no x3dMaterial -> default x3dMaterial (gray)
+                                            addX3dMaterial(surfaceId, x3dWallMaterial);
 									}
 								}
 							}

--- a/src/org/citydb/modules/kml/database/SolitaryVegetationObject.java
+++ b/src/org/citydb/modules/kml/database/SolitaryVegetationObject.java
@@ -525,7 +525,7 @@ public class SolitaryVegetationObject extends KmlGenericObject{
 								addX3dMaterial(surfaceId, x3dMaterial);
 							}
 							else if (theme == null) { // no theme for this parent surface
-								if (getX3dMaterial(parentId) != null) { // material for parent's parent known
+								if (getX3dMaterial(parentId) != null && getX3dMaterial(surfaceId) == null) { // material for parent's parent known
 									addX3dMaterial(surfaceId, getX3dMaterial(parentId));
 								}
 							}
@@ -538,16 +538,20 @@ public class SolitaryVegetationObject extends KmlGenericObject{
 						String texImageUri = null;
 						StringTokenizer texCoordsTokenized = null;
 
-						if (selectedTheme.equals(KmlExporter.THEME_NONE))
-							addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+						if (selectedTheme.equals(KmlExporter.THEME_NONE)) {
+							if (getX3dMaterial(surfaceId) == null)
+								addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+						}
 						else {
 							if (!selectedTheme.equalsIgnoreCase(theme) && !selectedTheme.equalsIgnoreCase("<unknown>")) { // no surface data for this surface and theme
-								if (getX3dMaterial(parentId) != null) // material for parent surface known
-									addX3dMaterial(surfaceId, getX3dMaterial(parentId));
-								else if (getX3dMaterial(rootId) != null) // material for root surface known
-									addX3dMaterial(surfaceId, getX3dMaterial(rootId));
-								else
-									addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+								if (getX3dMaterial(surfaceId) == null) {
+									if (getX3dMaterial(parentId) != null) // material for parent surface known
+										addX3dMaterial(surfaceId, getX3dMaterial(parentId));
+									else if (getX3dMaterial(rootId) != null) // material for root surface known
+										addX3dMaterial(surfaceId, getX3dMaterial(rootId));
+									else
+										addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+								}
 							}
 							else {
 								texImageUri = rs2.getString("tex_image_uri");
@@ -608,8 +612,12 @@ public class SolitaryVegetationObject extends KmlGenericObject{
 									// x3dMaterial will only added if not all x3dMaterial members are null
 									addX3dMaterial(surfaceId, x3dMaterial);
 									if (getX3dMaterial(surfaceId) == null) {
-										// untextured surface and no x3dMaterial -> default x3dMaterial (gray)
-										addX3dMaterial(surfaceId, x3dSurfaceMaterial);
+										if (getX3dMaterial(parentId) != null) // material for parent surface known
+											addX3dMaterial(surfaceId, getX3dMaterial(parentId));
+										else if (getX3dMaterial(rootId) != null) // material for root surface known
+											addX3dMaterial(surfaceId, getX3dMaterial(rootId));
+										else // untextured surface and no x3dMaterial -> default x3dMaterial (gray)
+											addX3dMaterial(surfaceId, x3dSurfaceMaterial);
 									}
 								}
 							}


### PR DESCRIPTION
…a for different appearance themes.

The surface_geometry - textureparam - surface_data - appear_to_surface_data - appearance join was originally read
row by row, and if the row with the surface_data - appearance of the selected theme was read first the material
data would be overwritten with the default material by reading of the next row containing surface_data
connected to another appearance theme.