### PR TITLE
fixed disabled VACUUM button issue

### DIFF
--- a/impexp-client/src/main/java/org/citydb/modules/database/gui/operations/IndexOperation.java
+++ b/impexp-client/src/main/java/org/citydb/modules/database/gui/operations/IndexOperation.java
@@ -576,8 +576,12 @@ public class IndexOperation extends DatabaseOperationView {
 
 	@Override
 	public void handleDatabaseConnectionStateEvent(DatabaseConnectionStateEvent event) {
-		if (event.isConnected())
+		boolean isConnected = event.isConnected();
+		
+		if (isConnected)
 			isStatsSupported = dbConnectionPool.getActiveDatabaseAdapter().hasTableStatsSupport();
+		
+		setEnabled(isConnected);
 	}
 
 }

--- a/impexp-client/src/main/java/org/citydb/modules/database/gui/operations/IndexOperation.java
+++ b/impexp-client/src/main/java/org/citydb/modules/database/gui/operations/IndexOperation.java
@@ -576,12 +576,8 @@ public class IndexOperation extends DatabaseOperationView {
 
 	@Override
 	public void handleDatabaseConnectionStateEvent(DatabaseConnectionStateEvent event) {
-		boolean isConnected = event.isConnected();
-		
-		if (isConnected)
+		if (event.isConnected())
 			isStatsSupported = dbConnectionPool.getActiveDatabaseAdapter().hasTableStatsSupport();
-		
-		setEnabled(isConnected);
 	}
 
 }

--- a/impexp-client/src/main/java/org/citydb/modules/database/gui/view/DatabasePanel.java
+++ b/impexp-client/src/main/java/org/citydb/modules/database/gui/view/DatabasePanel.java
@@ -143,9 +143,9 @@ public class DatabasePanel extends JPanel implements ConnectionViewHandler, Even
 		this.config = config;		
 
 		databaseController = ObjectRegistry.getInstance().getDatabaseController();
-		ObjectRegistry.getInstance().getEventDispatcher().addEventHandler(EventType.DATABASE_CONNECTION_STATE, this);
 
-		initGui();		
+		initGui();
+		ObjectRegistry.getInstance().getEventDispatcher().addEventHandler(EventType.DATABASE_CONNECTION_STATE, this);
 	}
 
 	private boolean isModified() {


### PR DESCRIPTION
When launching the import-export-tool and then connecting to a PostGIS database, The VACUUM button in the Database panel cannot be enabled automatically. This issue is new and does not appear in the release version 3.3.2. This pull request attempts to fix this issue. 