### PR TITLE
Add support for non-GUI plugins

### DIFF
--- a/impexp-client/build.gradle
+++ b/impexp-client/build.gradle
@@ -16,7 +16,6 @@ configurations {
 dependencies {
     compile project(':impexp-core')
     compile project(':impexp-client-common')
-    compile project(':impexp-plugin-api')
     compile project(':impexp-kml-collada-plugin')
     compile 'args4j:args4j:2.33'
     compile 'com.fifesoft:rsyntaxtextarea:3.0.0'

--- a/impexp-client/src/main/java/org/citydb/ImpExp.java
+++ b/impexp-client/src/main/java/org/citydb/ImpExp.java
@@ -37,7 +37,6 @@ import org.citydb.config.i18n.Language;
 import org.citydb.config.project.Project;
 import org.citydb.config.project.global.LanguageType;
 import org.citydb.config.project.global.Logging;
-import org.citydb.config.project.plugin.PluginConfig;
 import org.citydb.config.project.query.util.QueryWrapper;
 import org.citydb.database.DatabaseController;
 import org.citydb.database.schema.mapping.SchemaMapping;
@@ -256,7 +255,7 @@ public class ImpExp {
 		projectConfigClasses.add(Project.class);
 		projectConfigClasses.add(QueryWrapper.class);
 
-		for (ConfigExtension<? extends PluginConfig> plugin : pluginManager.getExternalConfigExtensions()) {
+		for (ConfigExtension<?> plugin : pluginManager.getExternalPlugins(ConfigExtension.class)) {
 			try {
 				projectConfigClasses.add(plugin.getClass().getMethod("getConfig").getReturnType());
 			} catch (SecurityException | NoSuchMethodException e) {
@@ -487,7 +486,7 @@ public class ImpExp {
 			databaseController.setConnectionViewHandler(databasePlugin.getConnectionViewHandler());
 
 			// propagate config to plugins
-			for (ConfigExtension<? extends PluginConfig> plugin : pluginManager.getExternalConfigExtensions())
+			for (ConfigExtension<?> plugin : pluginManager.getExternalPlugins(ConfigExtension.class))
 				PluginConfigController.getInstance(config).setOrCreatePluginConfig(plugin);
 
 			// register internal plugins

--- a/impexp-client/src/main/java/org/citydb/ImpExp.java
+++ b/impexp-client/src/main/java/org/citydb/ImpExp.java
@@ -36,6 +36,7 @@ import org.citydb.config.gui.Gui;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.Project;
 import org.citydb.config.project.global.LanguageType;
+import org.citydb.config.project.global.LogLevel;
 import org.citydb.config.project.global.Logging;
 import org.citydb.config.project.query.util.QueryWrapper;
 import org.citydb.database.DatabaseController;
@@ -91,8 +92,10 @@ import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.stream.Stream;
 
@@ -135,7 +138,7 @@ public class ImpExp {
 
 	private SplashScreen splashScreen;
 	private boolean useSplashScreen;
-	private List<String> errMsgs = new ArrayList<>();
+	private Map<LogLevel, String> logMessages = new HashMap<>();
 
 	public static void main(String[] args) {
 		new ImpExp().doMain(args);
@@ -410,8 +413,10 @@ public class ImpExp {
 				log.error(errMsg);
 				log.error("Aborting...");
 				System.exit(1);
-			} else
-				errMsgs.add(errMsg);
+			} else {
+				logMessages.put(LogLevel.ERROR, errMsg);
+				logMessages.put(LogLevel.INFO, "Project settings initialized using default values.");
+			}
 		} finally {
 			config.setProject(project);
 		}
@@ -515,7 +520,7 @@ public class ImpExp {
 
 			// initialize gui
 			printInfoMessage("Starting graphical user interface");
-			SwingUtilities.invokeLater(() -> mainView.invoke(projectContext, guiContext, errMsgs));
+			SwingUtilities.invokeLater(() -> mainView.invoke(projectContext, guiContext, logMessages));
 
 			try {
 				// clean up heap space

--- a/impexp-client/src/main/java/org/citydb/ImpExp.java
+++ b/impexp-client/src/main/java/org/citydb/ImpExp.java
@@ -60,6 +60,7 @@ import org.citydb.plugin.Plugin;
 import org.citydb.plugin.PluginConfigController;
 import org.citydb.plugin.PluginManager;
 import org.citydb.plugin.extension.config.ConfigExtension;
+import org.citydb.plugin.extension.view.ViewExtension;
 import org.citydb.registry.ObjectRegistry;
 import org.citydb.util.ClientConstants;
 import org.citydb.util.CoreConstants;
@@ -493,8 +494,6 @@ public class ImpExp {
 				log.info("Initializing plugin " + plugin.getClass().getName());
 				if (useSplashScreen)
 					splashScreen.setMessage("Initializing plugin " + plugin.getClass().getName());
-
-				plugin.init(mainView, new Locale(lang.value()));
 			}
 
 			// register internal plugins
@@ -504,9 +503,10 @@ public class ImpExp {
 			pluginManager.registerInternalPlugin(databasePlugin);
 			pluginManager.registerInternalPlugin(new PreferencesPlugin(mainView, config));
 
-			// initialize internal plugins
-			for (Plugin plugin : pluginManager.getInternalPlugins())
-				plugin.init(mainView, new Locale(lang.value()));
+			for (Plugin plugin : pluginManager.getPlugins()) {
+				if (plugin instanceof ViewExtension)
+					((ViewExtension) plugin).initViewExtension(mainView, new Locale(lang.value()));
+			}
 
 			// initialize gui
 			printInfoMessage("Starting graphical user interface");

--- a/impexp-client/src/main/java/org/citydb/ImpExp.java
+++ b/impexp-client/src/main/java/org/citydb/ImpExp.java
@@ -56,6 +56,7 @@ import org.citydb.modules.database.DatabasePlugin;
 import org.citydb.modules.kml.KMLExportPlugin;
 import org.citydb.modules.preferences.PreferencesPlugin;
 import org.citydb.plugin.IllegalEventSourceChecker;
+import org.citydb.plugin.InternalPlugin;
 import org.citydb.plugin.Plugin;
 import org.citydb.plugin.PluginConfigController;
 import org.citydb.plugin.PluginManager;
@@ -489,13 +490,6 @@ public class ImpExp {
 			for (ConfigExtension<? extends PluginConfig> plugin : pluginManager.getExternalConfigExtensions())
 				PluginConfigController.getInstance(config).setOrCreatePluginConfig(plugin);
 
-			// initialize plugins
-			for (Plugin plugin : pluginManager.getExternalPlugins()) {
-				log.info("Initializing plugin " + plugin.getClass().getName());
-				if (useSplashScreen)
-					splashScreen.setMessage("Initializing plugin " + plugin.getClass().getName());
-			}
-
 			// register internal plugins
 			pluginManager.registerInternalPlugin(new CityGMLImportPlugin(mainView, config));		
 			pluginManager.registerInternalPlugin(new CityGMLExportPlugin(mainView, projectContext, config));
@@ -503,7 +497,14 @@ public class ImpExp {
 			pluginManager.registerInternalPlugin(databasePlugin);
 			pluginManager.registerInternalPlugin(new PreferencesPlugin(mainView, config));
 
+			// initialize plugins
 			for (Plugin plugin : pluginManager.getPlugins()) {
+				if (!(plugin instanceof InternalPlugin)) {
+					log.info("Initializing plugin " + plugin.getClass().getName());
+					if (useSplashScreen)
+						splashScreen.setMessage("Initializing plugin " + plugin.getClass().getName());
+				}
+
 				if (plugin instanceof ViewExtension)
 					((ViewExtension) plugin).initViewExtension(mainView, new Locale(lang.value()));
 			}

--- a/impexp-client/src/main/java/org/citydb/gui/ImpExpGui.java
+++ b/impexp-client/src/main/java/org/citydb/gui/ImpExpGui.java
@@ -34,6 +34,7 @@ import org.citydb.config.gui.window.MainWindow;
 import org.citydb.config.gui.window.WindowSize;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.global.LanguageType;
+import org.citydb.config.project.global.LogLevel;
 import org.citydb.database.connection.DatabaseConnectionPool;
 import org.citydb.event.Event;
 import org.citydb.event.EventDispatcher;
@@ -91,6 +92,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
@@ -149,22 +151,21 @@ public final class ImpExpGui extends JFrame implements ViewController, EventHand
 
 	public void invoke(JAXBContext jaxbProjectContext,
 			JAXBContext jaxbGuiContext,
-			List<String> errMsgs) {		
+			Map<LogLevel, String> logMessages) {
 		this.jaxbProjectContext = jaxbProjectContext;
 		this.jaxbGuiContext = jaxbGuiContext;		
 		
 		// init GUI elements
-		initGui();
+		initGui(logMessages);
 		doTranslation();
 		showWindow();
 
 		// initConsole;
 		initConsole();
 
-		if (!errMsgs.isEmpty()) {
-			for (String msg : errMsgs)
-				log.error(msg);
-			log.info("Project settings initialized using default values.");
+		if (!logMessages.isEmpty()) {
+			for (Map.Entry<LogLevel, String> entry : logMessages.entrySet())
+				log.log(entry.getKey(), entry.getValue());
 		}
 
 		// log exceptions for disabled ADE extensions
@@ -179,7 +180,7 @@ public final class ImpExpGui extends JFrame implements ViewController, EventHand
 		showWindow();
 	}
 
-	private void initGui() {
+	private void initGui(Map<LogLevel, String> logMessages) {
 		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
 		activePosition = 0;
@@ -219,8 +220,15 @@ public final class ImpExpGui extends JFrame implements ViewController, EventHand
 		views.add(pluginManager.getInternalPlugin(CityGMLExportPlugin.class).getView());
 		views.add(pluginManager.getInternalPlugin(KMLExportPlugin.class).getView());
 
-		for (ViewExtension viewExtension : pluginManager.getExternalPlugins(ViewExtension.class))
-			views.add(viewExtension.getView());
+		for (ViewExtension viewExtension : pluginManager.getExternalPlugins(ViewExtension.class)) {
+			View view = viewExtension.getView();
+			if (view == null || view.getViewComponent() == null) {
+				logMessages.put(LogLevel.ERROR, "Failed to get view component from plugin " + viewExtension.getClass().getName() + ".");
+				continue;
+			}
+
+			views.add(view);
+		}
 
 		views.add(databasePlugin.getView());
 		views.add(preferencesPlugin.getView());

--- a/impexp-client/src/main/java/org/citydb/gui/ImpExpGui.java
+++ b/impexp-client/src/main/java/org/citydb/gui/ImpExpGui.java
@@ -68,18 +68,7 @@ import org.citydb.registry.ObjectRegistry;
 import org.citydb.util.ClientConstants;
 import org.citydb.util.CoreConstants;
 
-import javax.swing.BorderFactory;
-import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JSplitPane;
-import javax.swing.JTabbedPane;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import javax.swing.event.ChangeEvent;
@@ -90,17 +79,7 @@ import javax.swing.plaf.basic.BasicSplitPaneDivider;
 import javax.swing.plaf.basic.BasicSplitPaneUI;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.GraphicsConfiguration;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.Rectangle;
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.IOException;
@@ -238,7 +217,7 @@ public final class ImpExpGui extends JFrame implements ViewController, EventHand
 		views.add(pluginManager.getInternalPlugin(CityGMLExportPlugin.class).getView());
 		views.add(pluginManager.getInternalPlugin(KMLExportPlugin.class).getView());
 
-		for (ViewExtension viewExtension : pluginManager.getExternalViewExtensions())
+		for (ViewExtension viewExtension : pluginManager.getExternalPlugins(ViewExtension.class))
 			views.add(viewExtension.getView());
 
 		views.add(databasePlugin.getView());

--- a/impexp-client/src/main/java/org/citydb/gui/ImpExpGui.java
+++ b/impexp-client/src/main/java/org/citydb/gui/ImpExpGui.java
@@ -425,8 +425,10 @@ public final class ImpExpGui extends JFrame implements ViewController, EventHand
 			consoleLabel.setText(Language.I18N.getString("main.console.label"));
 
 			// fire translation notification to plugins
-			for (Plugin plugin : pluginManager.getPlugins())
-				plugin.switchLocale(locale);
+			for (Plugin plugin : pluginManager.getPlugins()) {
+				if (plugin instanceof ViewExtension)
+					((ViewExtension) plugin).switchLocale(locale);
+			}
 
 			int index = 0;
 			for (View view : views)

--- a/impexp-client/src/main/java/org/citydb/gui/components/menubar/MenuBar.java
+++ b/impexp-client/src/main/java/org/citydb/gui/components/menubar/MenuBar.java
@@ -32,7 +32,9 @@ import org.citydb.config.i18n.Language;
 import org.citydb.gui.ImpExpGui;
 import org.citydb.gui.util.GuiUtil;
 import org.citydb.gui.util.OSXAdapter;
+import org.citydb.log.Logger;
 import org.citydb.plugin.PluginManager;
+import org.citydb.plugin.extension.menu.Menu;
 import org.citydb.plugin.extension.menu.MenuExtension;
 
 import javax.swing.*;
@@ -67,14 +69,20 @@ public class MenuBar extends JMenuBar {
 		add(project);
 
 		for (MenuExtension extension : pluginManager.getExternalPlugins(MenuExtension.class)) {
+			Menu menu = extension.getMenu();
+			if (menu == null || menu.getMenuComponent() == null) {
+				Logger.getInstance().error("Failed to get menu entry from plugin " + extension.getClass().getName() + ".");
+				continue;
+			}
+
 			if (extensions == null)
 				extensions = new JMenu();
 
-			JMenu menu = extension.getMenu().getMenuComponent();
-			menu.setText(extension.getMenu().getLocalizedTitle());
-			menu.setIcon(extension.getMenu().getIcon());
-			GuiUtil.setMnemonic(menu, menu.getText(), extension.getMenu().getMnemonicIndex());
-			extensions.add(menu);
+			JMenu component = menu.getMenuComponent();
+			component.setText(menu.getLocalizedTitle());
+			component.setIcon(menu.getIcon());
+			GuiUtil.setMnemonic(component, component.getText(), menu.getMnemonicIndex());
+			extensions.add(component);
 		}
 
 		if (extensions != null)

--- a/impexp-client/src/main/java/org/citydb/gui/components/menubar/MenuBar.java
+++ b/impexp-client/src/main/java/org/citydb/gui/components/menubar/MenuBar.java
@@ -35,8 +35,7 @@ import org.citydb.gui.util.OSXAdapter;
 import org.citydb.plugin.PluginManager;
 import org.citydb.plugin.extension.menu.MenuExtension;
 
-import javax.swing.JMenu;
-import javax.swing.JMenuBar;
+import javax.swing.*;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.xml.bind.JAXBContext;
@@ -67,7 +66,7 @@ public class MenuBar extends JMenuBar {
 		
 		add(project);
 
-		for (MenuExtension extension : pluginManager.getExternalMenuExtensions()) {
+		for (MenuExtension extension : pluginManager.getExternalPlugins(MenuExtension.class)) {
 			if (extensions == null)
 				extensions = new JMenu();
 
@@ -114,7 +113,7 @@ public class MenuBar extends JMenuBar {
 			GuiUtil.setMnemonic(extensions, "menu.extensions.label", "menu.extensions.label.mnemonic");
 
 			int index = 0;
-			for (MenuExtension extension : pluginManager.getExternalMenuExtensions())
+			for (MenuExtension extension : pluginManager.getExternalPlugins(MenuExtension.class))
 				((JMenu)extensions.getMenuComponent(index++)).setText(extension.getMenu().getLocalizedTitle());
 		}
 

--- a/impexp-client/src/main/java/org/citydb/gui/components/menubar/MenuProject.java
+++ b/impexp-client/src/main/java/org/citydb/gui/components/menubar/MenuProject.java
@@ -27,14 +27,11 @@
  */
 package org.citydb.gui.components.menubar;
 
-import org.citydb.util.ClientConstants;
 import org.citydb.config.Config;
-import org.citydb.util.CoreConstants;
 import org.citydb.config.ConfigUtil;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.Project;
 import org.citydb.config.project.global.Logging;
-import org.citydb.config.project.plugin.PluginConfig;
 import org.citydb.event.global.ProjectChangedEvent;
 import org.citydb.gui.ImpExpGui;
 import org.citydb.gui.factory.SrsComboBoxFactory;
@@ -47,16 +44,14 @@ import org.citydb.plugin.PluginManager;
 import org.citydb.plugin.extension.config.ConfigExtension;
 import org.citydb.plugin.extension.config.PluginConfigEvent;
 import org.citydb.registry.ObjectRegistry;
+import org.citydb.util.ClientConstants;
+import org.citydb.util.CoreConstants;
 
-import javax.swing.JFileChooser;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JOptionPane;
-import javax.swing.KeyStroke;
+import javax.swing.*;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -119,7 +114,7 @@ public class MenuProject extends JMenu {
                 plugin.setSettings();
 
             // fire event to external plugins
-            for (ConfigExtension<? extends PluginConfig> plugin : pluginService.getExternalConfigExtensions())
+            for (ConfigExtension<?> plugin : pluginService.getExternalPlugins(ConfigExtension.class))
                 plugin.handleEvent(PluginConfigEvent.PRE_SAVE_CONFIG);
 
             if (mainView.saveProjectSettings())
@@ -140,7 +135,7 @@ public class MenuProject extends JMenu {
                         plugin.setSettings();
 
                     // fire event to external plugins
-                    for (ConfigExtension<? extends PluginConfig> plugin : pluginService.getExternalConfigExtensions())
+                    for (ConfigExtension<?> plugin : pluginService.getExternalPlugins(ConfigExtension.class))
                         plugin.handleEvent(PluginConfigEvent.PRE_SAVE_CONFIG);
 
                     ConfigUtil.marshal(config.getProject(), file, ctx);
@@ -175,7 +170,7 @@ public class MenuProject extends JMenu {
 						plugin.loadSettings();
 
 					// update plugin configs
-					for (ConfigExtension<? extends PluginConfig> plugin : pluginService.getExternalConfigExtensions())
+					for (ConfigExtension<?> plugin : pluginService.getExternalPlugins(ConfigExtension.class))
 						plugin.handleEvent(PluginConfigEvent.RESET_DEFAULT_CONFIG);
 
 					// trigger event
@@ -261,7 +256,7 @@ public class MenuProject extends JMenu {
 
 			// update plugin configs
 			PluginConfigController pluginConfigController = PluginConfigController.getInstance(config);
-			for (ConfigExtension<? extends PluginConfig> plugin : pluginService.getExternalConfigExtensions())
+			for (ConfigExtension<?> plugin : pluginService.getExternalPlugins(ConfigExtension.class))
 				pluginConfigController.setOrCreatePluginConfig(plugin);
 
 			// adapt logging subsystem

--- a/impexp-client/src/main/java/org/citydb/modules/citygml/exporter/CityGMLExportPlugin.java
+++ b/impexp-client/src/main/java/org/citydb/modules/citygml/exporter/CityGMLExportPlugin.java
@@ -50,7 +50,7 @@ public class CityGMLExportPlugin implements InternalPlugin, ViewExtension, Prefe
 	}
 		
 	@Override
-	public void init(ViewController viewController, Locale locale) {
+	public void initViewExtension(ViewController viewController, Locale locale) {
 		loadSettings();
 	}
 

--- a/impexp-client/src/main/java/org/citydb/modules/citygml/importer/CityGMLImportPlugin.java
+++ b/impexp-client/src/main/java/org/citydb/modules/citygml/importer/CityGMLImportPlugin.java
@@ -49,7 +49,7 @@ public class CityGMLImportPlugin implements InternalPlugin, ViewExtension, Prefe
 	}
 		
 	@Override
-	public void init(ViewController viewController, Locale locale) {
+	public void initViewExtension(ViewController viewController, Locale locale) {
 		loadSettings();
 	}
 

--- a/impexp-client/src/main/java/org/citydb/modules/database/DatabasePlugin.java
+++ b/impexp-client/src/main/java/org/citydb/modules/database/DatabasePlugin.java
@@ -50,7 +50,7 @@ public class DatabasePlugin implements InternalPlugin, ViewExtension, Preference
 	}
 		
 	@Override
-	public void init(ViewController viewController, Locale locale) {
+	public void initViewExtension(ViewController viewController, Locale locale) {
 		loadSettings();
 	}
 

--- a/impexp-client/src/main/java/org/citydb/modules/kml/KMLExportPlugin.java
+++ b/impexp-client/src/main/java/org/citydb/modules/kml/KMLExportPlugin.java
@@ -51,7 +51,7 @@ public class KMLExportPlugin implements InternalPlugin, ViewExtension, Preferenc
 	}
 		
 	@Override
-	public void init(ViewController viewController, Locale locale) {
+	public void initViewExtension(ViewController viewController, Locale locale) {
 		loadSettings();
 	}
 

--- a/impexp-client/src/main/java/org/citydb/modules/preferences/PreferencesPlugin.java
+++ b/impexp-client/src/main/java/org/citydb/modules/preferences/PreferencesPlugin.java
@@ -51,7 +51,7 @@ public class PreferencesPlugin implements InternalPlugin, ViewExtension, Prefere
 	}
 		
 	@Override
-	public void init(ViewController viewController, Locale locale) {
+	public void initViewExtension(ViewController viewController, Locale locale) {
 		loadSettings();
 	}
 

--- a/impexp-client/src/main/java/org/citydb/modules/preferences/gui/view/PreferencesPanel.java
+++ b/impexp-client/src/main/java/org/citydb/modules/preferences/gui/view/PreferencesPanel.java
@@ -27,32 +27,6 @@
  */
 package org.citydb.modules.preferences.gui.view;
 
-import java.awt.Font;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JSeparator;
-import javax.swing.JSplitPane;
-import javax.swing.JTree;
-import javax.swing.UIManager;
-import javax.swing.event.TreeSelectionEvent;
-import javax.swing.event.TreeSelectionListener;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeCellRenderer;
-import javax.swing.tree.DefaultTreeModel;
-import javax.swing.tree.TreeNode;
-import javax.swing.tree.TreePath;
-import javax.swing.tree.TreeSelectionModel;
-
 import org.citydb.config.Config;
 import org.citydb.config.i18n.Language;
 import org.citydb.gui.ImpExpGui;
@@ -70,6 +44,19 @@ import org.citydb.plugin.PluginManager;
 import org.citydb.plugin.extension.preferences.PreferencesEntry;
 import org.citydb.plugin.extension.preferences.PreferencesEvent;
 import org.citydb.plugin.extension.preferences.PreferencesExtension;
+
+import javax.swing.*;
+import javax.swing.event.TreeSelectionEvent;
+import javax.swing.event.TreeSelectionListener;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeCellRenderer;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
+import javax.swing.tree.TreePath;
+import javax.swing.tree.TreeSelectionModel;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 @SuppressWarnings("serial")
 public class PreferencesPanel extends JPanel implements TreeSelectionListener {
@@ -142,7 +129,7 @@ public class PreferencesPanel extends JPanel implements TreeSelectionListener {
 		rootNode.add(pluginManager.getInternalPlugin(CityGMLExportPlugin.class).getPreferences().getPreferencesEntry());
 		rootNode.add(pluginManager.getInternalPlugin(KMLExportPlugin.class).getPreferences().getPreferencesEntry());
 
-		for (PreferencesExtension extension : pluginManager.getExternalPreferencesExtensions())
+		for (PreferencesExtension extension : pluginManager.getExternalPlugins(PreferencesExtension.class))
 			rootNode.add(extension.getPreferences().getPreferencesEntry());	
 
 		rootNode.add(pluginManager.getInternalPlugin(DatabasePlugin.class).getPreferences().getPreferencesEntry());

--- a/impexp-client/src/main/java/org/citydb/modules/preferences/gui/view/PreferencesPanel.java
+++ b/impexp-client/src/main/java/org/citydb/modules/preferences/gui/view/PreferencesPanel.java
@@ -41,6 +41,7 @@ import org.citydb.modules.kml.KMLExportPlugin;
 import org.citydb.modules.preferences.gui.preferences.GeneralPreferences;
 import org.citydb.modules.preferences.gui.preferences.RootPreferencesEntry;
 import org.citydb.plugin.PluginManager;
+import org.citydb.plugin.extension.preferences.Preferences;
 import org.citydb.plugin.extension.preferences.PreferencesEntry;
 import org.citydb.plugin.extension.preferences.PreferencesEvent;
 import org.citydb.plugin.extension.preferences.PreferencesExtension;
@@ -60,7 +61,7 @@ import java.awt.event.ActionListener;
 
 @SuppressWarnings("serial")
 public class PreferencesPanel extends JPanel implements TreeSelectionListener {
-	private final Logger LOG = Logger.getInstance();
+	private final Logger log = Logger.getInstance();
 	private final ImpExpGui mainView;
 	private final PluginManager pluginManager;
 	private final Config config;
@@ -117,7 +118,7 @@ public class PreferencesPanel extends JPanel implements TreeSelectionListener {
 				if (activeEntry != null) {
 					boolean success = activeEntry.handleEvent(PreferencesEvent.APPLY_SETTINGS);
 					if (success)
-						LOG.info("Settings successfully applied.");
+						log.info("Settings successfully applied.");
 				}
 			}
 		});
@@ -129,8 +130,15 @@ public class PreferencesPanel extends JPanel implements TreeSelectionListener {
 		rootNode.add(pluginManager.getInternalPlugin(CityGMLExportPlugin.class).getPreferences().getPreferencesEntry());
 		rootNode.add(pluginManager.getInternalPlugin(KMLExportPlugin.class).getPreferences().getPreferencesEntry());
 
-		for (PreferencesExtension extension : pluginManager.getExternalPlugins(PreferencesExtension.class))
-			rootNode.add(extension.getPreferences().getPreferencesEntry());	
+		for (PreferencesExtension extension : pluginManager.getExternalPlugins(PreferencesExtension.class)) {
+			Preferences preferences = extension.getPreferences();
+			if (preferences == null || preferences.getPreferencesEntry() == null) {
+				log.error("Failed to get preference entry from plugin " + extension.getClass().getName() + ".");
+				continue;
+			}
+
+			rootNode.add(preferences.getPreferencesEntry());
+		}
 
 		rootNode.add(pluginManager.getInternalPlugin(DatabasePlugin.class).getPreferences().getPreferencesEntry());
 		rootNode.add(generalPreferences.getPreferencesEntry());

--- a/impexp-config/src/main/java/org/citydb/config/project/Project.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/Project.java
@@ -41,6 +41,7 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.HashMap;
+import java.util.Map;
 
 @XmlRootElement
 @XmlType(name="ProjectType", propOrder={
@@ -61,7 +62,7 @@ public class Project {
 	private KmlExporter kmlExporter;
 	private Global global;
 	@XmlJavaTypeAdapter(org.citydb.config.project.plugin.PluginConfigListAdapter.class)
-	private HashMap<Class<? extends PluginConfig>, PluginConfig> extensions;
+	private Map<Class<? extends PluginConfig>, PluginConfig> extensions;
 	
 	@XmlTransient
 	private ConfigNamespaceFilter namespaceFilter;

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/Exporter.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/Exporter.java
@@ -45,6 +45,7 @@ import javax.xml.bind.annotation.XmlType;
 		"appearances",
 		"xlink",
 		"xslTransformation",
+		"metadataProvider",
 		"cityGMLOptions",
 		"resources"
 })
@@ -60,6 +61,7 @@ public class Exporter {
 	private ExportAppearance appearances;
 	private XLink xlink;
 	private XSLTransformation xslTransformation;
+	private String metadataProvider;
 	private CityGMLOptions cityGMLOptions;
 	private Resources resources;
 
@@ -164,6 +166,18 @@ public class Exporter {
 	public void setXSLTransformation(XSLTransformation xslTransformation) {
 		if (xslTransformation != null)
 			this.xslTransformation = xslTransformation;
+	}
+
+	public boolean isSetMetadataProvider() {
+		return metadataProvider != null;
+	}
+
+	public String getMetadataProvider() {
+		return metadataProvider;
+	}
+
+	public void setMetadataProvider(String metadataProvider) {
+		this.metadataProvider = metadataProvider;
 	}
 
 	public CityGMLOptions getCityGMLOptions() {

--- a/impexp-core/build.gradle
+++ b/impexp-core/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compile project(':impexp-config')
+    compile project(':impexp-plugin-api')
     compile 'org.citydb:sqlbuilder:2.1.3'
     compile 'org.citydb:3dcitydb-ade-citygml4j:1.1.0'
     compile 'org.citygml4j:citygml4j:2.9.0'

--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/writer/CityGMLWriter.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/writer/CityGMLWriter.java
@@ -106,11 +106,6 @@ public class CityGMLWriter implements FeatureWriter {
 	}
 
 	@Override
-	public void setMetadata(Metadata metadata) {
-		this.metadata = metadata;
-	}
-
-	@Override
 	public void writeHeader() throws FeatureWriteException {
 		headerWritten = true;
 		writeCityModel(WriteMode.HEAD);

--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/writer/FeatureWriter.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/writer/FeatureWriter.java
@@ -35,7 +35,6 @@ public interface FeatureWriter extends AutoCloseable {
 	void write(AbstractFeature feature) throws FeatureWriteException;
 	void useIndentation(boolean useIndentation);
 	Metadata getMetadata();
-	void setMetadata(Metadata metadata);
 	void close() throws FeatureWriteException;
 
 	default boolean supportsFlatHierarchies() {

--- a/impexp-core/src/main/java/org/citydb/plugin/IllegalEventSourceChecker.java
+++ b/impexp-core/src/main/java/org/citydb/plugin/IllegalEventSourceChecker.java
@@ -31,7 +31,7 @@ import org.citydb.database.connection.DatabaseConnectionPool;
 import org.citydb.event.Event;
 import org.citydb.event.EventHandler;
 import org.citydb.event.global.EventType;
-import org.citydb.gui.ImpExpGui;
+import org.citydb.plugin.extension.view.ViewController;
 
 public class IllegalEventSourceChecker implements EventHandler {
 	private static IllegalEventSourceChecker instance;
@@ -52,7 +52,7 @@ public class IllegalEventSourceChecker implements EventHandler {
 		if (event.getEventType() == EventType.DATABASE_CONNECTION_STATE && event.getSource() != DatabaseConnectionPool.getInstance())
 			throw new IllegalArgumentException("Illegal source for event of type " + EventType.DATABASE_CONNECTION_STATE + ".");
 
-		else if (event.getEventType() == EventType.SWITCH_LOCALE && !(event.getSource() instanceof ImpExpGui))
+		else if (event.getEventType() == EventType.SWITCH_LOCALE && !(event.getSource() instanceof ViewController))
 			throw new IllegalArgumentException("Illegal source for event of type " + EventType.SWITCH_LOCALE + ".");
 	}
 	

--- a/impexp-core/src/main/java/org/citydb/plugin/InternalPlugin.java
+++ b/impexp-core/src/main/java/org/citydb/plugin/InternalPlugin.java
@@ -28,6 +28,6 @@
 package org.citydb.plugin;
 
 public interface InternalPlugin extends Plugin {
-	public void loadSettings();
-	public void setSettings();
+	void loadSettings();
+	void setSettings();
 }

--- a/impexp-core/src/main/java/org/citydb/plugin/PluginConfigController.java
+++ b/impexp-core/src/main/java/org/citydb/plugin/PluginConfigController.java
@@ -32,8 +32,6 @@ import org.citydb.config.project.plugin.PluginConfig;
 import org.citydb.log.Logger;
 import org.citydb.plugin.extension.config.ConfigExtension;
 
-import java.lang.reflect.InvocationTargetException;
-
 public class PluginConfigController {
 	public static PluginConfigController instance;
 	private final Logger log = Logger.getInstance();
@@ -51,7 +49,7 @@ public class PluginConfigController {
 	}
 
 	@SuppressWarnings("unchecked")
-	public <T extends PluginConfig> void setOrCreatePluginConfig(ConfigExtension<T> plugin) {
+	public <T extends PluginConfig> void setOrCreatePluginConfig(ConfigExtension<T> plugin) throws PluginException {
 		Class<T> pluginConfigClass = null;
 		T pluginConfig;
 
@@ -67,15 +65,8 @@ public class PluginConfigController {
 			// propagate new config to plugin
 			plugin.configLoaded(pluginConfig);
 			
-		} catch (NoSuchMethodException | SecurityException e) {
-			log.error("Failed to instantiate config for plugin '" + plugin.getClass().getCanonicalName() + "'.");
-			log.error("Please check the following error message: " + e.getMessage());
-		} catch (InstantiationException | InvocationTargetException e) {
-			log.error("Failed to instantiate class '" + pluginConfigClass.getCanonicalName() + "'.");
-			log.error("Please provide a no-arg constructor.");
-		} catch (IllegalAccessException e) {
-			log.error("Failed to access no-arg constructor of class '" + pluginConfigClass.getCanonicalName() + "'.");
-			log.error("Please check the following error message: " + e.getMessage());
+		} catch (Exception e) {
+			throw new PluginException("Failed to load config for plugin " + plugin.getClass().getName(), e);
 		}
 	}
 

--- a/impexp-core/src/main/java/org/citydb/plugin/PluginManager.java
+++ b/impexp-core/src/main/java/org/citydb/plugin/PluginManager.java
@@ -27,9 +27,8 @@
  */
 package org.citydb.plugin;
 
-import org.citydb.config.project.plugin.PluginConfig;
 import org.citydb.log.Logger;
-import org.citydb.plugin.extension.config.ConfigExtension;
+import org.citydb.plugin.extension.Extension;
 import org.citydb.plugin.extension.menu.MenuExtension;
 import org.citydb.plugin.extension.preferences.PreferencesExtension;
 import org.citydb.plugin.extension.view.ViewExtension;
@@ -124,43 +123,14 @@ public class PluginManager {
         return null;
     }
 
-    public List<ViewExtension> getExternalViewExtensions() {
-        List<ViewExtension> viewExtensions = new ArrayList<>();
+    public <T extends Extension> List<T> getExternalPlugins(Class<T> extensionClass) {
+        List<T> plugins = new ArrayList<>();
         for (Plugin plugin : externalPlugins) {
-            if (plugin instanceof ViewExtension)
-                viewExtensions.add((ViewExtension) plugin);
+            if (extensionClass.isAssignableFrom(plugin.getClass()))
+                plugins.add(extensionClass.cast(plugin));
         }
 
-        return viewExtensions;
-    }
-
-    public List<PreferencesExtension> getExternalPreferencesExtensions() {
-        List<PreferencesExtension> preferencesExtensions = new ArrayList<>();
-        for (Plugin plugin : externalPlugins) {
-            if (plugin instanceof PreferencesExtension)
-                preferencesExtensions.add((PreferencesExtension) plugin);
-        }
-
-        return preferencesExtensions;
-    }
-
-    public List<MenuExtension> getExternalMenuExtensions() {
-        List<MenuExtension> menuExtensions = new ArrayList<>();
-        for (Plugin plugin : externalPlugins) {
-            if (plugin instanceof MenuExtension)
-                menuExtensions.add((MenuExtension) plugin);
-        }
-
-        return menuExtensions;
-    }
-
-    public List<ConfigExtension<? extends PluginConfig>> getExternalConfigExtensions() {
-        List<ConfigExtension<? extends PluginConfig>> configExtensions = new ArrayList<>();
-        for (Plugin plugin : externalPlugins)
-            if (plugin instanceof ConfigExtension<?>)
-                configExtensions.add((ConfigExtension<? extends PluginConfig>) plugin);
-
-        return configExtensions;
+        return plugins;
     }
 
     public List<Plugin> getPlugins() {

--- a/impexp-core/src/main/java/org/citydb/plugin/PluginManager.java
+++ b/impexp-core/src/main/java/org/citydb/plugin/PluginManager.java
@@ -30,7 +30,6 @@ package org.citydb.plugin;
 import org.citydb.config.project.plugin.PluginConfig;
 import org.citydb.log.Logger;
 import org.citydb.plugin.extension.config.ConfigExtension;
-import org.citydb.plugin.extension.export.CityGMLExportExtension;
 import org.citydb.plugin.extension.menu.MenuExtension;
 import org.citydb.plugin.extension.preferences.PreferencesExtension;
 import org.citydb.plugin.extension.view.ViewExtension;
@@ -162,15 +161,6 @@ public class PluginManager {
                 configExtensions.add((ConfigExtension<? extends PluginConfig>) plugin);
 
         return configExtensions;
-    }
-
-    public List<CityGMLExportExtension> getCityGMLExportExtensions() {
-        List<CityGMLExportExtension> exportExtensions = new ArrayList<>();
-        for (Plugin plugin : externalPlugins)
-            if (plugin instanceof CityGMLExportExtension)
-                exportExtensions.add((CityGMLExportExtension) plugin);
-
-        return exportExtensions;
     }
 
     public List<Plugin> getPlugins() {

--- a/impexp-core/src/main/java/org/citydb/plugin/PluginManager.java
+++ b/impexp-core/src/main/java/org/citydb/plugin/PluginManager.java
@@ -29,9 +29,6 @@ package org.citydb.plugin;
 
 import org.citydb.log.Logger;
 import org.citydb.plugin.extension.Extension;
-import org.citydb.plugin.extension.menu.MenuExtension;
-import org.citydb.plugin.extension.preferences.PreferencesExtension;
-import org.citydb.plugin.extension.view.ViewExtension;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -76,34 +73,7 @@ public class PluginManager {
                 return;
         }
 
-        try {
-            validate(plugin);
-            externalPlugins.add(plugin);
-        } catch (PluginException e) {
-            log.warn("Failed to load plugin " + plugin.getClass().getName());
-            log.warn("Cause: " + e.getMessage());
-        }
-    }
-
-    private void validate(Plugin plugin) throws PluginException {
-        if (plugin instanceof ViewExtension) {
-            ViewExtension viewExtension = (ViewExtension) plugin;
-            if (viewExtension.getView() == null || viewExtension.getView().getViewComponent() == null)
-                throw new PluginException("The plugins lacks a valid view component");
-        }
-
-        if (plugin instanceof PreferencesExtension) {
-            PreferencesExtension preferencesExtension = (PreferencesExtension) plugin;
-            if (preferencesExtension.getPreferences() == null
-                    || preferencesExtension.getPreferences().getPreferencesEntry() == null)
-                throw new PluginException("The plugins lacks a valid preference entry");
-        }
-
-        if (plugin instanceof MenuExtension) {
-            MenuExtension menuExtension = (MenuExtension) plugin;
-            if (menuExtension.getMenu() == null || menuExtension.getMenu().getMenuComponent() == null)
-                throw new PluginException("The plugins lacks a valid menu entry");
-        }
+        externalPlugins.add(plugin);
     }
 
     public List<InternalPlugin> getInternalPlugins() {

--- a/impexp-core/src/main/java/org/citydb/plugin/PluginManager.java
+++ b/impexp-core/src/main/java/org/citydb/plugin/PluginManager.java
@@ -137,7 +137,6 @@ public class PluginManager {
 		return menuExtensions;
 	}
 	
-	@SuppressWarnings("unchecked")
 	public List<ConfigExtension<? extends PluginConfig>> getExternalConfigExtensions() {
 		List<ConfigExtension<? extends PluginConfig>> configExtensions = new ArrayList<>();
 		for (Plugin plugin : externalPlugins)

--- a/impexp-core/src/main/java/org/citydb/plugin/extension/export/MetadataProvider.java
+++ b/impexp-core/src/main/java/org/citydb/plugin/extension/export/MetadataProvider.java
@@ -1,0 +1,10 @@
+package org.citydb.plugin.extension.export;
+
+import org.citydb.citygml.exporter.util.Metadata;
+import org.citydb.config.project.exporter.Exporter;
+import org.citydb.plugin.PluginException;
+import org.citydb.query.Query;
+
+public interface MetadataProvider {
+    void setMetadata(Metadata metadata, Query query, Exporter exportConfig) throws PluginException;
+}

--- a/impexp-plugin-api/build.gradle
+++ b/impexp-plugin-api/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    compile project(':impexp-core')
+    compile project(':impexp-config')
 }
 
 bintray {

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/Plugin.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/Plugin.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 import org.citydb.plugin.extension.view.ViewController;
 
 public interface Plugin {
-	public void init(ViewController viewController, Locale locale);
-	public void shutdown();
-	public void switchLocale(Locale locale);		
+	void init(ViewController viewController, Locale locale);
+	void shutdown();
+	void switchLocale(Locale locale);
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/PluginException.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/PluginException.java
@@ -25,8 +25,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.citydb.plugin;
 
-public interface Plugin {
-	void shutdown();
+public class PluginException extends Exception {
+	private static final long serialVersionUID = -3716015045363231263L;
+
+	public PluginException() {
+		super();
+	}
+
+	public PluginException(String message) {
+		super(message);
+	}
+
+	public PluginException(Throwable cause) {
+		super(cause);
+	}
+
+	public PluginException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/Extension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/Extension.java
@@ -1,0 +1,4 @@
+package org.citydb.plugin.extension;
+
+public interface Extension {
+}

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/config/ConfigExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/config/ConfigExtension.java
@@ -28,8 +28,9 @@
 package org.citydb.plugin.extension.config;
 
 import org.citydb.config.project.plugin.PluginConfig;
+import org.citydb.plugin.extension.Extension;
 
-public interface ConfigExtension<T extends PluginConfig> {
+public interface ConfigExtension<T extends PluginConfig> extends Extension {
 	T getConfig();
 	void configLoaded(T config);
 	void handleEvent(PluginConfigEvent event);

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/config/ConfigExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/config/ConfigExtension.java
@@ -30,7 +30,7 @@ package org.citydb.plugin.extension.config;
 import org.citydb.config.project.plugin.PluginConfig;
 
 public interface ConfigExtension<T extends PluginConfig> {
-	public T getConfig();
-	public void configLoaded(T config);
-	public void handleEvent(PluginConfigEvent event);
+	T getConfig();
+	void configLoaded(T config);
+	void handleEvent(PluginConfigEvent event);
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/export/CityGMLExportExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/export/CityGMLExportExtension.java
@@ -25,10 +25,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.citydb.plugin.extension.preferences;
 
+package org.citydb.plugin.extension.export;
+
+import org.citydb.plugin.PluginException;
 import org.citydb.plugin.extension.Extension;
+import org.citygml4j.model.gml.feature.AbstractFeature;
 
-public interface PreferencesExtension extends Extension {
-	Preferences getPreferences();
+public interface CityGMLExportExtension extends Extension {
+    void postprocess(AbstractFeature feature) throws PluginException;
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/export/CityGMLExportExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/export/CityGMLExportExtension.java
@@ -33,5 +33,5 @@ import org.citydb.plugin.extension.Extension;
 import org.citygml4j.model.gml.feature.AbstractFeature;
 
 public interface CityGMLExportExtension extends Extension {
-    void postprocess(AbstractFeature feature) throws PluginException;
+    AbstractFeature postprocess(AbstractFeature feature) throws PluginException;
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/menu/MenuExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/menu/MenuExtension.java
@@ -28,5 +28,5 @@
 package org.citydb.plugin.extension.menu;
 
 public interface MenuExtension {
-	public Menu getMenu();
+	Menu getMenu();
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/menu/MenuExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/menu/MenuExtension.java
@@ -27,6 +27,8 @@
  */
 package org.citydb.plugin.extension.menu;
 
-public interface MenuExtension {
+import org.citydb.plugin.extension.Extension;
+
+public interface MenuExtension extends Extension {
 	Menu getMenu();
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/preferences/Preferences.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/preferences/Preferences.java
@@ -28,5 +28,5 @@
 package org.citydb.plugin.extension.preferences;
 
 public interface Preferences {
-	public PreferencesEntry getPreferencesEntry();
+	PreferencesEntry getPreferencesEntry();
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/preferences/PreferencesEntry.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/preferences/PreferencesEntry.java
@@ -41,14 +41,14 @@ public abstract class PreferencesEntry {
 
 	public void addChildEntry(PreferencesEntry child) {
 		if (childEntries == null)
-			childEntries = new ArrayList<PreferencesEntry>();
+			childEntries = new ArrayList<>();
 		
 		childEntries.add(child);
 	}
 	
 	public List<PreferencesEntry> getChildEntries() {
 		if (childEntries == null)
-			childEntries = new ArrayList<PreferencesEntry>();
+			childEntries = new ArrayList<>();
 		
 		return childEntries;
 	}

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/preferences/PreferencesExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/preferences/PreferencesExtension.java
@@ -28,5 +28,5 @@
 package org.citydb.plugin.extension.preferences;
 
 public interface PreferencesExtension {
-	public Preferences getPreferences();
+	Preferences getPreferences();
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/View.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/View.java
@@ -27,14 +27,10 @@
  */
 package org.citydb.plugin.extension.view;
 
-import java.awt.Component;
+import javax.swing.*;
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
-
-import javax.swing.Icon;
-import javax.swing.SwingUtilities;
-
-import org.citydb.plugin.extension.view.ViewListener;
 
 public abstract class View {
 	private List<ViewListener> viewListeners;
@@ -46,28 +42,26 @@ public abstract class View {
 
 	public final void addViewListener(ViewListener listener) {
 		if (viewListeners == null)
-			viewListeners = new ArrayList<ViewListener>();
+			viewListeners = new ArrayList<>();
 
 		viewListeners.add(listener);
 	}
 
 	public final boolean removeViewListener(ViewListener listener) {
-		return viewListeners != null ? viewListeners.remove(listener) : false;
+		return viewListeners != null && viewListeners.remove(listener);
 	}
 
 	public final void fireViewEvent(final ViewEvent e) {
 		if (viewListeners != null) {
 			for (final ViewListener listener : viewListeners) {
-				SwingUtilities.invokeLater(new Runnable() {
-					public void run() {
-						switch (e.getViewState()) {
-						case VIEW_ACTIVATED:
-							listener.viewActivated(e);
-							break;
-						case VIEW_DEACTIVATED:
-							listener.viewDeactivated(e);
-							break;
-						}
+				SwingUtilities.invokeLater(() -> {
+					switch (e.getViewState()) {
+					case VIEW_ACTIVATED:
+						listener.viewActivated(e);
+						break;
+					case VIEW_DEACTIVATED:
+						listener.viewDeactivated(e);
+						break;
 					}
 				});
 			}

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewController.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewController.java
@@ -32,12 +32,11 @@ import javax.swing.JFrame;
 import org.citydb.plugin.extension.view.components.ComponentFactory;
 
 public interface ViewController {
-	public JFrame getTopFrame();
-	public void clearConsole();
-	public void setStatusText(String statusText);
-	public void setDefaultStatus();	
-	public void errorMessage(String title, String message);
-	public int warnMessage(String title, String message);
-	
-	public ComponentFactory getComponentFactory();
+	JFrame getTopFrame();
+	void clearConsole();
+	void setStatusText(String statusText);
+	void setDefaultStatus();
+	void errorMessage(String title, String message);
+	int warnMessage(String title, String message);
+	ComponentFactory getComponentFactory();
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewEvent.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewEvent.java
@@ -27,10 +27,7 @@
  */
 package org.citydb.plugin.extension.view;
 
-import org.citydb.event.Event;
-import org.citydb.event.global.EventType;
-
-public final class ViewEvent extends Event {
+public final class ViewEvent {
 	public enum ViewState {
 		VIEW_ACTIVATED,
 		VIEW_DEACTIVATED
@@ -40,7 +37,6 @@ public final class ViewEvent extends Event {
 	private final ViewState viewState;
 	
 	public ViewEvent(View view, ViewState viewState, Object source) {
-		super(EventType.VIEW_STATE, GLOBAL_CHANNEL, source);
 		this.view = view;
 		this.viewState = viewState;
 	}

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewExtension.java
@@ -27,6 +27,10 @@
  */
 package org.citydb.plugin.extension.view;
 
+import java.util.Locale;
+
 public interface ViewExtension {
+	void initViewExtension(ViewController viewController, Locale locale);
+	void switchLocale(Locale locale);
 	View getView();
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewExtension.java
@@ -27,9 +27,11 @@
  */
 package org.citydb.plugin.extension.view;
 
+import org.citydb.plugin.extension.Extension;
+
 import java.util.Locale;
 
-public interface ViewExtension {
+public interface ViewExtension extends Extension {
 	void initViewExtension(ViewController viewController, Locale locale);
 	void switchLocale(Locale locale);
 	View getView();

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewExtension.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewExtension.java
@@ -27,8 +27,6 @@
  */
 package org.citydb.plugin.extension.view;
 
-import org.citydb.plugin.extension.view.View;
-
 public interface ViewExtension {
-	public View getView();
+	View getView();
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewListener.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/ViewListener.java
@@ -28,6 +28,6 @@
 package org.citydb.plugin.extension.view;
 
 public interface ViewListener {
-	public void viewActivated(ViewEvent e);
-	public void viewDeactivated(ViewEvent e);
+	void viewActivated(ViewEvent e);
+	void viewDeactivated(ViewEvent e);
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/components/ComponentFactory.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/components/ComponentFactory.java
@@ -28,7 +28,7 @@
 package org.citydb.plugin.extension.view.components;
 
 public interface ComponentFactory {
-	public DatabaseSrsComboBox createDatabaseSrsComboBox();
-	public StandardEditingPopupMenuDecorator createPopupMenuDecorator();
-	public BoundingBoxPanel createBoundingBoxPanel();
+	DatabaseSrsComboBox createDatabaseSrsComboBox();
+	StandardEditingPopupMenuDecorator createPopupMenuDecorator();
+	BoundingBoxPanel createBoundingBoxPanel();
 }

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/components/StandardEditingPopupMenuDecorator.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/extension/view/components/StandardEditingPopupMenuDecorator.java
@@ -33,10 +33,10 @@ import javax.swing.JTree;
 import javax.swing.text.JTextComponent;
 
 public interface StandardEditingPopupMenuDecorator {
-	public void decorate(JTextComponent... components);
-	public JPopupMenu decorateAndGet(JTextComponent component);
-	public void decorate(JTree... trees);
-	public JPopupMenu decorateAndGet(JTree tree);
-	public void decorateCheckBoxGroup(JCheckBox... group);
-	public JPopupMenu[] decorateAndGetCheckBoxGroup(JCheckBox... group);
+	void decorate(JTextComponent... components);
+	JPopupMenu decorateAndGet(JTextComponent component);
+	void decorate(JTree... trees);
+	JPopupMenu decorateAndGet(JTree tree);
+	void decorateCheckBoxGroup(JCheckBox... group);
+	JPopupMenu[] decorateAndGetCheckBoxGroup(JCheckBox... group);
 }


### PR DESCRIPTION
The current Plugin API and its internal implementation suppose that each plugin provides some sort of GUI component. However, it is also useful to have plugins that are just hooked into internal processes such as CityGML imports and exports. For example, this would allow for writing a plugin that receives and thus can manipulate every CityGML feature before it is written to the output file.

This PR is to rework the Plugin API such that non-GUI plugins can be supported in principal.