### PR TITLE
Add support for implicit geometries of nested sub-features in KML/COLLADA/glTF exports

### DIFF
--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Bridge.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Bridge.java
@@ -327,17 +327,17 @@ public class Bridge extends KmlGenericObject{
 					setId(work.getId());
 					if (work.getDisplayForm().isHighlightingEnabled()) {
 						if (query.isSetTiling()) { // region
-							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work, false);
-							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work, false));
+							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work, true);
+							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work, true));
 							return hlPlacemarks;
 						}
 						else { // reverse order for single buildings
-							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work, false);
-							placemarks.addAll(createPlacemarksForHighlighting(rs, work, false));
+							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work, true);
+							placemarks.addAll(createPlacemarksForHighlighting(rs, work, true));
 							return placemarks;
 						}
 					}
-					return createPlacemarksForGeometry(rs, work, false);
+					return createPlacemarksForGeometry(rs, work, true);
 
 				case DisplayForm.COLLADA:
 					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getBridgeColladaOptions().isGenerateTextureAtlases()); // fill and refill
@@ -359,7 +359,7 @@ public class Bridge extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled()) {
-							return createPlacemarksForHighlighting(rs, work, false);
+							return createPlacemarksForHighlighting(rs, work, true);
 						}
 						// just COLLADA, no KML
 						List<PlacemarkType> dummy = new ArrayList<>();

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Bridge.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Bridge.java
@@ -340,7 +340,7 @@ public class Bridge extends KmlGenericObject{
 					return createPlacemarksForGeometry(rs, work, true);
 
 				case DisplayForm.COLLADA:
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getBridgeColladaOptions().isGenerateTextureAtlases()); // fill and refill
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getBridgeColladaOptions().isGenerateTextureAtlases(), true); // fill and refill
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Bridge.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Bridge.java
@@ -327,17 +327,17 @@ public class Bridge extends KmlGenericObject{
 					setId(work.getId());
 					if (work.getDisplayForm().isHighlightingEnabled()) {
 						if (query.isSetTiling()) { // region
-							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work);
-							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work));
+							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work, false);
+							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work, false));
 							return hlPlacemarks;
 						}
 						else { // reverse order for single buildings
-							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work);
-							placemarks.addAll(createPlacemarksForHighlighting(rs, work));
+							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work, false);
+							placemarks.addAll(createPlacemarksForHighlighting(rs, work, false));
 							return placemarks;
 						}
 					}
-					return createPlacemarksForGeometry(rs, work);
+					return createPlacemarksForGeometry(rs, work, false);
 
 				case DisplayForm.COLLADA:
 					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getBridgeColladaOptions().isGenerateTextureAtlases()); // fill and refill
@@ -359,7 +359,7 @@ public class Bridge extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled()) {
-							return createPlacemarksForHighlighting(rs, work);
+							return createPlacemarksForHighlighting(rs, work, false);
 						}
 						// just COLLADA, no KML
 						List<PlacemarkType> dummy = new ArrayList<>();

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Building.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Building.java
@@ -326,17 +326,17 @@ public class Building extends KmlGenericObject{
 					setId(work.getId());
 					if (work.getDisplayForm().isHighlightingEnabled()) {
 						if (query.isSetTiling()) { // region
-							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work);
-							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work));
+							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work, true);
+							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work, true));
 							return hlPlacemarks;
 						}
 						else { // reverse order for single buildings
-							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work);
-							placemarks.addAll(createPlacemarksForHighlighting(rs, work));
+							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work, true);
+							placemarks.addAll(createPlacemarksForHighlighting(rs, work, true));
 							return placemarks;
 						}
 					}
-					return createPlacemarksForGeometry(rs, work);
+					return createPlacemarksForGeometry(rs, work, true);
 
 				case DisplayForm.COLLADA:
 					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getBuildingColladaOptions().isGenerateTextureAtlases()); // fill and refill
@@ -358,7 +358,7 @@ public class Building extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled()) {
-							return createPlacemarksForHighlighting(rs, work);
+							return createPlacemarksForHighlighting(rs, work, true);
 						}
 						// just COLLADA, no KML
 						List<PlacemarkType> dummy = new ArrayList<>();

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Building.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Building.java
@@ -339,7 +339,7 @@ public class Building extends KmlGenericObject{
 					return createPlacemarksForGeometry(rs, work, true);
 
 				case DisplayForm.COLLADA:
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getBuildingColladaOptions().isGenerateTextureAtlases()); // fill and refill
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getBuildingColladaOptions().isGenerateTextureAtlases(), true); // fill and refill
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/CityFurniture.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/CityFurniture.java
@@ -225,7 +225,7 @@ public class CityFurniture extends KmlGenericObject{
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getCityFurnitureColladaOptions().isGenerateTextureAtlases(),  transformer);
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getCityFurnitureColladaOptions().isGenerateTextureAtlases(),  transformer, false);
 
 					if (currentgmlId != null && !currentgmlId.equals(work.getGmlId()) && getGeometryAmount() > GEOMETRY_AMOUNT_WARNING)
 						log.info("Object " + work.getGmlId() + " has more than " + GEOMETRY_AMOUNT_WARNING + " geometries. This may take a while to process...");

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/CityFurniture.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/CityFurniture.java
@@ -155,17 +155,7 @@ public class CityFurniture extends KmlGenericObject{
 				long sgRootId = rs.getLong(4);
 				if (sgRootId == 0) {
 					sgRootId = rs.getLong(1);
-					if (sgRootId != 0) {
-						GeometryObject point = geometryConverterAdapter.getPoint(rs.getObject(2));
-						String transformationString = rs.getString(3);
-						if (point != null && transformationString != null) {
-							double[] ordinatesArray = point.getCoordinates(0);
-							Point referencePoint = new Point(ordinatesArray[0], ordinatesArray[1], ordinatesArray[2]);						
-							List<Double> m = Util.string2double(transformationString, "\\s+");
-							if (m != null && m.size() >= 16)
-								transformer = new AffineTransformer(new Matrix(m.subList(0, 16), 4), referencePoint, databaseAdapter.getConnectionMetaData().getReferenceSystem().getSrid());
-						}
-					}
+					transformer = getAffineTransformer(rs, 2, 3);
 				}
 
 				try { rs.close(); } catch (SQLException sqle) {} 
@@ -221,13 +211,13 @@ public class CityFurniture extends KmlGenericObject{
 					setId(work.getId());
 					if (this.query.isSetTiling()) { // region
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} else { // reverse order for single objects
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					}
 					break;
 
@@ -251,7 +241,7 @@ public class CityFurniture extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled()) 
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} catch (Exception ioe) {
 						log.logStackTrace(ioe);
 					}

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/GenericCityObject.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/GenericCityObject.java
@@ -207,17 +207,7 @@ public class GenericCityObject extends KmlGenericObject{
 					long sgRootId = rs.getLong(4);
 					if (sgRootId == 0) {
 						sgRootId = rs.getLong(1);
-						if (sgRootId != 0) {
-							GeometryObject point = geometryConverterAdapter.getPoint(rs.getObject(2));
-							String transformationString = rs.getString(3);
-							if (point != null && transformationString != null) {
-								double[] ordinatesArray = point.getCoordinates(0);
-								Point referencePoint = new Point(ordinatesArray[0], ordinatesArray[1], ordinatesArray[2]);						
-								List<Double> m = Util.string2double(transformationString, "\\s+");
-								if (m != null && m.size() >= 16)
-									transformer = new AffineTransformer(new Matrix(m.subList(0, 16), 4), referencePoint, databaseAdapter.getConnectionMetaData().getReferenceSystem().getSrid());
-							}
-						}
+						transformer = getAffineTransformer(rs, 2, 3);
 					}
 
 					try { rs.close(); } catch (SQLException sqle) {} 
@@ -271,13 +261,13 @@ public class GenericCityObject extends KmlGenericObject{
 						setId(work.getId());
 						if (this.query.isSetTiling()) { // region
 							if (work.getDisplayForm().isHighlightingEnabled())
-								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 
-							kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						} else { // reverse order for single objects
-							kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 							if (work.getDisplayForm().isHighlightingEnabled())
-								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						}
 						break;
 						
@@ -301,7 +291,7 @@ public class GenericCityObject extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled()) 
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} catch (Exception ioe) {
 						log.logStackTrace(ioe);
 					}

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/GenericCityObject.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/GenericCityObject.java
@@ -275,7 +275,7 @@ public class GenericCityObject extends KmlGenericObject{
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getGenericCityObjectColladaOptions().isGenerateTextureAtlases(), transformer);
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getGenericCityObjectColladaOptions().isGenerateTextureAtlases(), transformer, false);
 
 					if (currentgmlId != null && !currentgmlId.equals(work.getGmlId()) && getGeometryAmount() > GEOMETRY_AMOUNT_WARNING)
 						log.info("Object " + work.getGmlId() + " has more than " + GEOMETRY_AMOUNT_WARNING + " geometries. This may take a while to process...");

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlGenericObject.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlGenericObject.java
@@ -69,6 +69,8 @@ import org.citydb.textureAtlas.image.ImageReader;
 import org.citydb.textureAtlas.model.TextureImage;
 import org.citydb.textureAtlas.model.TextureImagesInfo;
 import org.citydb.util.Util;
+import org.citygml4j.geometry.Matrix;
+import org.citygml4j.geometry.Point;
 import org.citygml4j.model.citygml.CityGMLClass;
 import org.citygml4j.model.citygml.appearance.Color;
 import org.citygml4j.model.citygml.appearance.X3DMaterial;
@@ -123,9 +125,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.Transparency;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -1502,11 +1502,11 @@ public abstract class KmlGenericObject {
 		return placemarkList;
 	}
 
-	protected List<PlacemarkType> createPlacemarksForGeometry(ResultSet rs, KmlSplittingResult work) throws SQLException {
-		return createPlacemarksForGeometry(rs, work, null);
+	protected List<PlacemarkType> createPlacemarksForGeometry(ResultSet rs, KmlSplittingResult work, boolean supportsNestedImplicitGeometries) throws SQLException {
+		return createPlacemarksForGeometry(rs, work, null, supportsNestedImplicitGeometries);
 	}
 
-	protected List<PlacemarkType> createPlacemarksForGeometry(ResultSet _rs, KmlSplittingResult work, AffineTransformer transformer) throws SQLException {		
+	protected List<PlacemarkType> createPlacemarksForGeometry(ResultSet _rs, KmlSplittingResult work, AffineTransformer globalTransformer, boolean supportsNestedImplicitGeometries) throws SQLException {
 		HashSet<String> exportedGmlIds = new HashSet<String>();
 		HashMap<String, MultiGeometryType> multiGeometries = new HashMap<String, MultiGeometryType>();
 		MultiGeometryType multiGeometry = null;
@@ -1515,7 +1515,19 @@ public abstract class KmlGenericObject {
 		_rs.beforeFirst(); // return cursor to beginning
 
 		while (_rs.next()) {
+			AffineTransformer transformer = globalTransformer;
 			long rootId = _rs.getLong(1);
+
+			if (rootId == 0) {
+				// get nested implicit geometry
+				if (supportsNestedImplicitGeometries) {
+					rootId = _rs.getLong(3);
+					transformer = getAffineTransformer(_rs, 4, 5);
+				}
+
+				if (rootId == 0 || transformer == null)
+					continue;
+			}
 
 			// skip closure surfaces
 			int surfaceTypeID = _rs.getInt("objectclass_id");
@@ -1756,11 +1768,11 @@ public abstract class KmlGenericObject {
 		fillGenericObjectForCollada(rs, generateTextureAtlas, null);
 	}
 
-	protected void fillGenericObjectForCollada(ResultSet _rs, boolean generateTextureAtlas, AffineTransformer transformer) throws SQLException {
+	protected void fillGenericObjectForCollada(ResultSet _rs, boolean generateTextureAtlas, AffineTransformer globalTransformer) throws SQLException {
 		HashSet<String> exportedGmlIds = new HashSet<String>();
 
 		String selectedTheme = config.getProject().getKmlExporter().getAppearanceTheme();
-		boolean exportAppearance = selectedTheme != KmlExporter.THEME_NONE;
+		boolean exportAppearance = !selectedTheme.equals(KmlExporter.THEME_NONE);
 		int texImageCounter = 0;
 
 		DisplayForm colladaDisplayForm = null;
@@ -1776,11 +1788,25 @@ public abstract class KmlGenericObject {
 		if (colladaDisplayForm.isSetRgba2())
 			x3dRoofMaterial = getX3dMaterialFromIntColor(colladaDisplayForm.getRgba2());
 
-		boolean isImplicit = transformer != null;
-		HashMap<Long, Long> implicitIdMap = !isImplicit ? null : new HashMap<Long, Long>();
+		HashMap<Long, Long> implicitIdMap = new HashMap<Long, Long>();
+		boolean supportsNestedImplicitGeometries = _rs.getMetaData().getColumnCount() == 5;
 
 		while (_rs.next()) {
+			AffineTransformer transformer = globalTransformer;
 			long rootId = _rs.getLong(1);
+
+			if (rootId == 0) {
+				// get nested implicit geometry
+				if (supportsNestedImplicitGeometries) {
+					rootId = _rs.getLong(3);
+					transformer = getAffineTransformer(_rs, 4, 5);
+				}
+
+				if (rootId == 0 || transformer == null)
+					continue;
+			}
+
+			boolean isImplicit = transformer != null;
 
 			// skip closure surfaces
 			int surfaceTypeID = _rs.getInt("objectclass_id");
@@ -2068,11 +2094,11 @@ public abstract class KmlGenericObject {
 		return placemark;
 	}
 
-	protected List<PlacemarkType> createPlacemarksForHighlighting(ResultSet rs, KmlSplittingResult work) throws SQLException {
-		return createPlacemarksForHighlighting(rs, work, null);
+	protected List<PlacemarkType> createPlacemarksForHighlighting(ResultSet rs, KmlSplittingResult work, boolean supportsNestedImplicitGeometries) throws SQLException {
+		return createPlacemarksForHighlighting(rs, work, null, supportsNestedImplicitGeometries);
 	}
 
-	protected List<PlacemarkType> createPlacemarksForHighlighting(ResultSet _rs, KmlSplittingResult work, AffineTransformer transformer) throws SQLException {
+	protected List<PlacemarkType> createPlacemarksForHighlighting(ResultSet _rs, KmlSplittingResult work, AffineTransformer globalTransformer, boolean supportsNestedImplicitGeometries) throws SQLException {
 		HashSet<String> exportedGmlIds = new HashSet<String>();
 
 		List<PlacemarkType> placemarkList= new ArrayList<PlacemarkType>();
@@ -2094,7 +2120,19 @@ public abstract class KmlGenericObject {
 		_rs.beforeFirst(); // return cursor to beginning
 
 		while (_rs.next()) {
+			AffineTransformer transformer = globalTransformer;
 			long rootId = _rs.getLong(1);
+
+			if (rootId == 0) {
+				// get nested implicit geometry
+				if (supportsNestedImplicitGeometries) {
+					rootId = _rs.getLong(3);
+					transformer = getAffineTransformer(_rs, 4, 5);
+				}
+
+				if (rootId == 0 || transformer == null)
+					continue;
+			}
 
 			PreparedStatement geometryQuery = null;
 			ResultSet rs = null;
@@ -2213,6 +2251,20 @@ public abstract class KmlGenericObject {
 		}
 
 		return placemarkList;
+	}
+
+	protected AffineTransformer getAffineTransformer(ResultSet rs, int referencePoint, int transformationMatrix) throws SQLException {
+		GeometryObject obj = geometryConverterAdapter.getPoint(rs.getObject(referencePoint));
+		String transformationString = rs.getString(transformationMatrix);
+		if (obj != null && transformationString != null) {
+			double[] ordinatesArray = obj.getCoordinates(0);
+			Point point = new Point(ordinatesArray[0], ordinatesArray[1], ordinatesArray[2]);
+			List<Double> m = Util.string2double(transformationString, "\\s+");
+			if (m != null && m.size() >= 16)
+				return new AffineTransformer(new Matrix(m.subList(0, 16), 4), point, databaseAdapter.getConnectionMetaData().getReferenceSystem().getSrid());
+		}
+
+		return null;
 	}
 
 	private String getBalloonContentFromGenericAttribute(long id) {

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlGenericObject.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlGenericObject.java
@@ -125,7 +125,9 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.awt.*;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Transparency;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -1764,11 +1766,11 @@ public abstract class KmlGenericObject {
 		return x3dMaterial;
 	}
 
-	protected void fillGenericObjectForCollada(ResultSet rs, boolean generateTextureAtlas) throws SQLException {
-		fillGenericObjectForCollada(rs, generateTextureAtlas, null);
+	protected void fillGenericObjectForCollada(ResultSet rs, boolean generateTextureAtlas, boolean supportsNestedImplicitGeometries) throws SQLException {
+		fillGenericObjectForCollada(rs, generateTextureAtlas, null, supportsNestedImplicitGeometries);
 	}
 
-	protected void fillGenericObjectForCollada(ResultSet _rs, boolean generateTextureAtlas, AffineTransformer globalTransformer) throws SQLException {
+	protected void fillGenericObjectForCollada(ResultSet _rs, boolean generateTextureAtlas, AffineTransformer globalTransformer, boolean supportsNestedImplicitGeometries) throws SQLException {
 		HashSet<String> exportedGmlIds = new HashSet<String>();
 
 		String selectedTheme = config.getProject().getKmlExporter().getAppearanceTheme();
@@ -1789,7 +1791,6 @@ public abstract class KmlGenericObject {
 			x3dRoofMaterial = getX3dMaterialFromIntColor(colladaDisplayForm.getRgba2());
 
 		HashMap<Long, Long> implicitIdMap = new HashMap<Long, Long>();
-		boolean supportsNestedImplicitGeometries = _rs.getMetaData().getColumnCount() == 5;
 
 		while (_rs.next()) {
 			AffineTransformer transformer = globalTransformer;

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/LandUse.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/LandUse.java
@@ -191,7 +191,7 @@ public class LandUse extends KmlGenericObject{
 					break;
 
 				case DisplayForm.COLLADA:
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getLandUseColladaOptions().isGenerateTextureAtlases());
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getLandUseColladaOptions().isGenerateTextureAtlases(), false);
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/LandUse.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/LandUse.java
@@ -180,13 +180,13 @@ public class LandUse extends KmlGenericObject{
 					setId(work.getId());
 					if (query.isSetTiling()) { // region
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} else { // reverse order for single objects
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					}
 					break;
 
@@ -210,7 +210,7 @@ public class LandUse extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} catch (Exception ioe) {
 						log.logStackTrace(ioe);
 					}

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/PlantCover.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/PlantCover.java
@@ -180,13 +180,13 @@ public class PlantCover extends KmlGenericObject{
 					setId(work.getId());
 					if (query.isSetTiling()) { // region
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} else { // reverse order for single objects
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					}
 					break;
 
@@ -210,7 +210,7 @@ public class PlantCover extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} catch (Exception ioe) {
 						log.logStackTrace(ioe);
 					}

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/PlantCover.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/PlantCover.java
@@ -191,7 +191,7 @@ public class PlantCover extends KmlGenericObject{
 					break;
 
 				case DisplayForm.COLLADA:
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getVegetationColladaOptions().isGenerateTextureAtlases());
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getVegetationColladaOptions().isGenerateTextureAtlases(), false);
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Queries.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Queries.java
@@ -35,10 +35,22 @@ import org.citydb.database.schema.SequenceEnum;
 public class Queries {
 	private AbstractDatabaseAdapter databaseAdapter;
 	private String schema;
+	private String implicitGeometryNullColumns;
 
 	public Queries(AbstractDatabaseAdapter databaseAdapter, String schema) {
 		this.databaseAdapter = databaseAdapter;
 		this.schema = schema;
+
+		switch (databaseAdapter.getDatabaseType()) {
+			case ORACLE:
+				implicitGeometryNullColumns = "null as implicit_id, null as implicit_ref_point, null as implicit_transformation ";
+				break;
+			case POSTGIS:
+				implicitGeometryNullColumns = "null::integer as implicit_id, null::geometry as implicit_ref_point, null::text as implicit_transformation ";
+				break;
+			default:
+				implicitGeometryNullColumns = "";
+		}
 	}
 
 	// ----------------------------------------------------------------------
@@ -200,16 +212,18 @@ public class Queries {
 
 		if (lod > 1) {
 			// exterior thematic surfaces
-			query.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			query.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".thematic_surface ts ")
 			.append("WHERE ts.building_id = ? ")
 			.append("AND ts.lod").append(lod).append("_multi_surface_id is not null ")
 			.append(") tmp) ");
 
 			if (!lodCheckOnly) {
-				// exterior thematic surfaces of building installations
+				// thematic surfaces of exterior building installations
 				query.append("UNION ALL ")
-				.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+				.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+				.append(implicitGeometryNullColumns)
 				.append("FROM ").append(schema).append(".thematic_surface ts ")
 				.append("JOIN ").append(schema).append(".building_installation bi ON ts.building_installation_id = bi.id ")
 				.append("WHERE bi.building_id = ? ")
@@ -217,10 +231,13 @@ public class Queries {
 				.append(") tmp) ")
 				// exterior building installations
 				.append("UNION ALL ")
-				.append("(SELECT tmp.* FROM (SELECT bi.lod").append(lod).append("_brep_id, bi.objectclass_id ")
+				.append("(SELECT tmp.* FROM (SELECT bi.lod").append(lod).append("_brep_id, bi.objectclass_id, ")
+				.append("ig.relative_brep_id, bi.lod").append(lod).append("_implicit_ref_point, ").append("bi.lod").append(lod).append("_implicit_transformation ")
 				.append("FROM ").append(schema).append(".building_installation bi ")
+				.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = bi.lod").append(lod).append("_implicit_rep_id ")
 				.append("WHERE bi.building_id = ? ")
-				.append("AND bi.lod").append(lod).append("_brep_id is not null ")
+				.append("AND (bi.lod").append(lod).append("_brep_id is not null ")
+				.append("OR ig.relative_brep_id is not null) ")
 				.append(") tmp) ");
 			}
 		}
@@ -228,29 +245,36 @@ public class Queries {
 		if (lod > 2 && !lodCheckOnly) {
 			// openings in exterior thematic surfaces
 			query.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".opening o ")
 			.append("JOIN ").append(schema).append(".opening_to_them_surface o2ts ON o2ts.opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".thematic_surface ts ON ts.id = o2ts.thematic_surface_id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE ts.building_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// openings in exterior thematic surfaces of building installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".opening o ")
 			.append("JOIN ").append(schema).append(".opening_to_them_surface o2ts ON o2ts.opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".thematic_surface ts ON ts.id = o2ts.thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".building_installation bi ON ts.building_installation_id = bi.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE bi.building_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ");
 		}
 
 		if (lod > 3 && !lodCheckOnly) {
 			// interior thematic surfaces of building installations
 			query.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".thematic_surface ts ")
 			.append("JOIN ").append(schema).append(".building_installation bi ON ts.building_installation_id = bi.id ")
 			.append("JOIN ").append(schema).append(".room r ON bi.room_id = r.id ")
@@ -259,7 +283,8 @@ public class Queries {
 			.append(") tmp) ")
 			// interior thematic surfaces of rooms
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".thematic_surface ts ")
 			.append("JOIN ").append(schema).append(".room r ON ts.room_id = r.id ")
 			.append("WHERE r.building_id = ? ")
@@ -267,53 +292,67 @@ public class Queries {
 			.append(") tmp) ")
 			// openings of interior thematic surfaces of building installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".opening o ")
 			.append("JOIN ").append(schema).append(".opening_to_them_surface o2ts ON o2ts.opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".thematic_surface ts ON ts.id = o2ts.thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".building_installation bi ON ts.building_installation_id = bi.id ")
 			.append("JOIN ").append(schema).append(".room r ON bi.room_id = r.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE r.building_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// openings of interior thematic surfaces of rooms
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".opening o ")
 			.append("JOIN ").append(schema).append(".opening_to_them_surface o2ts ON o2ts.opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".thematic_surface ts ON ts.id = o2ts.thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".room r ON ts.room_id = r.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE r.building_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// building furniture
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT bf.lod4_brep_id, bf.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT bf.lod4_brep_id, bf.objectclass_id, ")
+			.append("ig.relative_brep_id, bf.lod4_implicit_ref_point, ").append("bf.lod4_implicit_transformation ")
 			.append("FROM ").append(schema).append(".building_furniture bf ")
 			.append("JOIN ").append(schema).append(".room r ON bf.room_id = r.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = bf.lod4_implicit_rep_id ")
 			.append("WHERE r.building_id = ? ")
-			.append("AND bf.lod4_brep_id is not null ")
+			.append("AND (bf.lod4_brep_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// rooms
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT r.lod4_solid_id, r.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT r.lod4_solid_id, r.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".room r ")
 			.append("WHERE r.building_id = ? ")
 			.append("AND r.lod4_solid_id is not null ")
 			.append(") tmp) ")
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT r.lod4_multi_surface_id, r.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT r.lod4_multi_surface_id, r.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".room r ")
 			.append("WHERE r.building_id = ? ")
 			.append("AND r.lod4_multi_surface_id is not null ")
 			.append(") tmp) ")
 			// interior building installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT bi.lod").append(lod).append("_brep_id, bi.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT bi.lod").append(lod).append("_brep_id, bi.objectclass_id, ")
+			.append("ig.relative_brep_id, bi.lod").append(lod).append("_implicit_ref_point, ").append("bi.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".building_installation bi ")
 			.append("JOIN ").append(schema).append(".room r ON bi.room_id = r.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = bi.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE r.building_id = ? ")
-			.append("AND bi.lod").append(lod).append("_brep_id is not null ")
+			.append("AND (bi.lod").append(lod).append("_brep_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ");
 		}
 
@@ -321,13 +360,15 @@ public class Queries {
 			query.append("UNION ALL ");
 
 		// building geometry
-		query.append("(SELECT tmp.* FROM (SELECT b.lod").append(lod).append("_solid_id, 0 as objectclass_id ")
+		query.append("(SELECT tmp.* FROM (SELECT b.lod").append(lod).append("_solid_id, 0 as objectclass_id, ")
+		.append(implicitGeometryNullColumns)
 		.append("FROM ").append(schema).append(".building b ")
 		.append("WHERE b.id = ? ")
 		.append("AND b.lod").append(lod).append("_solid_id is not null ")
 		.append(") tmp) ")
 		.append("UNION ALL ")
-		.append("(SELECT tmp.* FROM (SELECT b.lod").append(lod).append("_multi_surface_id, 0 as objectclass_id ")
+		.append("(SELECT tmp.* FROM (SELECT b.lod").append(lod).append("_multi_surface_id, 0 as objectclass_id, ")
+		.append(implicitGeometryNullColumns)
 		.append("FROM ").append(schema).append(".building b ")
 		.append("WHERE b.id = ? ")
 		.append("AND b.lod").append(lod).append("_multi_surface_id is not null ")
@@ -623,24 +664,27 @@ public class Queries {
 
 		if (lod > 1) {
 			// exterior thematic surfaces
-			query.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			query.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".bridge_thematic_surface ts ")
 			.append("WHERE ts.bridge_id = ? ")
 			.append("AND ts.lod").append(lod).append("_multi_surface_id is not null ")
 			.append(") tmp) ");
 
 			if (!lodCheckOnly) {
-				// exterior thematic surfaces of bridge construction elements
+				// thematic surfaces of bridge construction elements
 				query.append("UNION ALL ")
-				.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+				.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+				.append(implicitGeometryNullColumns)
 				.append("FROM ").append(schema).append(".bridge_thematic_surface ts ")
 				.append("JOIN ").append(schema).append(".bridge_constr_element bc ON ts.bridge_constr_element_id = bc.id ")
 				.append("WHERE bc.bridge_id = ? ")
 				.append("AND ts.lod").append(lod).append("_multi_surface_id is not null ")
 				.append(") tmp) ")				
-				// exterior thematic surfaces of bridge installations
+				// thematic surfaces of exterior bridge installations
 				.append("UNION ALL ")
-				.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+				.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+				.append(implicitGeometryNullColumns)
 				.append("FROM ").append(schema).append(".bridge_thematic_surface ts ")
 				.append("JOIN ").append(schema).append(".bridge_installation bi ON ts.bridge_installation_id = bi.id ")
 				.append("WHERE bi.bridge_id = ? ")
@@ -648,10 +692,13 @@ public class Queries {
 				.append(") tmp) ")
 				// exterior bridge installations
 				.append("UNION ALL ")
-				.append("(SELECT tmp.* FROM (SELECT bi.lod").append(lod).append("_brep_id, bi.bjectclass_id ")
+				.append("(SELECT tmp.* FROM (SELECT bi.lod").append(lod).append("_brep_id, bi.objectclass_id, ")
+				.append("ig.relative_brep_id, bi.lod").append(lod).append("_implicit_ref_point, ").append("bi.lod").append(lod).append("_implicit_transformation ")
 				.append("FROM ").append(schema).append(".bridge_installation bi ")
+				.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = bi.lod").append(lod).append("_implicit_rep_id ")
 				.append("WHERE bi.bridge_id = ? ")
-				.append("AND bi.lod").append(lod).append("_brep_id is not null ")
+				.append("AND (bi.lod").append(lod).append("_brep_id is not null ")
+				.append("OR ig.relative_brep_id is not null) ")
 				.append(") tmp) ");
 			}
 		}
@@ -659,39 +706,49 @@ public class Queries {
 		if (lod > 2 && !lodCheckOnly) {
 			// openings in exterior thematic surfaces
 			query.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".bridge_opening o ")
 			.append("JOIN ").append(schema).append(".bridge_open_to_them_srf o2ts ON o2ts.bridge_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".bridge_thematic_surface ts ON ts.id = o2ts.bridge_thematic_surface_id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE ts.bridge_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// openings in exterior thematic surfaces of bridge construction elements		
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".bridge_opening o ")
 			.append("JOIN ").append(schema).append(".bridge_open_to_them_srf o2ts ON o2ts.bridge_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".bridge_thematic_surface ts ON ts.id = o2ts.bridge_thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".bridge_constr_element bc ON ts.bridge_constr_element_id = bc.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE bc.bridge_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// openings in exterior thematic surfaces of building installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".bridge_opening o ")
 			.append("JOIN ").append(schema).append(".bridge_open_to_them_srf o2ts ON o2ts.bridge_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".bridge_thematic_surface ts ON ts.id = o2ts.bridge_thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".bridge_installation bi ON ts.bridge_installation_id = bi.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE bi.bridge_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ");
 		}
 
 		if (lod > 3 && !lodCheckOnly) {
 			// interior thematic surfaces of bridge installations
 			query.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".bridge_thematic_surface ts ")
 			.append("JOIN ").append(schema).append(".bridge_installation bi ON ts.bridge_installation_id = bi.id ")
 			.append("JOIN ").append(schema).append(".bridge_room r ON bi.bridge_room_id = r.id ")
@@ -700,7 +757,8 @@ public class Queries {
 			.append(") tmp) ")
 			// interior thematic surfaces of rooms
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".bridge_thematic_surface ts ")
 			.append("JOIN ").append(schema).append(".bridge_room r ON ts.bridge_room_id = r.id ")
 			.append("WHERE r.bridge_id = ? ")
@@ -708,53 +766,67 @@ public class Queries {
 			.append(") tmp) ")
 			// openings of interior thematic surfaces of bridge installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".bridge_opening o ")
 			.append("JOIN ").append(schema).append(".bridge_open_to_them_srf o2ts ON o2ts.bridge_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".bridge_thematic_surface ts ON ts.id = o2ts.bridge_thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".bridge_installation bi ON ts.bridge_installation_id = bi.id ")
 			.append("JOIN ").append(schema).append(".bridge_room r ON bi.bridge_room_id = r.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE r.bridge_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// openings of interior thematic surfaces of bridge rooms
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".bridge_opening o ")
 			.append("JOIN ").append(schema).append(".bridge_open_to_them_srf o2ts ON o2ts.bridge_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".bridge_thematic_surface ts ON ts.id = o2ts.bridge_thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".bridge_room r ON ts.bridge_room_id = r.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE r.bridge_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// bridge furniture
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT bf.lod4_brep_id, bf.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT bf.lod4_brep_id, bf.objectclass_id, ")
+			.append("ig.relative_brep_id, bf.lod4_implicit_ref_point, ").append("bf.lod4_implicit_transformation ")
 			.append("FROM ").append(schema).append(".bridge_furniture bf ")
 			.append("JOIN ").append(schema).append(".bridge_room r ON bf.bridge_room_id = r.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = bf.lod4_implicit_rep_id ")
 			.append("WHERE r.bridge_id = ? ")
-			.append("AND bf.lod4_brep_id is not null ")
+			.append("AND (bf.lod4_brep_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// bridge rooms
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT r.lod4_solid_id, r.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT r.lod4_solid_id, r.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".bridge_room r ")
 			.append("WHERE r.bridge_id = ? ")
 			.append("AND r.lod4_solid_id is not null ")
 			.append(") tmp) ")
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT r.lod4_multi_surface_id, r.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT r.lod4_multi_surface_id, r.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".bridge_room r ")
 			.append("WHERE r.bridge_id = ? ")
 			.append("AND r.lod4_multi_surface_id is not null ")
 			.append(") tmp) ")
 			// interior bridge installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT bi.lod").append(lod).append("_brep_id, bi.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT bi.lod").append(lod).append("_brep_id, bi.objectclass_id, ")
+			.append("ig.relative_brep_id, bi.lod").append(lod).append("_implicit_ref_point, ").append("bi.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".bridge_installation bi ")
 			.append("JOIN ").append(schema).append(".bridge_room r ON bi.bridge_room_id = r.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = bi.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE r.bridge_id = ? ")
-			.append("AND bi.lod").append(lod).append("_brep_id is not null ")
+			.append("AND (bi.lod").append(lod).append("_brep_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ");
 		}
 
@@ -762,13 +834,15 @@ public class Queries {
 			query.append("UNION ALL ");
 
 		// bridge geometry
-		query.append("(SELECT tmp.* FROM (SELECT b.lod").append(lod).append("_solid_id, 0 as objectclass_id ")
+		query.append("(SELECT tmp.* FROM (SELECT b.lod").append(lod).append("_solid_id, 0 as objectclass_id, ")
+		.append(implicitGeometryNullColumns)
 		.append("FROM ").append(schema).append(".bridge b ")
 		.append("WHERE b.id = ? ")
 		.append("AND b.lod").append(lod).append("_solid_id is not null ")
 		.append(") tmp) ")
 		.append("UNION ALL ")
-		.append("(SELECT tmp.* FROM (SELECT b.lod").append(lod).append("_multi_surface_id, 0 as objectclass_id ")
+		.append("(SELECT tmp.* FROM (SELECT b.lod").append(lod).append("_multi_surface_id, 0 as objectclass_id, ")
+		.append(implicitGeometryNullColumns)
 		.append("FROM ").append(schema).append(".bridge b ")
 		.append("WHERE b.id = ? ")
 		.append("AND b.lod").append(lod).append("_multi_surface_id is not null ")
@@ -777,10 +851,13 @@ public class Queries {
 		if (!lodCheckOnly) {
 			// exterior bridge construction elements
 			query.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT bc.lod").append(lod).append("_brep_id, bc.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT bc.lod").append(lod).append("_brep_id, bc.objectclass_id, ")
+			.append("ig.relative_brep_id, bc.lod").append(lod).append("_implicit_ref_point, ").append("bc.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".bridge_constr_element bc ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = bc.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE bc.bridge_id = ? ")
-			.append("AND bc.lod").append(lod).append("_brep_id is not null ")
+			.append("AND (bc.lod").append(lod).append("_brep_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ");
 		}
 
@@ -1004,16 +1081,18 @@ public class Queries {
 
 		if (lod > 1) {
 			// exterior thematic surfaces
-			query.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			query.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".tunnel_thematic_surface ts ")
 			.append("WHERE ts.tunnel_id = ? ")
 			.append("AND ts.lod").append(lod).append("_multi_surface_id is not null ")
 			.append(") tmp) ");
 
 			if (!lodCheckOnly) {
-				// exterior thematic surfaces of tunnel installations
+				// thematic surfaces of exterior tunnel installations
 				query.append("UNION ALL ")
-				.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+				.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+				.append(implicitGeometryNullColumns)
 				.append("FROM ").append(schema).append(".tunnel_thematic_surface ts ")
 				.append("JOIN ").append(schema).append(".tunnel_installation tui ON ts.tunnel_installation_id = tui.id ")
 				.append("WHERE tui.tunnel_id = ? ")
@@ -1021,10 +1100,13 @@ public class Queries {
 				.append(") tmp) ")
 				// exterior tunnel installations
 				.append("UNION ALL ")
-				.append("(SELECT tmp.* FROM (SELECT tui.lod").append(lod).append("_brep_id, tui.objectclass_id ")
+				.append("(SELECT tmp.* FROM (SELECT tui.lod").append(lod).append("_brep_id, tui.objectclass_id, ")
+				.append("ig.relative_brep_id, tui.lod").append(lod).append("_implicit_ref_point, ").append("tui.lod").append(lod).append("_implicit_transformation ")
 				.append("FROM ").append(schema).append(".tunnel_installation tui ")
+				.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = tui.lod").append(lod).append("_implicit_rep_id ")
 				.append("WHERE tui.tunnel_id = ? ")
-				.append("AND tui.lod").append(lod).append("_brep_id is not null ")
+				.append("AND (tui.lod").append(lod).append("_brep_id is not null ")
+				.append("OR ig.relative_brep_id is not null) ")
 				.append(") tmp) ");
 			}
 		}
@@ -1032,29 +1114,36 @@ public class Queries {
 		if (lod > 2 && !lodCheckOnly) {
 			// openings in exterior thematic surfaces
 			query.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".tunnel_opening o ")
 			.append("JOIN ").append(schema).append(".tunnel_open_to_them_srf o2ts ON o2ts.tunnel_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".tunnel_thematic_surface ts ON ts.id = o2ts.tunnel_thematic_surface_id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE ts.tunnel_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// openings in exterior thematic surfaces of tunnel installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".tunnel_opening o ")
 			.append("JOIN ").append(schema).append(".tunnel_open_to_them_srf o2ts ON o2ts.tunnel_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".tunnel_thematic_surface ts ON ts.id = o2ts.tunnel_thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".tunnel_installation tui ON ts.tunnel_installation_id = tui.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE tui.tunnel_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ");
 		}
 
 		if (lod > 3 && !lodCheckOnly) {
 			// interior thematic surfaces of tunnel installations
 			query.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".tunnel_thematic_surface ts ")
 			.append("JOIN ").append(schema).append(".tunnel_installation tui ON ts.tunnel_installation_id = tui.id ")
 			.append("JOIN ").append(schema).append(".tunnel_hollow_space hs ON tui.tunnel_hollow_space_id = hs.id ")
@@ -1063,7 +1152,8 @@ public class Queries {
 			.append(") tmp) ")
 			// interior thematic surfaces of hollow spaces
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ") 
+			.append("(SELECT tmp.* FROM (SELECT ts.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".tunnel_thematic_surface ts ")
 			.append("JOIN ").append(schema).append(".tunnel_hollow_space hs ON ts.tunnel_hollow_space_id = hs.id ")
 			.append("WHERE hs.tunnel_id = ? ")
@@ -1071,53 +1161,67 @@ public class Queries {
 			.append(") tmp) ")
 			// openings of interior thematic surfaces of tunnel installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".tunnel_opening o ")
 			.append("JOIN ").append(schema).append(".tunnel_open_to_them_srf o2ts ON o2ts.tunnel_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".tunnel_thematic_surface ts ON ts.id = o2ts.tunnel_thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".tunnel_installation tui ON ts.tunnel_installation_id = tui.id ")
 			.append("JOIN ").append(schema).append(".tunnel_hollow_space hs ON tui.tunnel_hollow_space_id = hs.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE hs.tunnel_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// openings of interior thematic surfaces of hollow spaces
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT o.lod").append(lod).append("_multi_surface_id, ts.objectclass_id, ")
+			.append("ig.relative_brep_id, o.lod").append(lod).append("_implicit_ref_point, ").append("o.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".tunnel_opening o ")
 			.append("JOIN ").append(schema).append(".tunnel_open_to_them_srf o2ts ON o2ts.tunnel_opening_id = o.id ")
 			.append("JOIN ").append(schema).append(".tunnel_thematic_surface ts ON ts.id = o2ts.tunnel_thematic_surface_id ")
 			.append("JOIN ").append(schema).append(".tunnel_hollow_space hs ON ts.tunnel_hollow_space_id = hs.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = o.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE hs.tunnel_id = ? ")
-			.append("AND o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("AND (o.lod").append(lod).append("_multi_surface_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// tunnel furniture
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT tf.lod4_brep_id, tf.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT tf.lod4_brep_id, tf.objectclass_id, ")
+			.append("ig.relative_brep_id, tf.lod4_implicit_ref_point, ").append("tf.lod4_implicit_transformation ")
 			.append("FROM ").append(schema).append(".tunnel_furniture tf ")
 			.append("JOIN ").append(schema).append(".tunnel_hollow_space hs ON tbf.tunnel_hollow_space_id = hs.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = tf.lod4_implicit_rep_id ")
 			.append("WHERE hs.tunnel_id = ? ")
-			.append("AND tf.lod4_brep_id is not null ")
+			.append("AND (tf.lod4_brep_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ")
 			// hollow spaces
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT hs.lod4_solid_id, hs.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT hs.lod4_solid_id, hs.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".tunnel_hollow_space hs ")
 			.append("WHERE hs.tunnel_id = ? ")
 			.append("AND hs.lod4_solid_id is not null ")
 			.append(") tmp) ")
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT r.lod4_multi_surface_id, hs.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT r.lod4_multi_surface_id, hs.objectclass_id, ")
+			.append(implicitGeometryNullColumns)
 			.append("FROM ").append(schema).append(".tunnel_hollow_space hs ")
 			.append("WHERE hs.tunnel_id = ? ")
 			.append("AND r.lod4_multi_surface_id is not null ")
 			.append(") tmp) ")
 			// interior tunnel installations
 			.append("UNION ALL ")
-			.append("(SELECT tmp.* FROM (SELECT tui.lod").append(lod).append("_brep_id, tui.objectclass_id ")
+			.append("(SELECT tmp.* FROM (SELECT tui.lod").append(lod).append("_brep_id, tui.objectclass_id, ")
+			.append("ig.relative_brep_id, tui.lod").append(lod).append("_implicit_ref_point, ").append("tui.lod").append(lod).append("_implicit_transformation ")
 			.append("FROM ").append(schema).append(".tunnel_installation tui ")
 			.append("JOIN ").append(schema).append(".tunnel_hollow_space hs ON tui.tunnel_hollow_space_id = hs.id ")
+			.append("LEFT JOIN ").append(schema).append(".IMPLICIT_GEOMETRY ig ON ig.id = tui.lod").append(lod).append("_implicit_rep_id ")
 			.append("WHERE hs.tunnel_id = ? ")
-			.append("AND tui.lod").append(lod).append("_brep_id is not null ")
+			.append("AND (tui.lod").append(lod).append("_brep_id is not null ")
+			.append("OR ig.relative_brep_id is not null) ")
 			.append(") tmp) ");
 		}
 
@@ -1125,13 +1229,15 @@ public class Queries {
 			query.append("UNION ALL ");
 
 		// tunnel geometry
-		query.append("(SELECT tmp.* FROM (SELECT lod").append(lod).append("_solid_id, 0 as objectclass_id ")
+		query.append("(SELECT tmp.* FROM (SELECT lod").append(lod).append("_solid_id, 0 as objectclass_id, ")
+		.append(implicitGeometryNullColumns)
 		.append("FROM ").append(schema).append(".tunnel t ")
 		.append("WHERE t.id = ? ")
 		.append("AND lod").append(lod).append("_solid_id is not null ")
 		.append(") tmp) ")
 		.append("UNION ALL ")
-		.append("(SELECT tmp.* FROM (SELECT t.lod").append(lod).append("_multi_surface_id, 0 as objectclass_id ")
+		.append("(SELECT tmp.* FROM (SELECT t.lod").append(lod).append("_multi_surface_id, 0 as objectclass_id, ")
+		.append(implicitGeometryNullColumns)
 		.append("FROM ").append(schema).append(".tunnel t ")
 		.append("WHERE t.id = ? ")
 		.append("AND t.lod").append(lod).append("_multi_surface_id is not null ")

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Relief.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Relief.java
@@ -192,7 +192,7 @@ public class Relief extends KmlGenericObject{
 					break;
 
 				case DisplayForm.COLLADA:
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getReliefColladaOptions().isGenerateTextureAtlases());
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getReliefColladaOptions().isGenerateTextureAtlases(), false);
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Relief.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Relief.java
@@ -181,13 +181,13 @@ public class Relief extends KmlGenericObject{
 					setId(work.getId());
 					if (query.isSetTiling()) { // region
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} else { // reverse order for single objects
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					}
 					break;
 
@@ -211,7 +211,7 @@ public class Relief extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} catch (Exception ioe) {
 						log.logStackTrace(ioe);
 					}

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/SolitaryVegetationObject.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/SolitaryVegetationObject.java
@@ -221,7 +221,7 @@ public class SolitaryVegetationObject extends KmlGenericObject{
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getVegetationColladaOptions().isGenerateTextureAtlases(), transformer);
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getVegetationColladaOptions().isGenerateTextureAtlases(), transformer, false);
 
 					if (currentgmlId != null && !currentgmlId.equals(work.getGmlId()) && getGeometryAmount() > GEOMETRY_AMOUNT_WARNING)
 						log.info("Object " + work.getGmlId() + " has more than " + GEOMETRY_AMOUNT_WARNING + " geometries. This may take a while to process...");

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/SolitaryVegetationObject.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/SolitaryVegetationObject.java
@@ -29,7 +29,6 @@ package org.citydb.modules.kml.database;
 
 import net.opengis.kml._2.PlacemarkType;
 import org.citydb.config.Config;
-import org.citydb.config.geometry.GeometryObject;
 import org.citydb.config.project.kmlExporter.Balloon;
 import org.citydb.config.project.kmlExporter.ColladaOptions;
 import org.citydb.config.project.kmlExporter.DisplayForm;
@@ -42,9 +41,6 @@ import org.citydb.modules.kml.util.AffineTransformer;
 import org.citydb.modules.kml.util.BalloonTemplateHandler;
 import org.citydb.modules.kml.util.ElevationServiceHandler;
 import org.citydb.query.Query;
-import org.citydb.util.Util;
-import org.citygml4j.geometry.Matrix;
-import org.citygml4j.geometry.Point;
 
 import javax.vecmath.Point3d;
 import javax.xml.bind.JAXBException;
@@ -155,17 +151,7 @@ public class SolitaryVegetationObject extends KmlGenericObject{
 				long sgRootId = rs.getLong(4);
 				if (sgRootId == 0) {
 					sgRootId = rs.getLong(1);
-					if (sgRootId != 0) {
-						GeometryObject point = geometryConverterAdapter.getPoint(rs.getObject(2));
-						String transformationString = rs.getString(3);
-						if (point != null && transformationString != null) {
-							double[] ordinatesArray = point.getCoordinates(0);
-							Point referencePoint = new Point(ordinatesArray[0], ordinatesArray[1], ordinatesArray[2]);						
-							List<Double> m = Util.string2double(transformationString, "\\s+");
-							if (m != null && m.size() >= 16)
-								transformer = new AffineTransformer(new Matrix(m.subList(0, 16), 4), referencePoint, databaseAdapter.getConnectionMetaData().getReferenceSystem().getSrid());
-						}
-					}
+					transformer = getAffineTransformer(rs, 2, 3);
 				}
 
 				try { rs.close(); } catch (SQLException sqle) {} 
@@ -221,13 +207,13 @@ public class SolitaryVegetationObject extends KmlGenericObject{
 					setId(work.getId());
 					if (this.query.isSetTiling()) { // region
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} else { // reverse order for single objects
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					}
 					break;
 
@@ -251,7 +237,7 @@ public class SolitaryVegetationObject extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled()) 
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, transformer, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} catch (Exception ioe) {
 						log.logStackTrace(ioe);
 					}

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Transportation.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Transportation.java
@@ -204,7 +204,7 @@ public class Transportation extends KmlGenericObject{
 						break;
 
 					case DisplayForm.COLLADA:
-						fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getTransportationColladaOptions().isGenerateTextureAtlases());
+						fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getTransportationColladaOptions().isGenerateTextureAtlases(), false);
 						String currentgmlId = getGmlId();
 						setGmlId(work.getGmlId());
 						setId(work.getId());

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Transportation.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Transportation.java
@@ -193,13 +193,13 @@ public class Transportation extends KmlGenericObject{
 						setId(work.getId());
 						if (query.isSetTiling()) { // region
 							if (work.getDisplayForm().isHighlightingEnabled())
-								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 
-							kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						} else { // reverse order for single objects
-							kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 							if (work.getDisplayForm().isHighlightingEnabled())
-								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						}
 						break;
 
@@ -223,7 +223,7 @@ public class Transportation extends KmlGenericObject{
 						setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 						try {
 							if (work.getDisplayForm().isHighlightingEnabled())
-								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+								kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						} catch (Exception ioe) {
 							log.logStackTrace(ioe);
 						}

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Tunnel.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Tunnel.java
@@ -325,17 +325,17 @@ public class Tunnel extends KmlGenericObject{
 					setId(work.getId());
 					if (work.getDisplayForm().isHighlightingEnabled()) {
 						if (query.isSetTiling()) { // region
-							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work, false);
-							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work, false));
+							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work, true);
+							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work, true));
 							return hlPlacemarks;
 						}
 						else { // reverse order for single buildings
-							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work, false);
-							placemarks.addAll(createPlacemarksForHighlighting(rs, work, false));
+							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work, true);
+							placemarks.addAll(createPlacemarksForHighlighting(rs, work, true));
 							return placemarks;
 						}
 					}
-					return createPlacemarksForGeometry(rs, work, false);
+					return createPlacemarksForGeometry(rs, work, true);
 
 				case DisplayForm.COLLADA:
 					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getTunnelColladaOptions().isGenerateTextureAtlases()); // fill and refill
@@ -357,7 +357,7 @@ public class Tunnel extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled()) {
-							return createPlacemarksForHighlighting(rs, work, false);
+							return createPlacemarksForHighlighting(rs, work, true);
 						}
 						// just COLLADA, no KML
 						List<PlacemarkType> dummy = new ArrayList<>();

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Tunnel.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Tunnel.java
@@ -338,7 +338,7 @@ public class Tunnel extends KmlGenericObject{
 					return createPlacemarksForGeometry(rs, work, true);
 
 				case DisplayForm.COLLADA:
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getTunnelColladaOptions().isGenerateTextureAtlases()); // fill and refill
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getTunnelColladaOptions().isGenerateTextureAtlases(), true); // fill and refill
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Tunnel.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/Tunnel.java
@@ -325,17 +325,17 @@ public class Tunnel extends KmlGenericObject{
 					setId(work.getId());
 					if (work.getDisplayForm().isHighlightingEnabled()) {
 						if (query.isSetTiling()) { // region
-							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work);
-							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work));
+							List<PlacemarkType> hlPlacemarks = createPlacemarksForHighlighting(rs, work, false);
+							hlPlacemarks.addAll(createPlacemarksForGeometry(rs, work, false));
 							return hlPlacemarks;
 						}
 						else { // reverse order for single buildings
-							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work);
-							placemarks.addAll(createPlacemarksForHighlighting(rs, work));
+							List<PlacemarkType> placemarks = createPlacemarksForGeometry(rs, work, false);
+							placemarks.addAll(createPlacemarksForHighlighting(rs, work, false));
 							return placemarks;
 						}
 					}
-					return createPlacemarksForGeometry(rs, work);
+					return createPlacemarksForGeometry(rs, work, false);
 
 				case DisplayForm.COLLADA:
 					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getTunnelColladaOptions().isGenerateTextureAtlases()); // fill and refill
@@ -357,7 +357,7 @@ public class Tunnel extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled()) {
-							return createPlacemarksForHighlighting(rs, work);
+							return createPlacemarksForHighlighting(rs, work, false);
 						}
 						// just COLLADA, no KML
 						List<PlacemarkType> dummy = new ArrayList<>();

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/WaterBody.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/WaterBody.java
@@ -191,7 +191,7 @@ public class WaterBody extends KmlGenericObject{
 					break;
 
 				case DisplayForm.COLLADA:
-					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getWaterBodyColladaOptions().isGenerateTextureAtlases());
+					fillGenericObjectForCollada(rs, config.getProject().getKmlExporter().getWaterBodyColladaOptions().isGenerateTextureAtlases(), false);
 					String currentgmlId = getGmlId();
 					setGmlId(work.getGmlId());
 					setId(work.getId());

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/WaterBody.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/WaterBody.java
@@ -180,13 +180,13 @@ public class WaterBody extends KmlGenericObject{
 					setId(work.getId());
 					if (query.isSetTiling()) { // region
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} else { // reverse order for single objects
-						kmlExporterManager.print(createPlacemarksForGeometry(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+						kmlExporterManager.print(createPlacemarksForGeometry(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					}
 					break;
 
@@ -210,7 +210,7 @@ public class WaterBody extends KmlGenericObject{
 					setIgnoreSurfaceOrientation(colladaOptions.isIgnoreSurfaceOrientation());
 					try {
 						if (work.getDisplayForm().isHighlightingEnabled())
-							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work), work, getBalloonSettings().isBalloonContentInSeparateFile());
+							kmlExporterManager.print(createPlacemarksForHighlighting(rs, work, false), work, getBalloonSettings().isBalloonContentInSeparateFile());
 					} catch (Exception ioe) {
 						log.logStackTrace(ioe);
 					}


### PR DESCRIPTION
The current implementation of the KML/COLLADA/glTF exporter supports implicit geometries only for top-level features such as `frn:CityFurniture` or `gen:GenericCityObject` but not for nested sub-features such as `bldg:BuildingInstallation` (also see #93).

This PR enhances the KML/COLLADA/glTF exporter to also export implicit geometries of nested sub-features.

One simple test dataset: [Test_mini_out.zip](https://github.com/3dcitydb/importer-exporter/files/3311150/Test_mini_out.zip)