### PR TITLE
Resolve the limitation to gml:CompositeSurface as exterior shell of solid geometries

### DIFF
--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/DBSurfaceGeometry.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/DBSurfaceGeometry.java
@@ -98,7 +98,7 @@ public class DBSurfaceGeometry implements DBExporter {
 			if (exporter.getDatabaseAdapter().getSQLAdapter().requiresPseudoTableInSelect()) select.setPseudoTable(exporter.getDatabaseAdapter().getSQLAdapter().getPseudoTableName());
 			select.addSelection(ComparisonFactory.exists(new Select().addProjection(new ConstantColumn(1).withFromTable(table))
 					.addSelection(ComparisonFactory.equalTo(table.getColumn("surface_geometry_id"), new PlaceHolder<>()))));
-			
+
 			psImport = cacheTable.getConnection().prepareStatement("insert into " + cacheTable.getTableName() + " " + select.toString());
 		}
 
@@ -129,7 +129,7 @@ public class DBSurfaceGeometry implements DBExporter {
 
 				// constructing a geometry node
 				GeometryNode geomNode = new GeometryNode();
-				geomNode.id = id;				
+				geomNode.id = id;
 				geomNode.gmlId = rs.getString(2);
 				geomNode.parentId = rs.getLong(3);
 				geomNode.isSolid = rs.getBoolean(4);
@@ -200,7 +200,7 @@ public class DBSurfaceGeometry implements DBExporter {
 						}
 					}
 
-					if (isMultiSolid) 
+					if (isMultiSolid)
 						surfaceGeometryType = GMLClass.MULTI_SOLID;
 					else
 						surfaceGeometryType = GMLClass.MULTI_SURFACE;
@@ -213,19 +213,11 @@ public class DBSurfaceGeometry implements DBExporter {
 		if (geomNode.gmlId != null) {
 			if (geomNode.isXlink) {
 				if (exporter.lookupAndPutGeometryUID(geomNode.gmlId, geomNode.id)) {
-
 					if (useXLink) {
 						// check whether we have to embrace the geometry with an orientableSurface
-						if (geomNode.isReverse != isSetOrientableSurface) {
-							OrientableSurface orientableSurface = new OrientableSurface();				
-							SurfaceProperty surfaceProperty = new SurfaceProperty();
-							surfaceProperty.setHref("#" + geomNode.gmlId); 
-							orientableSurface.setBaseSurface(surfaceProperty);
-							orientableSurface.setOrientation(Sign.MINUS);
-
-							return new SurfaceGeometry(orientableSurface);
-						} else
-							return new SurfaceGeometry("#" + geomNode.gmlId, surfaceGeometryType);
+						return geomNode.isReverse != isSetOrientableSurface ?
+								new SurfaceGeometry(reverseSurface("#" + geomNode.gmlId)) :
+								new SurfaceGeometry("#" + geomNode.gmlId, surfaceGeometryType);
 					} else {
 						geomNode.isXlink = false;
 						String gmlId = DefaultGMLIdManager.getInstance().generateUUID(gmlIdPrefix);
@@ -236,7 +228,7 @@ public class DBSurfaceGeometry implements DBExporter {
 						return rebuildGeometry(geomNode, isSetOrientableSurface, true);
 					}
 				}
-			} 
+			}
 
 			if (exportAppearance && !wasXlink)
 				writeToAppearanceCache(geomNode);
@@ -261,13 +253,11 @@ public class DBSurfaceGeometry implements DBExporter {
 				forceRingIds = true;
 			}
 
-			// we suppose we have one outer ring and one or more inner rings
-			boolean isExterior = true;
 			for (int ringIndex = 0; ringIndex < geomNode.geometry.getNumElements(); ringIndex++) {
 				List<Double> values;
 
 				// check whether we have to reverse the coordinate order
-				if (!geomNode.isReverse) { 
+				if (!geomNode.isReverse) {
 					values = geomNode.geometry.getCoordinatesAsList(ringIndex);
 				} else {
 					values = new ArrayList<>(geomNode.geometry.getCoordinates(ringIndex).length);
@@ -279,50 +269,25 @@ public class DBSurfaceGeometry implements DBExporter {
 					}
 				}
 
-				if (isExterior) {
-					LinearRing linearRing = new LinearRing();
-					DirectPositionList directPositionList = new DirectPositionList();
+				LinearRing linearRing = new LinearRing();
+				DirectPositionList posList = new DirectPositionList();
+				if (forceRingIds)
+					linearRing.setId(polygon.getId() + '_' + ringIndex + '_');
 
-					if (forceRingIds)
-						linearRing.setId(polygon.getId() + '_' + ringIndex + '_');
+				posList.setValue(values);
+				posList.setSrsDimension(3);
+				linearRing.setPosList(posList);
 
-					directPositionList.setValue(values);
-					directPositionList.setSrsDimension(3);
-					linearRing.setPosList(directPositionList);
-
-					Exterior exterior = new Exterior();
-					exterior.setRing(linearRing);
-					polygon.setExterior(exterior);
-
-					isExterior = false;
-				} else {
-					LinearRing linearRing = new LinearRing();
-					DirectPositionList directPositionList = new DirectPositionList();
-
-					if (forceRingIds)
-						linearRing.setId(polygon.getId() + '_' + ringIndex + '_');
-
-					directPositionList.setValue(values);
-					directPositionList.setSrsDimension(3);
-					linearRing.setPosList(directPositionList);
-
-					Interior interior = new Interior();
-					interior.setRing(linearRing);
-					polygon.addInterior(interior);
-				}
+				if (ringIndex == 0)
+					polygon.setExterior(new Exterior(linearRing));
+				else
+					polygon.addInterior(new Interior(linearRing));
 			}
 
 			// check whether we have to embrace the polygon with an orientableSurface
-			if (initOrientableSurface || (isSetOrientableSurface && !geomNode.isReverse)) {
-				OrientableSurface orientableSurface = new OrientableSurface();				
-				SurfaceProperty surfaceProperty = new SurfaceProperty();
-				surfaceProperty.setSurface(polygon);
-				orientableSurface.setBaseSurface(surfaceProperty);
-				orientableSurface.setOrientation(Sign.MINUS);
-
-				return new SurfaceGeometry(orientableSurface);
-			} else
-				return new SurfaceGeometry(polygon);
+			return initOrientableSurface || (isSetOrientableSurface && !geomNode.isReverse) ?
+					new SurfaceGeometry(reverseSurface(polygon)) :
+					new SurfaceGeometry(polygon);
 		}
 
 		// compositeSurface
@@ -333,45 +298,27 @@ public class DBSurfaceGeometry implements DBExporter {
 				compositeSurface.setId(geomNode.gmlId);
 
 			for (GeometryNode childNode : geomNode.childNodes) {
-				SurfaceGeometry geomMember = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				SurfaceGeometry member = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				if (member != null) {
+					AbstractGeometry geometry = member.getGeometry();
+					SurfaceProperty property = null;
 
-				if (geomMember != null) {
-					AbstractGeometry absGeom = geomMember.getGeometry();
-					SurfaceProperty surfaceMember = new SurfaceProperty();
+					if (geometry instanceof AbstractSurface)
+						property = new SurfaceProperty((AbstractSurface) geometry);
+					else if (member.isSetReference())
+						property = new SurfaceProperty(member.getReference());
 
-					if (absGeom != null) {
-						switch (geomMember.getType()) {
-						case POLYGON:
-						case ORIENTABLE_SURFACE:
-						case COMPOSITE_SURFACE:
-						case TRIANGULATED_SURFACE:
-							surfaceMember.setSurface((AbstractSurface)absGeom);
-							break;						
-						default:
-							surfaceMember = null;
-						}
-					} else {
-						surfaceMember.setHref(geomMember.getReference());
-					}
-
-					if (surfaceMember != null)
-						compositeSurface.addSurfaceMember(surfaceMember);
+					if (property != null)
+						compositeSurface.addSurfaceMember(property);
 				}
 			}
 
 			if (compositeSurface.isSetSurfaceMember()) {
 				// check whether we have to embrace the compositeSurface with an orientableSurface
-				if (initOrientableSurface || (isSetOrientableSurface && !geomNode.isReverse)) {
-					OrientableSurface orientableSurface = new OrientableSurface();				
-					SurfaceProperty surfaceProperty = new SurfaceProperty();
-					surfaceProperty.setSurface(compositeSurface);
-					orientableSurface.setBaseSurface(surfaceProperty);
-					orientableSurface.setOrientation(Sign.MINUS);
-
-					return new SurfaceGeometry(orientableSurface);
-				} else
-					return new SurfaceGeometry(compositeSurface);
-			}					
+				return initOrientableSurface || (isSetOrientableSurface && !geomNode.isReverse) ?
+						new SurfaceGeometry(reverseSurface(compositeSurface)) :
+						new SurfaceGeometry(compositeSurface);
+			}
 
 			return null;
 		}
@@ -384,34 +331,22 @@ public class DBSurfaceGeometry implements DBExporter {
 				compositeSolid.setId(geomNode.gmlId);
 
 			for (GeometryNode childNode : geomNode.childNodes) {
-				SurfaceGeometry geomMember = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				SurfaceGeometry member = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				if (member != null) {
+					AbstractGeometry geometry = member.getGeometry();
+					SolidProperty property = null;
 
-				if (geomMember != null) {
-					AbstractGeometry absGeom = geomMember.getGeometry();
-					SolidProperty solidMember = new SolidProperty();
+					if (geometry instanceof AbstractSolid)
+						property = new SolidProperty((AbstractSolid) geometry);
+					else if (member.isSetReference())
+						property = new SolidProperty(member.getReference());
 
-					if (absGeom != null) {					
-						switch (geomMember.getType()) {
-						case SOLID:
-						case COMPOSITE_SOLID:
-							solidMember.setSolid((AbstractSolid)absGeom);
-							break;
-						default:
-							solidMember = null;
-						}
-					} else {
-						solidMember.setHref(geomMember.getReference());
-					}
-
-					if (solidMember != null)
-						compositeSolid.addSolidMember(solidMember);
+					if (property != null)
+						compositeSolid.addSolidMember(property);
 				}
 			}
 
-			if (compositeSolid.isSetSolidMember())
-				return new SurfaceGeometry(compositeSolid);
-
-			return null;
+			return compositeSolid.isSetSolidMember() ? new SurfaceGeometry(compositeSolid) : null;
 		}
 
 		// a simple solid
@@ -421,37 +356,23 @@ public class DBSurfaceGeometry implements DBExporter {
 			if (geomNode.gmlId != null)
 				solid.setId(geomNode.gmlId);
 
-			// we strongly assume solids contain one single CompositeSurface
-			// as exterior. Nothing else is interpreted here...
 			if (geomNode.childNodes.size() == 1) {
-				SurfaceGeometry geomMember = rebuildGeometry(geomNode.childNodes.get(0), isSetOrientableSurface, wasXlink);
+				SurfaceGeometry exterior = rebuildGeometry(geomNode.childNodes.get(0), isSetOrientableSurface, wasXlink);
+				if (exterior != null) {
+					AbstractGeometry geometry = exterior.getGeometry();
+					SurfaceProperty property = null;
 
-				if (geomMember != null) {
-					AbstractGeometry absGeom = geomMember.getGeometry();
-					SurfaceProperty surfaceProperty = new SurfaceProperty();
+					if (geometry instanceof AbstractSurface)
+						property = new SurfaceProperty((AbstractSurface) geometry);
+					else if (exterior.isSetReference())
+						property = new SurfaceProperty(exterior.getReference());
 
-					if (absGeom != null) {
-						switch (geomMember.getType()) {
-						case COMPOSITE_SURFACE:
-						case ORIENTABLE_SURFACE:
-							surfaceProperty.setSurface((AbstractSurface)absGeom);
-							break;
-						default:
-							surfaceProperty = null;
-						}
-					} else {
-						surfaceProperty.setHref(geomMember.getReference());
-					}
-
-					if (surfaceProperty != null)
-						solid.setExterior(surfaceProperty);
+					if (property != null)
+						solid.setExterior(property);
 				}
 			}
 
-			if (solid.isSetExterior())
-				return new SurfaceGeometry(solid);
-
-			return null;
+			return solid.isSetExterior() ? new SurfaceGeometry(solid) : null;
 		}
 
 		// multiSolid
@@ -462,35 +383,22 @@ public class DBSurfaceGeometry implements DBExporter {
 				multiSolid.setId(geomNode.gmlId);
 
 			for (GeometryNode childNode : geomNode.childNodes) {
-				SurfaceGeometry geomMember = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				SurfaceGeometry member = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				if (member != null) {
+					AbstractGeometry geometry = member.getGeometry();
+					SolidProperty property = null;
 
-				if (geomMember != null) {
-					AbstractGeometry absGeom = geomMember.getGeometry();
-					SolidProperty solidMember = new SolidProperty();
+					if (geometry instanceof AbstractSolid)
+						property = new SolidProperty((AbstractSolid) geometry);
+					else if (member.isSetReference())
+						property = new SolidProperty(member.getReference());
 
-					if (absGeom != null) {
-						switch (geomMember.getType()) {
-						case SOLID:
-						case COMPOSITE_SOLID:
-							solidMember.setSolid((AbstractSolid)absGeom);
-							break;
-						default:
-							solidMember = null;
-						}
-					} else {
-						solidMember.setHref(geomMember.getReference());
-					}
-
-					if (solidMember != null)
-						multiSolid.addSolidMember(solidMember);
+					if (property != null)
+						multiSolid.addSolidMember(property);
 				}
 			}
 
-			if (multiSolid.isSetSolidMember())
-				return new SurfaceGeometry(multiSolid);
-
-			return null;
-
+			return multiSolid.isSetSolidMember() ? new SurfaceGeometry(multiSolid) : null;
 		}
 
 		// multiSurface
@@ -501,36 +409,22 @@ public class DBSurfaceGeometry implements DBExporter {
 				multiSurface.setId(geomNode.gmlId);
 
 			for (GeometryNode childNode : geomNode.childNodes) {
-				SurfaceGeometry geomMember = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				SurfaceGeometry member = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				if (member != null) {
+					AbstractGeometry geometry = member.getGeometry();
+					SurfaceProperty property = null;
 
-				if (geomMember != null) {
-					AbstractGeometry absGeom = geomMember.getGeometry();
-					SurfaceProperty surfaceMember = new SurfaceProperty();
+					if (geometry instanceof AbstractSurface)
+						property = new SurfaceProperty((AbstractSurface) geometry);
+					else if (member.isSetReference())
+						property = new SurfaceProperty(member.getReference());
 
-					if (absGeom != null) {
-						switch (geomMember.getType()) {
-						case POLYGON:
-						case ORIENTABLE_SURFACE:
-						case COMPOSITE_SURFACE:
-						case TRIANGULATED_SURFACE:
-							surfaceMember.setSurface((AbstractSurface)absGeom);
-							break;
-						default:
-							surfaceMember = null;
-						}
-					} else {
-						surfaceMember.setHref(geomMember.getReference());
-					}
-
-					if (surfaceMember != null)
-						multiSurface.addSurfaceMember(surfaceMember);
+					if (property != null)
+						multiSurface.addSurfaceMember(property);
 				}
 			}
 
-			if (multiSurface.isSetSurfaceMember())
-				return new SurfaceGeometry(multiSurface);
-
-			return null;
+			return multiSurface.isSetSurfaceMember() ? new SurfaceGeometry(multiSurface) : null;
 		}
 
 		// triangulatedSurface
@@ -540,50 +434,52 @@ public class DBSurfaceGeometry implements DBExporter {
 			if (geomNode.gmlId != null)
 				triangulatedSurface.setId(geomNode.gmlId);
 
-			TrianglePatchArrayProperty triangleArray = new TrianglePatchArrayProperty();
+			TrianglePatchArrayProperty property = new TrianglePatchArrayProperty();
 			for (GeometryNode childNode : geomNode.childNodes) {
-				SurfaceGeometry geomMember = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				SurfaceGeometry member = rebuildGeometry(childNode, isSetOrientableSurface, wasXlink);
+				if (member != null) {
+					AbstractGeometry geometry = member.getGeometry();
 
-				if (geomMember != null) {
-					// we are only expecting polygons...
-					AbstractGeometry absGeom = geomMember.getGeometry();					
+					if (geometry instanceof Polygon) {
+						// we only expect polygons
+						Polygon polygon = (Polygon) geometry;
+						Triangle triangle = new Triangle();
 
-					if (geomMember.getType() == GMLClass.POLYGON) {
-						// we do not have to deal with xlinks here...
-						if (absGeom != null) {
-							// convert polygon to trianglePatch
-							Triangle triangle = new Triangle();
-							Polygon polygon = (Polygon)absGeom;
-
-							if (polygon.isSetExterior()) {								
-								triangle.setExterior(polygon.getExterior());
-								triangleArray.addTriangle(triangle);
-							}							
+						if (polygon.isSetExterior()) {
+							triangle.setExterior(polygon.getExterior());
+							property.addTriangle(triangle);
 						}
 					}
 				}
 			}
 
-			if (triangleArray.isSetTriangle() && !triangleArray.getTriangle().isEmpty()) {
-				triangulatedSurface.setTrianglePatches(triangleArray);
+			if (property.isSetTriangle() && !property.getTriangle().isEmpty()) {
+				triangulatedSurface.setTrianglePatches(property);
 
 				// check whether we have to embrace the compositeSurface with an orientableSurface
-				if (initOrientableSurface || (isSetOrientableSurface && !geomNode.isReverse)) {
-					OrientableSurface orientableSurface = new OrientableSurface();				
-					SurfaceProperty surfaceProperty = new SurfaceProperty();
-					surfaceProperty.setSurface(triangulatedSurface);
-					orientableSurface.setBaseSurface(surfaceProperty);
-					orientableSurface.setOrientation(Sign.MINUS);
-
-					return new SurfaceGeometry(orientableSurface);
-				} else
-					return new SurfaceGeometry(triangulatedSurface);
+				return initOrientableSurface || (isSetOrientableSurface && !geomNode.isReverse) ?
+						new SurfaceGeometry(reverseSurface(triangulatedSurface)) :
+						new SurfaceGeometry(triangulatedSurface);
 			}
 
 			return null;
 		}
 
 		return null;
+	}
+
+	private OrientableSurface reverseSurface(AbstractSurface surface) {
+		OrientableSurface orientableSurface = new OrientableSurface();
+		orientableSurface.setBaseSurface(new SurfaceProperty(surface));
+		orientableSurface.setOrientation(Sign.MINUS);
+		return orientableSurface;
+	}
+
+	private OrientableSurface reverseSurface(String reference) {
+		OrientableSurface orientableSurface = new OrientableSurface();
+		orientableSurface.setBaseSurface(new SurfaceProperty(reference));
+		orientableSurface.setOrientation(Sign.MINUS);
+		return orientableSurface;
 	}
 
 	private void writeToAppearanceCache(GeometryNode geomNode) throws SQLException {

--- a/impexp-core/src/main/java/org/citydb/citygml/importer/database/content/DBSurfaceGeometry.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/importer/database/content/DBSurfaceGeometry.java
@@ -188,8 +188,8 @@ public class DBSurfaceGeometry implements DBImporter {
         }
     }
 
-    private long doImport(AbstractGeometry geometry, long parentId, long rootId, boolean reverse, boolean isXlink, boolean isCopy, long cityObjectId) throws CityGMLImportException, SQLException {
-        return doImport(geometry, ids.next(geometry), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+    private void doImport(AbstractGeometry geometry, long parentId, long rootId, boolean reverse, boolean isXlink, boolean isCopy, long cityObjectId) throws CityGMLImportException, SQLException {
+        doImport(geometry, ids.next(geometry), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
     }
 
     private long doImport(AbstractGeometry geometry, long id, long parentId, long rootId, boolean reverse, boolean isXlink, boolean isCopy, long cityObjectId) throws CityGMLImportException, SQLException {

--- a/impexp-core/src/main/java/org/citydb/citygml/importer/database/content/DBSurfaceGeometry.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/importer/database/content/DBSurfaceGeometry.java
@@ -40,9 +40,9 @@ import org.citydb.database.connection.DatabaseConnectionPool;
 import org.citydb.database.schema.SequenceEnum;
 import org.citydb.database.schema.TableEnum;
 import org.citydb.util.CoreConstants;
-import org.citygml4j.model.citygml.CityGMLClass;
 import org.citygml4j.model.citygml.texturedsurface._AbstractAppearance;
 import org.citygml4j.model.citygml.texturedsurface._AppearanceProperty;
+import org.citygml4j.model.citygml.texturedsurface._SimpleTexture;
 import org.citygml4j.model.citygml.texturedsurface._TexturedSurface;
 import org.citygml4j.model.gml.GMLClass;
 import org.citygml4j.model.gml.geometry.AbstractGeometry;
@@ -86,339 +86,251 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DBSurfaceGeometry implements DBImporter {
-	private final Connection batchConn;
-	private final CityGMLImportManager importer;
+    private final Connection batchConn;
+    private final CityGMLImportManager importer;
 
-	private PreparedStatement psGeomElem;
-	private PreparedStatement psNextSeqValues;
-	private GeometryConverter geometryConverter;
-	private DBAppearance appearanceImporter;
-	private PrimaryKeyManager pkManager;
+    private final PreparedStatement psGeomElem;
+    private final PreparedStatement psNextSeqValues;
+    private final GeometryConverter geometryConverter;
+    private final DBAppearance appearanceImporter;
+    private final PrimaryKeyManager pkManager;
+	private final LocalAppearanceHandler localAppearanceHandler;
+	private final RingValidator ringValidator;
+
+	private final boolean replaceGmlId;
+	private final boolean importAppearance;
+	private final int nullGeometryType;
+	private final String nullGeometryTypeName;
 
 	private int dbSrid;
-	private boolean replaceGmlId;
-	private boolean importAppearance;
-	private boolean applyTransformation;
-	private boolean isImplicit;
-	private int batchCounter;
-	private int nullGeometryType;
-	private String nullGeometryTypeName;
-	private LocalAppearanceHandler localAppearanceHandler;
-	private RingValidator ringValidator;
+    private boolean applyTransformation;
+    private boolean isImplicit;
+    private int batchCounter;
 
-	public DBSurfaceGeometry(Connection batchConn, Config config, CityGMLImportManager importer) throws CityGMLImportException, SQLException {
-		this.batchConn = batchConn;
-		this.importer = importer;
+    public DBSurfaceGeometry(Connection batchConn, Config config, CityGMLImportManager importer) throws CityGMLImportException, SQLException {
+        this.batchConn = batchConn;
+        this.importer = importer;
 
-		replaceGmlId = config.getProject().getImporter().getGmlId().isUUIDModeReplace();
-		dbSrid = DatabaseConnectionPool.getInstance().getActiveDatabaseAdapter().getConnectionMetaData().getReferenceSystem().getSrid();
-		importAppearance = config.getProject().getImporter().getAppearances().isSetImportAppearance();
-		applyTransformation = config.getProject().getImporter().getAffineTransformation().isEnabled();
-		nullGeometryType = importer.getDatabaseAdapter().getGeometryConverter().getNullGeometryType();
-		nullGeometryTypeName = importer.getDatabaseAdapter().getGeometryConverter().getNullGeometryTypeName();
-		String schema = importer.getDatabaseAdapter().getConnectionDetails().getSchema();
+        replaceGmlId = config.getProject().getImporter().getGmlId().isUUIDModeReplace();
+        dbSrid = DatabaseConnectionPool.getInstance().getActiveDatabaseAdapter().getConnectionMetaData().getReferenceSystem().getSrid();
+        importAppearance = config.getProject().getImporter().getAppearances().isSetImportAppearance();
+        applyTransformation = config.getProject().getImporter().getAffineTransformation().isEnabled();
+        nullGeometryType = importer.getDatabaseAdapter().getGeometryConverter().getNullGeometryType();
+        nullGeometryTypeName = importer.getDatabaseAdapter().getGeometryConverter().getNullGeometryTypeName();
+        String schema = importer.getDatabaseAdapter().getConnectionDetails().getSchema();
 
-		String gmlIdCodespace = config.getInternal().getCurrentGmlIdCodespace();
-		if (gmlIdCodespace != null)
-			gmlIdCodespace = "'" + gmlIdCodespace + "', ";
+        String gmlIdCodespace = config.getInternal().getCurrentGmlIdCodespace();
+        if (gmlIdCodespace != null)
+            gmlIdCodespace = "'" + gmlIdCodespace + "', ";
 
-		StringBuilder stmt = new StringBuilder()
-				.append("insert into ").append(schema).append(".surface_geometry (id, gmlid, ").append(gmlIdCodespace != null ? "gmlid_codespace, " : "")
-				.append("parent_id, root_id, is_solid, is_composite, is_triangulated, is_xlink, is_reverse, geometry, solid_geometry, implicit_geometry, cityobject_id) values ")
-				.append("(?, ?, ").append(gmlIdCodespace != null ? gmlIdCodespace : "").append("?, ?, ?, ?, ?, ?, ?, ?, ");
+        StringBuilder stmt = new StringBuilder()
+                .append("insert into ").append(schema).append(".surface_geometry (id, gmlid, ").append(gmlIdCodespace != null ? "gmlid_codespace, " : "")
+                .append("parent_id, root_id, is_solid, is_composite, is_triangulated, is_xlink, is_reverse, geometry, solid_geometry, implicit_geometry, cityobject_id) values ")
+                .append("(?, ?, ").append(gmlIdCodespace != null ? gmlIdCodespace : "").append("?, ?, ?, ?, ?, ?, ?, ?, ");
 
-		if (importer.getDatabaseAdapter().getDatabaseType() == DatabaseType.POSTGIS) {
-			// the current PostGIS JDBC driver lacks support for geometry objects of type PolyhedralSurface
-			// thus, we have to use the database function ST_GeomFromEWKT to insert such geometries
-			// TODO: rework as soon as the JDBC driver supports PolyhedralSurface
-			stmt.append("ST_GeomFromEWKT(?), ");
-		} else
-			stmt.append("?, ");
+        if (importer.getDatabaseAdapter().getDatabaseType() == DatabaseType.POSTGIS) {
+            // the current PostGIS JDBC driver lacks support for geometry objects of type PolyhedralSurface
+            // thus, we have to use the database function ST_GeomFromEWKT to insert such geometries
+            // TODO: rework as soon as the JDBC driver supports PolyhedralSurface
+            stmt.append("ST_GeomFromEWKT(?), ");
+        } else
+            stmt.append("?, ");
 
-		stmt.append("?, ?)");
+        stmt.append("?, ?)");
 
-		psGeomElem = batchConn.prepareStatement(stmt.toString());
-		psNextSeqValues = batchConn.prepareStatement(importer.getDatabaseAdapter().getSQLAdapter().getNextSequenceValuesQuery(SequenceEnum.SURFACE_GEOMETRY_ID_SEQ.getName()));
+        psGeomElem = batchConn.prepareStatement(stmt.toString());
+        psNextSeqValues = batchConn.prepareStatement(importer.getDatabaseAdapter().getSQLAdapter().getNextSequenceValuesQuery(SequenceEnum.SURFACE_GEOMETRY_ID_SEQ.getName()));
 
-		appearanceImporter = importer.getImporter(DBAppearance.class);
-		localAppearanceHandler = importer.getLocalAppearanceHandler();
-		geometryConverter = importer.getGeometryConverter();
+        appearanceImporter = importer.getImporter(DBAppearance.class);
+        localAppearanceHandler = importer.getLocalAppearanceHandler();
+        geometryConverter = importer.getGeometryConverter();
+        pkManager = new PrimaryKeyManager();
+        ringValidator = new RingValidator();
+    }
 
-		pkManager = new PrimaryKeyManager();
-		ringValidator = new RingValidator();
-	}
+    protected long doImport(AbstractGeometry geometry, long cityObjectId) throws CityGMLImportException, SQLException {
+        // check whether we can deal with the geometry
+        if (!geometryConverter.isSurfaceGeometry(geometry)) {
+            importer.logOrThrowErrorMessage("Unsupported geometry type " + importer.getObjectSignature(geometry));
+            return 0;
+        }
 
-	protected long doImport(AbstractGeometry surfaceGeometry, long cityObjectId) throws CityGMLImportException, SQLException {
-		// check whether we can deal with the geometry
-		if (!geometryConverter.isSurfaceGeometry(surfaceGeometry)) {
-			importer.logOrThrowErrorMessage("Unsupported geometry type " + importer.getObjectSignature(surfaceGeometry));
-			return 0;
-		}
+        try {
+			long id = pkManager.retrieveIds(geometry);
+			if (id == 0) {
+				importer.logOrThrowErrorMessage("Failed to acquire primary keys from surface geometry sequence.");
+				return 0;
+			}
 
-		boolean success = pkManager.retrieveIds(surfaceGeometry);
-		if (!success) {
-			importer.logOrThrowErrorMessage("Failed to acquire primary key values for surface geometry from database.");
-			return 0;
-		}
+			if (geometry.isSetId())
+				geometry.setLocalProperty(CoreConstants.OBJECT_ORIGINAL_GMLID, geometry.getId());
 
-		if (surfaceGeometry.isSetId())
-			surfaceGeometry.setLocalProperty(CoreConstants.OBJECT_ORIGINAL_GMLID, surfaceGeometry.getId());
-
-		long surfaceGeometryId = pkManager.nextId();
-		doImport(surfaceGeometry, surfaceGeometryId, 0, surfaceGeometryId, false, false, false, cityObjectId);
-		pkManager.clear();
-
-		return surfaceGeometryId;
-	}
-
-	protected long importImplicitGeometry(AbstractGeometry surfaceGeometry) throws CityGMLImportException, SQLException {
-		// if affine transformation is activated we apply the user-defined affine
-		// transformation to the transformation matrix associated with the implicit geometry.
-		// thus, we do not need to apply it to the coordinate values
-		boolean _applyTransformation = applyTransformation;
-		int _dbSrid = dbSrid;
-
-		try {
-			isImplicit = true;
-			applyTransformation = false;
-			dbSrid = 0;
-			return doImport(surfaceGeometry, 0);
+			doImport(geometry, 0, id, false, false, false, cityObjectId);
+			return id;
 		} finally {
-			isImplicit = false;
-			applyTransformation = _applyTransformation;
-			dbSrid = _dbSrid;
+			pkManager.clear();
 		}
-	}
+    }
 
-	private void doImport(AbstractGeometry surfaceGeometry,
-			long surfaceGeometryId,
-			long parentId,
-			long rootId,
-			boolean reverse,
-			boolean isXlink,
-			boolean isCopy,
-			long cityObjectId) throws CityGMLImportException, SQLException {
-		GMLClass surfaceGeometryType = surfaceGeometry.getGMLClass();
-		importer.updateGeometryCounter(surfaceGeometryType);
+    protected long importImplicitGeometry(AbstractGeometry geometry) throws CityGMLImportException, SQLException {
+        // if affine transformation is activated we apply the user-defined affine
+        // transformation to the transformation matrix associated with the implicit geometry.
+        // thus, we do not need to apply it to the coordinate values
+        boolean _applyTransformation = applyTransformation;
+        int _dbSrid = dbSrid;
 
-		if (!isCopy)
-			isCopy = surfaceGeometry.hasLocalProperty(CoreConstants.GEOMETRY_ORIGINAL);
+        try {
+            isImplicit = true;
+            applyTransformation = false;
+            dbSrid = 0;
+            return doImport(geometry, 0);
+        } finally {
+            isImplicit = false;
+            applyTransformation = _applyTransformation;
+            dbSrid = _dbSrid;
+        }
+    }
 
-		if (!isXlink)
-			isXlink = surfaceGeometry.hasLocalProperty(CoreConstants.GEOMETRY_XLINK);
+    private void doImport(AbstractGeometry geometry, long parentId, long rootId, boolean reverse, boolean isXlink, boolean isCopy, long cityObjectId) throws CityGMLImportException, SQLException {
+		long id = pkManager.nextId(geometry);
+        importer.updateGeometryCounter(geometry.getGMLClass());
 
-		// gml:id handling
-		String origGmlId, gmlId;
-		origGmlId = gmlId = surfaceGeometry.getId();
-		if (gmlId == null || replaceGmlId) {
-			if (!surfaceGeometry.hasLocalProperty(CoreConstants.GEOMETRY_ORIGINAL)) {
-				if (!surfaceGeometry.hasLocalProperty("origGmlId")) {
-					gmlId = importer.generateNewGmlId();
-					surfaceGeometry.setId(gmlId);
-					surfaceGeometry.setLocalProperty("origGmlId", origGmlId);
-				} else
-					origGmlId = (String) surfaceGeometry.getLocalProperty("origGmlId");
-			} else {
-				AbstractGeometry original = (AbstractGeometry) surfaceGeometry.getLocalProperty(CoreConstants.GEOMETRY_ORIGINAL);
-				if (!original.hasLocalProperty("origGmlId")) {
-					gmlId = importer.generateNewGmlId();
-					original.setId(gmlId);
-					original.setLocalProperty("origGmlId", origGmlId);
-				} else
-					gmlId = original.getId();
+        if (!isCopy)
+            isCopy = geometry.hasLocalProperty(CoreConstants.GEOMETRY_ORIGINAL);
 
-				surfaceGeometry.setId(gmlId);
-			}
-		}
+        if (!isXlink)
+            isXlink = geometry.hasLocalProperty(CoreConstants.GEOMETRY_XLINK);
 
-		// ok, now we can have a look at different gml geometry objects
-		// firstly, handle simple surface geometries
-		// a simple polygon
-		if (surfaceGeometryType == GMLClass.POLYGON) {
-			Polygon polygon = (Polygon)surfaceGeometry;
+        // gml:id handling
+        String origGmlId, gmlId;
+        origGmlId = gmlId = geometry.getId();
+        if (gmlId == null || replaceGmlId) {
+            if (!geometry.hasLocalProperty(CoreConstants.GEOMETRY_ORIGINAL)) {
+                if (!geometry.hasLocalProperty("origGmlId")) {
+                    gmlId = importer.generateNewGmlId();
+                    geometry.setId(gmlId);
+                    geometry.setLocalProperty("origGmlId", origGmlId);
+                } else
+                    origGmlId = (String) geometry.getLocalProperty("origGmlId");
+            } else {
+                AbstractGeometry original = (AbstractGeometry) geometry.getLocalProperty(CoreConstants.GEOMETRY_ORIGINAL);
+                if (!original.hasLocalProperty("origGmlId")) {
+                    gmlId = importer.generateNewGmlId();
+                    original.setId(gmlId);
+                    original.setLocalProperty("origGmlId", origGmlId);
+                } else
+                    gmlId = original.getId();
 
-			if (polygon.isSetExterior()) {
-				List<List<Double>> pointList = new ArrayList<>();
-				AbstractRing exteriorRing = polygon.getExterior().getRing();
-				if (exteriorRing != null) {
-					List<Double> points = exteriorRing.toList3d(reverse);
-					if (!ringValidator.validate(points, exteriorRing))
-						return;
+                geometry.setId(gmlId);
+            }
+        }
 
-					if (applyTransformation)
-						importer.getAffineTransformer().transformCoordinates(points);
+        // ok, now we can have a look at different gml geometry objects
+        // firstly, handle simple surface geometries
+        // a simple polygon
+        if (geometry instanceof Polygon) {
+            Polygon polygon = (Polygon) geometry;
 
-					pointList.add(points);
-					int ringNo = 0;
-					importer.updateGeometryCounter(GMLClass.LINEAR_RING);
+            if (polygon.isSetExterior()) {
+                List<List<Double>> pointList = new ArrayList<>();
+                AbstractRing exterior = polygon.getExterior().getRing();
+                if (exterior != null) {
+                    List<Double> points = exterior.toList3d(reverse);
+                    if (!ringValidator.validate(points, exterior))
+                        return;
 
-					// well, taking care about geometry is not enough... this ring could
-					// be referenced by a <textureCoordinates> element. since we cannot store
-					// the gml:id of linear rings in the database, we have to remember its id
-					if (importAppearance && !isCopy && exteriorRing.isSetId()) {
-						if (localAppearanceHandler != null && localAppearanceHandler.hasParameterizedTextures())
-							localAppearanceHandler.registerLinearRing(exteriorRing.getId(), surfaceGeometryId, reverse);
+                    if (applyTransformation)
+                        importer.getAffineTransformer().transformCoordinates(points);
 
-						// the ring could also be the target of a global appearance
-						importer.propagateXlink(new DBXlinkLinearRing(
-								exteriorRing.getId(),
-								surfaceGeometryId,
-								ringNo,
-								reverse));
-					}
+                    pointList.add(points);
+                    int ringNo = 0;
+                    importer.updateGeometryCounter(GMLClass.LINEAR_RING);
 
-					if (polygon.isSetInterior()) {
-						for (AbstractRingProperty abstractRingProperty : polygon.getInterior()) {
-							AbstractRing interiorRing = abstractRingProperty.getRing();
-							if (interiorRing != null) {
-								List<Double> interiorPoints = interiorRing.toList3d(reverse);
-								if (!ringValidator.validate(interiorPoints, interiorRing))
-									continue;
+                    // well, taking care about geometry is not enough... this ring could
+                    // be referenced by a <textureCoordinates> element. since we cannot store
+                    // the gml:id of linear rings in the database, we have to remember its id
+                    if (importAppearance && !isCopy && exterior.isSetId()) {
+                        if (localAppearanceHandler != null && localAppearanceHandler.hasParameterizedTextures())
+                            localAppearanceHandler.registerLinearRing(exterior.getId(), id, reverse);
 
-								if (applyTransformation)
-									importer.getAffineTransformer().transformCoordinates(interiorPoints);
+                        // the ring could also be the target of a global appearance
+                        importer.propagateXlink(new DBXlinkLinearRing(exterior.getId(), id, ringNo, reverse));
+                    }
 
-								pointList.add(interiorPoints);
-								importer.updateGeometryCounter(GMLClass.LINEAR_RING);
+                    if (polygon.isSetInterior()) {
+                        for (AbstractRingProperty property : polygon.getInterior()) {
+                            AbstractRing interior = property.getRing();
+                            if (interior != null) {
+                                List<Double> interiorPoints = interior.toList3d(reverse);
+                                if (!ringValidator.validate(interiorPoints, interior))
+                                    continue;
 
-								// also remember the gml:id of interior rings in case it is
-								// referenced by a <textureCoordinates> element
-								if (importAppearance && !isCopy && interiorRing.isSetId()) {
-									if (localAppearanceHandler != null && localAppearanceHandler.hasParameterizedTextures())
-										localAppearanceHandler.registerLinearRing(interiorRing.getId(), surfaceGeometryId, reverse);
+                                if (applyTransformation)
+                                    importer.getAffineTransformer().transformCoordinates(interiorPoints);
 
-									// the ring could also be the target of a global appearance
-									importer.propagateXlink(new DBXlinkLinearRing(
-											interiorRing.getId(),
-											surfaceGeometryId,
-											++ringNo,
-											reverse));
-								}
-							}
-						}
-					}
+                                pointList.add(interiorPoints);
+                                importer.updateGeometryCounter(GMLClass.LINEAR_RING);
 
-					double[][] coordinates = new double[pointList.size()][];
-					int i = 0;
-					for (List<Double> coordsList : pointList) {
-						double[] coords = new double[coordsList.size()];
+                                // also remember the gml:id of interior rings
+                                if (importAppearance && !isCopy && interior.isSetId()) {
+                                    if (localAppearanceHandler != null && localAppearanceHandler.hasParameterizedTextures())
+                                        localAppearanceHandler.registerLinearRing(interior.getId(), id, reverse);
 
-						int j = 0;
-						for (Double coord : coordsList) {
-							coords[j] = coord;
-							j++;
-						}
+                                    // the ring could also be the target of a global appearance
+                                    importer.propagateXlink(new DBXlinkLinearRing(interior.getId(), id, ++ringNo, reverse));
+                                }
+                            }
+                        }
+                    }
 
-						coordinates[i] = coords;
-						i++;
-					}
+                    double[][] coordinates = new double[pointList.size()][];
+                    for (int i = 0; i < pointList.size(); i++)
+						coordinates[i] = pointList.get(i).stream().mapToDouble(Double::doubleValue).toArray();
 
-					GeometryObject geomObj = GeometryObject.createPolygon(coordinates, 3, dbSrid);
-					Object obj = importer.getDatabaseAdapter().getGeometryConverter().getDatabaseObject(geomObj, batchConn);
+                    GeometryObject geometryObject = GeometryObject.createPolygon(coordinates, 3, dbSrid);
+                    Object object = importer.getDatabaseAdapter().getGeometryConverter().getDatabaseObject(geometryObject, batchConn);
 
-					if (origGmlId != null && !isCopy)
-						importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
+                    if (origGmlId != null && !isCopy)
+                        importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
 
-					psGeomElem.setLong(1, surfaceGeometryId);
-					psGeomElem.setString(2, gmlId);
-					psGeomElem.setLong(4, rootId);
-					psGeomElem.setInt(5, 0);
-					psGeomElem.setInt(6, 0);
-					psGeomElem.setInt(7, 0);
-					psGeomElem.setInt(8, isXlink ? 1 : 0);
-					psGeomElem.setInt(9, reverse ? 1 : 0);
-					psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
+                    psGeomElem.setLong(1, id);
+                    psGeomElem.setString(2, gmlId);
+                    psGeomElem.setLong(4, rootId);
+                    psGeomElem.setInt(5, 0);
+                    psGeomElem.setInt(6, 0);
+                    psGeomElem.setInt(7, 0);
+                    psGeomElem.setInt(8, isXlink ? 1 : 0);
+                    psGeomElem.setInt(9, reverse ? 1 : 0);
+                    psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
 
-					if (parentId != 0)
-						psGeomElem.setLong(3, parentId);
-					else
-						psGeomElem.setNull(3, Types.NULL);
+                    if (parentId != 0)
+                        psGeomElem.setLong(3, parentId);
+                    else
+                        psGeomElem.setNull(3, Types.NULL);
 
-					if (!isImplicit) {
-						psGeomElem.setObject(10, obj);
-						psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
-					} else {
-						psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
-						psGeomElem.setObject(12, obj);
-					}
+                    if (!isImplicit) {
+                        psGeomElem.setObject(10, object);
+                        psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+                    } else {
+                        psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
+                        psGeomElem.setObject(12, object);
+                    }
 
-					if (cityObjectId != 0)
-						psGeomElem.setLong(13, cityObjectId);
-					else
-						psGeomElem.setNull(13, Types.NULL);
+                    if (cityObjectId != 0)
+                        psGeomElem.setLong(13, cityObjectId);
+                    else
+                        psGeomElem.setNull(13, Types.NULL);
 
-					addBatch();
-				}
-			}
-		}
-
-		// ok, handle complexes, composites and aggregates
-		// orientableSurface
-		else if (surfaceGeometryType == GMLClass.ORIENTABLE_SURFACE) {
-			OrientableSurface orientableSurface = (OrientableSurface)surfaceGeometry;
-
-			boolean negativeOrientation = false;
-			if (orientableSurface.isSetOrientation() && orientableSurface.getOrientation() == Sign.MINUS) {
-				reverse = !reverse;
-				negativeOrientation = true;
-			}
-
-			if (orientableSurface.isSetBaseSurface()) {
-				SurfaceProperty surfaceProperty = orientableSurface.getBaseSurface();
-				String mapping = null;
-
-				if (surfaceProperty.isSetSurface()) {
-					AbstractSurface abstractSurface = surfaceProperty.getSurface();
-					if (!abstractSurface.isSetId())
-						abstractSurface.setId(importer.generateNewGmlId());
-
-					// mapping target
-					mapping = abstractSurface.getId();
-
-					switch (abstractSurface.getGMLClass()) {
-					case _TEXTURED_SURFACE:
-					case ORIENTABLE_SURFACE:
-						doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-						break;
-					case POLYGON:
-					case COMPOSITE_SURFACE:
-					case SURFACE:
-					case TRIANGULATED_SURFACE:
-					case TIN:
-						surfaceGeometryId = pkManager.nextId();
-						doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-						break;
-					default:
-						importer.logOrThrowErrorMessage(importer.getObjectSignature(orientableSurface, origGmlId) +
-								": " + abstractSurface.getGMLClass() + " is not supported as the base surface.");
-					}
-
-				} else {
-					String href = surfaceProperty.getHref();
-					if (href != null && href.length() != 0) {
-						importer.propagateXlink(new DBXlinkSurfaceGeometry(
-								surfaceGeometryId,
-								parentId,
-								rootId,
-								reverse,
-								href,
-								cityObjectId));
-
-						mapping = href.replaceAll("^#", "");
-					}
-				}
-
-				// do mapping
-				if (origGmlId != null && !isCopy)
-					importer.putGeometryUID(origGmlId, -1, -1, negativeOrientation, mapping);
-			}
-		}
+                    addBatch();
+                }
+            }
+        }
 
 		// texturedSurface
 		// this is a CityGML class, not a GML class.
-		else if (surfaceGeometryType == GMLClass._TEXTURED_SURFACE) {
-			_TexturedSurface texturedSurface = (_TexturedSurface)surfaceGeometry;
-			AbstractSurface abstractSurface;
+		else if (geometry instanceof _TexturedSurface) {
+			_TexturedSurface texturedSurface = (_TexturedSurface) geometry;
+			AbstractSurface surface;
 
 			boolean negativeOrientation = false;
 			if (texturedSurface.isSetOrientation() && texturedSurface.getOrientation() == Sign.MINUS) {
@@ -429,66 +341,43 @@ public class DBSurfaceGeometry implements DBImporter {
 			String targetURI;
 
 			if (texturedSurface.isSetBaseSurface()) {
-				SurfaceProperty surfaceProperty = texturedSurface.getBaseSurface();
-				if (surfaceProperty.isSetSurface()) {
-					abstractSurface = surfaceProperty.getSurface();
-
-					if (!abstractSurface.isSetId())
-						abstractSurface.setId(importer.generateNewGmlId());
+				SurfaceProperty property = texturedSurface.getBaseSurface();
+				if (property.isSetSurface()) {
+					surface = property.getSurface();
+					if (!surface.isSetId())
+						surface.setId(importer.generateNewGmlId());
 
 					// appearance and mapping target
-					targetURI = abstractSurface.getId();
+					targetURI = surface.getId();
 
 					// do mapping
 					if (origGmlId != null && !isCopy)
 						importer.putGeometryUID(origGmlId, -1, -1, negativeOrientation, targetURI);
 
-					switch (abstractSurface.getGMLClass()) {
-					case _TEXTURED_SURFACE:
-					case ORIENTABLE_SURFACE:
-						doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-						break;
-					case POLYGON:
-						Polygon polygon = (Polygon)abstractSurface;
+					if (surface instanceof Polygon) {
+						// make sure all exterior and interior rings do have a gml:id to assign texture coordinates
+						Polygon polygon = (Polygon) surface;
 
-						// make sure all exterior and interior rings do have a gml:id
-						// in order to assign texture coordinates
 						if (polygon.isSetExterior()) {
-							LinearRing exteriorRing = (LinearRing)polygon.getExterior().getRing();
+							LinearRing exteriorRing = (LinearRing) polygon.getExterior().getRing();
 							if (exteriorRing != null && !exteriorRing.isSetId())
 								exteriorRing.setId(targetURI);
 						}
 
 						if (polygon.isSetInterior()) {
 							for (AbstractRingProperty abstractRingProperty : polygon.getInterior()) {
-								LinearRing interiorRing = (LinearRing)abstractRingProperty.getRing();
+								LinearRing interiorRing = (LinearRing) abstractRingProperty.getRing();
 								if (!interiorRing.isSetId())
 									interiorRing.setId(importer.generateNewGmlId());
 							}
 						}
-					case COMPOSITE_SURFACE:
-					case SURFACE:
-					case TRIANGULATED_SURFACE:
-					case TIN:
-						surfaceGeometryId = pkManager.nextId();
-						doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-						break;
-					default:
-						importer.logOrThrowErrorMessage(importer.getObjectSignature(texturedSurface, origGmlId) +
-								": " + abstractSurface.getGMLClass() + " is not supported as the base surface.");
 					}
 
+					doImport(surface, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
 				} else {
-					String href = surfaceProperty.getHref();
+					String href = property.getHref();
 					if (href != null && href.length() != 0) {
-						importer.propagateXlink(new DBXlinkSurfaceGeometry(
-								surfaceGeometryId,
-								parentId,
-								rootId,
-								reverse,
-								href,
-								cityObjectId));
-
+						importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
 						targetURI = href.replaceAll("^#", "");
 
 						// do mapping
@@ -503,127 +392,185 @@ public class DBSurfaceGeometry implements DBImporter {
 					return;
 				}
 			} else {
-				// we cannot continue without having a base surface...
 				importer.logOrThrowErrorMessage(importer.getObjectSignature(texturedSurface, origGmlId) +
-						": Failed to find base surface of textured surface.");
+						": The textured surface lacks a base surface.");
 				return;
 			}
 
 			if (importAppearance && !isCopy && texturedSurface.isSetAppearance()) {
-				for (_AppearanceProperty appearanceProperty : texturedSurface.getAppearance()) {
-					if (appearanceProperty.isSetAppearance()) {
-						_AbstractAppearance appearance = appearanceProperty.getAppearance();
+				for (_AppearanceProperty property : texturedSurface.getAppearance()) {
+					if (property.isSetAppearance()) {
+						_AbstractAppearance appearance = property.getAppearance();
 
-						// how to map texture coordinates to a composite surface of
-						// arbitrary depth?
-						if (appearance.getCityGMLClass() == CityGMLClass._SIMPLE_TEXTURE &&
-								abstractSurface.getGMLClass() != GMLClass.POLYGON) {
+						// we can only assign textures to polygons
+						if (appearance instanceof _SimpleTexture && !(surface instanceof Polygon)) {
 							importer.logOrThrowErrorMessage(importer.getObjectSignature(texturedSurface, origGmlId) +
 									": Texture coordinates are only supported for base surfaces of type gml:Polygon.");
 							continue;
 						}
 
-						boolean isFront = !(appearanceProperty.isSetOrientation() &&
-								appearanceProperty.getOrientation() == Sign.MINUS);
-
-						appearanceImporter.importTexturedSurface(appearance, abstractSurface, cityObjectId, isFront, targetURI);
+						boolean isFront = !(property.isSetOrientation() && property.getOrientation() == Sign.MINUS);
+						appearanceImporter.importTexturedSurface(appearance, surface, cityObjectId, isFront, targetURI);
 					} else {
-						String href = appearanceProperty.getHref();
+						String href = property.getHref();
 						if (href != null && href.length() != 0)
-							appearanceImporter.importTexturedSurfaceXlink(href, surfaceGeometryId, cityObjectId);
+							appearanceImporter.importTexturedSurfaceXlink(href, id, cityObjectId);
 					}
 				}
 			}
 		}
 
-		// compositeSurface
-		else if (surfaceGeometryType == GMLClass.COMPOSITE_SURFACE) {
-			CompositeSurface compositeSurface = (CompositeSurface)surfaceGeometry;
+        // ok, handle complexes, composites and aggregates
+        // orientableSurface
+        else if (geometry instanceof OrientableSurface) {
+            OrientableSurface orientableSurface = (OrientableSurface) geometry;
 
-			if (origGmlId != null && !isCopy)
-				importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
+            boolean negativeOrientation = false;
+            if (orientableSurface.isSetOrientation() && orientableSurface.getOrientation() == Sign.MINUS) {
+                reverse = !reverse;
+                negativeOrientation = true;
+            }
 
-			// set root entry
-			psGeomElem.setLong(1, surfaceGeometryId);
-			psGeomElem.setString(2, gmlId);
-			psGeomElem.setLong(4, rootId);
-			psGeomElem.setInt(5, 0);
-			psGeomElem.setInt(6, 1);
-			psGeomElem.setInt(7, 0);
-			psGeomElem.setInt(8, isXlink ? 1 : 0);
-			psGeomElem.setInt(9, reverse ? 1 : 0);
-			psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+            if (orientableSurface.isSetBaseSurface()) {
+                SurfaceProperty property = orientableSurface.getBaseSurface();
+                String mapping = null;
 
-			if (parentId != 0)
-				psGeomElem.setLong(3, parentId);
-			else
-				psGeomElem.setNull(3, Types.NULL);
+                if (property.isSetSurface()) {
+                    AbstractSurface surface = property.getSurface();
+                    if (!surface.isSetId())
+                        surface.setId(importer.generateNewGmlId());
 
-			if (cityObjectId != 0)
-				psGeomElem.setLong(13, cityObjectId);
-			else
-				psGeomElem.setNull(13, Types.NULL);
+                    // mapping target
+                    mapping = surface.getId();
 
-			addBatch();
+					doImport(surface, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+				} else {
+                    String href = property.getHref();
+                    if (href != null && href.length() != 0) {
+                        importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
+                        mapping = href.replaceAll("^#", "");
+                    }
+                }
 
-			// set parentId
-			parentId = surfaceGeometryId;
-
-			// get surfaceMember
-			if (compositeSurface.isSetSurfaceMember()) {
-				for (SurfaceProperty surfaceProperty : compositeSurface.getSurfaceMember()) {
-					if (surfaceProperty.isSetSurface()) {
-						AbstractSurface abstractSurface = surfaceProperty.getSurface();
-
-						switch (abstractSurface.getGMLClass()) {
-						case _TEXTURED_SURFACE:
-						case ORIENTABLE_SURFACE:
-							doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-							break;
-						case POLYGON:
-						case COMPOSITE_SURFACE:
-						case SURFACE:
-						case TRIANGULATED_SURFACE:
-						case TIN:
-							surfaceGeometryId = pkManager.nextId();
-							doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-							break;
-						default:
-							importer.logOrThrowErrorMessage(importer.getObjectSignature(compositeSurface, origGmlId) +
-									": " + abstractSurface.getGMLClass() + " is not supported as member surface.");
-						}
-
-					} else {
-						String href = surfaceProperty.getHref();
-						if (href != null && href.length() != 0) {
-							importer.propagateXlink(new DBXlinkSurfaceGeometry(
-									surfaceGeometryId,
-									parentId,
-									rootId,
-									reverse,
-									href,
-									cityObjectId));
-						}
-					}
-				}
+                // do mapping
+                if (origGmlId != null && !isCopy)
+                    importer.putGeometryUID(origGmlId, -1, -1, negativeOrientation, mapping);
+            } else {
+				importer.logOrThrowErrorMessage(importer.getObjectSignature(orientableSurface, origGmlId) +
+						": The orientable surface lacks a base surface.");
 			}
-		}
+        }
+
+        // compositeSurface
+        else if (geometry instanceof CompositeSurface) {
+            CompositeSurface compositeSurface = (CompositeSurface) geometry;
+
+            if (origGmlId != null && !isCopy)
+                importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
+
+            // set root entry
+            psGeomElem.setLong(1, id);
+            psGeomElem.setString(2, gmlId);
+            psGeomElem.setLong(4, rootId);
+            psGeomElem.setInt(5, 0);
+            psGeomElem.setInt(6, 1);
+            psGeomElem.setInt(7, 0);
+            psGeomElem.setInt(8, isXlink ? 1 : 0);
+            psGeomElem.setInt(9, reverse ? 1 : 0);
+            psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+
+            if (parentId != 0)
+                psGeomElem.setLong(3, parentId);
+            else
+                psGeomElem.setNull(3, Types.NULL);
+
+            if (cityObjectId != 0)
+                psGeomElem.setLong(13, cityObjectId);
+            else
+                psGeomElem.setNull(13, Types.NULL);
+
+            addBatch();
+
+            // set parentId
+            parentId = id;
+
+            // get surfaceMember
+            if (compositeSurface.isSetSurfaceMember()) {
+                for (SurfaceProperty property : compositeSurface.getSurfaceMember()) {
+                    if (property.isSetSurface()) {
+						doImport(property.getSurface(), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                    } else {
+                        String href = property.getHref();
+                        if (href != null && href.length() != 0)
+                            importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
+                    }
+                }
+            }
+        }
+
+        // TriangulatedSurface, TIN
+        else if (geometry instanceof TriangulatedSurface) {
+            TriangulatedSurface triangulatedSurface = (TriangulatedSurface) geometry;
+
+            if (origGmlId != null && !isCopy)
+                importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
+
+            // set root entry
+            psGeomElem.setLong(1, id);
+            psGeomElem.setString(2, gmlId);
+            psGeomElem.setLong(4, rootId);
+            psGeomElem.setInt(5, 0);
+            psGeomElem.setInt(6, 0);
+            psGeomElem.setInt(7, 1);
+            psGeomElem.setInt(8, isXlink ? 1 : 0);
+            psGeomElem.setInt(9, reverse ? 1 : 0);
+            psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+
+            if (parentId != 0)
+                psGeomElem.setLong(3, parentId);
+            else
+                psGeomElem.setNull(3, Types.NULL);
+
+            if (cityObjectId != 0)
+                psGeomElem.setLong(13, cityObjectId);
+            else
+                psGeomElem.setNull(13, Types.NULL);
+
+            addBatch();
+
+            // set parentId
+            parentId = id;
+
+            // get triangles
+            if (triangulatedSurface.isSetTrianglePatches()) {
+                TrianglePatchArrayProperty property = triangulatedSurface.getTrianglePatches();
+                if (property.isSetTriangle()) {
+                    for (Triangle triangle : property.getTriangle()) {
+                        Polygon polygon = new Polygon();
+                        polygon.setExterior(triangle.getExterior());
+                        doImport(polygon, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                    }
+                }
+            }
+        }
 
 		// Surface
-		else if (surfaceGeometryType == GMLClass.SURFACE) {
-			Surface surface = (Surface)surfaceGeometry;
+		else if (geometry instanceof Surface) {
+			Surface surface = (Surface) geometry;
 
 			if (origGmlId != null && !isCopy)
-				importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
+				importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
 
 			int nrOfPatches = surface.isSetPatches() && surface.getPatches().isSetSurfacePatch() ?
 					surface.getPatches().getSurfacePatch().size() : 0;
 
 			// add a composite surface as root unless there is only one surface patch
 			if (nrOfPatches != 1) {
-				psGeomElem.setLong(1, surfaceGeometryId);
+				psGeomElem.setLong(1, id);
 				psGeomElem.setString(2, gmlId);
 				psGeomElem.setLong(4, rootId);
 				psGeomElem.setInt(5, 0);
@@ -648,588 +595,433 @@ public class DBSurfaceGeometry implements DBImporter {
 				addBatch();
 
 				// set parentId
-				parentId = surfaceGeometryId;
+				parentId = id;
 			}
 
 			// import surface patches
 			if (nrOfPatches > 0) {
-				for (AbstractSurfacePatch surfacePatch : surface.getPatches().getSurfacePatch()) {
-					surfaceGeometryId = pkManager.nextId();
-
+				for (AbstractSurfacePatch patch : surface.getPatches().getSurfacePatch()) {
 					Polygon polygon = new Polygon();
 					if (nrOfPatches == 1)
 						polygon.setId(gmlId);
 
-					if (surfacePatch.getGMLClass() == GMLClass.RECTANGLE) {
-						Rectangle rectangle = (Rectangle) surfacePatch;
+					if (patch instanceof Rectangle) {
+						Rectangle rectangle = (Rectangle) patch;
 						polygon = new Polygon();
 						polygon.setExterior(rectangle.getExterior());
-					} else if (surfacePatch.getGMLClass() == GMLClass.TRIANGLE) {
-						Triangle triangle = (Triangle) surfacePatch;
+					} else if (patch instanceof Triangle) {
+						Triangle triangle = (Triangle) patch;
 						polygon = new Polygon();
 						polygon.setExterior(triangle.getExterior());
-					} else if (surfacePatch.getGMLClass() == GMLClass.POLYGON_PATCH) {
-						PolygonPatch polygonPatch = (PolygonPatch) surfacePatch;
+					} else if (patch instanceof PolygonPatch) {
+						PolygonPatch polygonPatch = (PolygonPatch) patch;
 						polygon.setExterior(polygonPatch.getExterior());
 						polygon.setInterior(polygonPatch.getInterior());
 					}
 
-					doImport(polygon, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+					doImport(polygon, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
 				}
 			}
 		}
 
-		// TriangulatedSurface, TIN
-		else if (surfaceGeometryType == GMLClass.TRIANGULATED_SURFACE ||
-				surfaceGeometryType == GMLClass.TIN) {
-			TriangulatedSurface triangulatedSurface = (TriangulatedSurface)surfaceGeometry;
+        // Solid
+        else if (geometry instanceof Solid) {
+            Solid solid = (Solid) geometry;
 
-			if (origGmlId != null && !isCopy)
-				importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
+            if (origGmlId != null && !isCopy)
+                importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
 
-			// set root entry
-			psGeomElem.setLong(1, surfaceGeometryId);
-			psGeomElem.setString(2, gmlId);
-			psGeomElem.setLong(4, rootId);
-			psGeomElem.setInt(5, 0);
-			psGeomElem.setInt(6, 0);
-			psGeomElem.setInt(7, 1);
-			psGeomElem.setInt(8, isXlink ? 1 : 0);
-			psGeomElem.setInt(9, reverse ? 1 : 0);
-			psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+            // set root entry
+            psGeomElem.setLong(1, id);
+            psGeomElem.setString(2, gmlId);
+            psGeomElem.setLong(4, rootId);
+            psGeomElem.setInt(5, 1);
+            psGeomElem.setInt(6, 0);
+            psGeomElem.setInt(7, 0);
+            psGeomElem.setInt(8, isXlink ? 1 : 0);
+            psGeomElem.setInt(9, reverse ? 1 : 0);
+            psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
 
-			if (parentId != 0)
-				psGeomElem.setLong(3, parentId);
-			else
-				psGeomElem.setNull(3, Types.NULL);
+            // create solid geometry object
+            Object object = null;
+            if (id == rootId) {
+                GeometryObject geometryObject = geometryConverter.getSolid(solid);
+                if (geometryObject != null)
+                    object = importer.getDatabaseAdapter().getGeometryConverter().getDatabaseObject(geometryObject, batchConn);
+                else {
+                    // we cannot build the solid geometry in main memory
+                    // possibly the solid references surfaces from another feature per xlink
+                    // so, remember its id to build the solid geometry later
+                    importer.propagateXlink(new DBXlinkSolidGeometry(id));
+                }
+            }
 
-			if (cityObjectId != 0)
-				psGeomElem.setLong(13, cityObjectId);
-			else
-				psGeomElem.setNull(13, Types.NULL);
+            if (object != null)
+                psGeomElem.setObject(11, object);
+            else
+                psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
 
-			addBatch();
+            if (parentId != 0)
+                psGeomElem.setLong(3, parentId);
+            else
+                psGeomElem.setNull(3, Types.NULL);
 
-			// set parentId
-			parentId = surfaceGeometryId;
+            if (cityObjectId != 0)
+                psGeomElem.setLong(13, cityObjectId);
+            else
+                psGeomElem.setNull(13, Types.NULL);
 
-			// get triangles
-			if (triangulatedSurface.isSetTrianglePatches()) {
-				TrianglePatchArrayProperty arrayProperty = triangulatedSurface.getTrianglePatches();
-				if (arrayProperty.isSetTriangle()) {
-					for (Triangle triangle : arrayProperty.getTriangle()) {
-						surfaceGeometryId = pkManager.nextId();
-						Polygon polygon = new Polygon();
-						polygon.setExterior(triangle.getExterior());
-						doImport(polygon, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-					}
-				}
-			}
-		}
+            addBatch();
 
-		// Solid
-		else if (surfaceGeometryType == GMLClass.SOLID) {
-			Solid solid = (Solid)surfaceGeometry;
+            // set parentId
+            parentId = id;
 
-			if (origGmlId != null && !isCopy)
-				importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
+            // get exterior
+            if (solid.isSetExterior()) {
+                SurfaceProperty property = solid.getExterior();
+                if (property.isSetSurface()) {
+                    doImport(property.getSurface(), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                } else {
+                    String href = property.getHref();
+                    if (href != null && href.length() != 0)
+                        importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
+                }
+            }
 
-			// set root entry
-			psGeomElem.setLong(1, surfaceGeometryId);
-			psGeomElem.setString(2, gmlId);
-			psGeomElem.setLong(4, rootId);
-			psGeomElem.setInt(5, 1);
-			psGeomElem.setInt(6, 0);
-			psGeomElem.setInt(7, 0);
-			psGeomElem.setInt(8, isXlink ? 1 : 0);
-			psGeomElem.setInt(9, reverse ? 1 : 0);
-			psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+            // interiors are not supported
+            if (solid.isSetInterior()) {
+                importer.logOrThrowErrorMessage(importer.getObjectSignature(solid, origGmlId) +
+                        ": Interior shells of solids are not supported.");
+            }
+        }
 
-			// create solid geometry object
-			Object solidObj = null;
-			if (surfaceGeometryId == rootId) {
-				GeometryObject geomObj = geometryConverter.getSolid(solid);
-				if (geomObj != null)
-					solidObj = importer.getDatabaseAdapter().getGeometryConverter().getDatabaseObject(geomObj, batchConn);
-				else {
-					// we cannot build the solid geometry in main memory
-					// possibly the solid references surfaces from another feature per xlink
-					// so, remember its id to build the solid geometry later
-					importer.propagateXlink(new DBXlinkSolidGeometry(surfaceGeometryId));
-				}
-			}
+        // CompositeSolid
+        else if (geometry instanceof CompositeSolid) {
+            CompositeSolid compositeSolid = (CompositeSolid) geometry;
 
-			if (solidObj != null)
-				psGeomElem.setObject(11, solidObj);
-			else
-				psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
+            if (origGmlId != null && !isCopy)
+                importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
 
-			if (parentId != 0)
-				psGeomElem.setLong(3, parentId);
-			else
-				psGeomElem.setNull(3, Types.NULL);
+            // set root entry
+            psGeomElem.setLong(1, id);
+            psGeomElem.setString(2, gmlId);
+            psGeomElem.setLong(4, rootId);
+            psGeomElem.setInt(5, 1);
+            psGeomElem.setInt(6, 1);
+            psGeomElem.setInt(7, 0);
+            psGeomElem.setInt(8, isXlink ? 1 : 0);
+            psGeomElem.setInt(9, reverse ? 1 : 0);
+            psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
 
-			if (cityObjectId != 0)
-				psGeomElem.setLong(13, cityObjectId);
-			else
-				psGeomElem.setNull(13, Types.NULL);
-
-			addBatch();
-
-			// set parentId
-			parentId = surfaceGeometryId;
-
-			// get Exterior
-			if (solid.isSetExterior()) {
-				SurfaceProperty exteriorSurface = solid.getExterior();
-
-				if (exteriorSurface.isSetSurface()) {
-					AbstractSurface abstractSurface = exteriorSurface.getSurface();
-
-					// we just allow CompositeSurfaces here!
-					if (abstractSurface.getGMLClass() == GMLClass.COMPOSITE_SURFACE) {
-						surfaceGeometryId = pkManager.nextId();
-						doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-					}
+            // create composite solid geometry object
+            Object object = null;
+            if (id == rootId) {
+                GeometryObject geometryObject = geometryConverter.getCompositeSolid(compositeSolid);
+                if (geometryObject != null) {
+					object = importer.getDatabaseAdapter().getGeometryConverter().getDatabaseObject(geometryObject, batchConn);
 				} else {
-					String href = exteriorSurface.getHref();
-					if (href != null && href.length() != 0) {
-						importer.propagateXlink(new DBXlinkSurfaceGeometry(
-								surfaceGeometryId,
-								parentId,
-								rootId,
-								reverse,
-								href,
-								cityObjectId));
-					}
-				}
-			}
+                    // we cannot build the solid geometry in main memory
+                    // possibly the solid references surfaces from another feature per xlink
+                    // so, remember its id to build the solid geometry later
+                    importer.propagateXlink(new DBXlinkSolidGeometry(id));
+                }
+            }
 
-			// interior is not supported!
-			if (solid.isSetInterior()) {
-				importer.logOrThrowErrorMessage(importer.getObjectSignature(solid, origGmlId) +
-						": Interior solids are not supported.");
-			}
-		}
+            if (object != null)
+                psGeomElem.setObject(11, object);
+            else
+                psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
 
-		// CompositeSolid
-		else if (surfaceGeometryType == GMLClass.COMPOSITE_SOLID) {
-			CompositeSolid compositeSolid = (CompositeSolid)surfaceGeometry;
+            if (parentId != 0)
+                psGeomElem.setLong(3, parentId);
+            else
+                psGeomElem.setNull(3, Types.NULL);
 
-			if (origGmlId != null && !isCopy)
-				importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
+            if (cityObjectId != 0)
+                psGeomElem.setLong(13, cityObjectId);
+            else
+                psGeomElem.setNull(13, Types.NULL);
 
-			// set root entry
-			psGeomElem.setLong(1, surfaceGeometryId);
-			psGeomElem.setString(2, gmlId);
-			psGeomElem.setLong(4, rootId);
-			psGeomElem.setInt(5, 1);
-			psGeomElem.setInt(6, 1);
-			psGeomElem.setInt(7, 0);
-			psGeomElem.setInt(8, isXlink ? 1 : 0);
-			psGeomElem.setInt(9, reverse ? 1 : 0);
-			psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+            addBatch();
 
-			// create composite solid geometry object
-			Object compositeSolidObj = null;
-			if (surfaceGeometryId == rootId) {
-				GeometryObject geomObj = geometryConverter.getCompositeSolid(compositeSolid);
-				if (geomObj != null)
-					compositeSolidObj = importer.getDatabaseAdapter().getGeometryConverter().getDatabaseObject(geomObj, batchConn);
-				else {
-					// we cannot build the solid geometry in main memory
-					// possibly the solid references surfaces from another feature per xlink
-					// so, remember its id to build the solid geometry later
-					importer.propagateXlink(new DBXlinkSolidGeometry(surfaceGeometryId));
-				}
-			}
+            // set parentId
+            parentId = id;
 
-			if (compositeSolidObj != null)
-				psGeomElem.setObject(11, compositeSolidObj);
-			else
-				psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
+            // get solidMember
+            if (compositeSolid.isSetSolidMember()) {
+                for (SolidProperty property : compositeSolid.getSolidMember()) {
+                    if (property.isSetSolid()) {
+                        doImport(property.getSolid(), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                    } else {
+                        String href = property.getHref();
+                        if (href != null && href.length() != 0)
+                            importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
+                    }
+                }
+            }
+        }
 
-			if (parentId != 0)
-				psGeomElem.setLong(3, parentId);
-			else
-				psGeomElem.setNull(3, Types.NULL);
+        // MultiPolygon
+        else if (geometry instanceof MultiPolygon) {
+            MultiPolygon multiPolygon = (MultiPolygon) geometry;
 
-			if (cityObjectId != 0)
-				psGeomElem.setLong(13, cityObjectId);
-			else
-				psGeomElem.setNull(13, Types.NULL);
+            if (origGmlId != null && !isCopy)
+                importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
 
-			addBatch();
+            // set root entry
+            psGeomElem.setLong(1, id);
+            psGeomElem.setString(2, gmlId);
+            psGeomElem.setLong(4, rootId);
+            psGeomElem.setInt(5, 0);
+            psGeomElem.setInt(6, 0);
+            psGeomElem.setInt(7, 0);
+            psGeomElem.setInt(8, isXlink ? 1 : 0);
+            psGeomElem.setInt(9, reverse ? 1 : 0);
+            psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
 
-			// set parentId
-			parentId = surfaceGeometryId;
+            if (parentId != 0)
+                psGeomElem.setLong(3, parentId);
+            else
+                psGeomElem.setNull(3, Types.NULL);
 
-			// get solidMember
-			if (compositeSolid.isSetSolidMember()) {
-				for (SolidProperty solidProperty : compositeSolid.getSolidMember()) {
-					if (solidProperty.isSetSolid()) {
-						surfaceGeometryId = pkManager.nextId();
-						doImport(solidProperty.getSolid(), surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+            if (cityObjectId != 0)
+                psGeomElem.setLong(13, cityObjectId);
+            else
+                psGeomElem.setNull(13, Types.NULL);
+
+            addBatch();
+
+            // set parentId
+            parentId = id;
+
+            // get polygonMember
+            if (multiPolygon.isSetPolygonMember()) {
+                for (PolygonProperty property : multiPolygon.getPolygonMember()) {
+                    if (property.isSetPolygon()) {
+                        doImport(property.getPolygon(), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                    } else {
+                        String href = property.getHref();
+                        if (href != null && href.length() != 0)
+                            importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
+                    }
+                }
+            }
+        }
+
+        // MultiSurface
+        else if (geometry instanceof MultiSurface) {
+            MultiSurface multiSurface = (MultiSurface) geometry;
+
+            if (origGmlId != null && !isCopy)
+                importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
+
+            // set root entry
+            psGeomElem.setLong(1, id);
+            psGeomElem.setString(2, gmlId);
+            psGeomElem.setLong(4, rootId);
+            psGeomElem.setInt(5, 0);
+            psGeomElem.setInt(6, 0);
+            psGeomElem.setInt(7, 0);
+            psGeomElem.setInt(8, isXlink ? 1 : 0);
+            psGeomElem.setInt(9, reverse ? 1 : 0);
+            psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+
+            if (parentId != 0)
+                psGeomElem.setLong(3, parentId);
+            else
+                psGeomElem.setNull(3, Types.NULL);
+
+            if (cityObjectId != 0)
+                psGeomElem.setLong(13, cityObjectId);
+            else
+                psGeomElem.setNull(13, Types.NULL);
+
+            addBatch();
+
+            // set parentId
+            parentId = id;
+
+            // get surfaceMember
+            if (multiSurface.isSetSurfaceMember()) {
+                for (SurfaceProperty property : multiSurface.getSurfaceMember()) {
+                    if (property.isSetSurface()) {
+						doImport(property.getSurface(), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                    } else {
+                        String href = property.getHref();
+                        if (href != null && href.length() != 0)
+                            importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
+                    }
+                }
+            }
+
+            // get surfaceMembers
+            if (multiSurface.isSetSurfaceMembers()) {
+                SurfaceArrayProperty property = multiSurface.getSurfaceMembers();
+                if (property.isSetSurface()) {
+                    for (AbstractSurface abstractSurface : property.getSurface())
+						doImport(abstractSurface, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                }
+            }
+        }
+
+        // MultiSolid
+        else if (geometry instanceof MultiSolid) {
+            MultiSolid multiSolid = (MultiSolid) geometry;
+
+            if (origGmlId != null && !isCopy)
+                importer.putGeometryUID(origGmlId, id, rootId, reverse, gmlId);
+
+            // set root entry
+            psGeomElem.setLong(1, id);
+            psGeomElem.setString(2, gmlId);
+            psGeomElem.setLong(4, rootId);
+            psGeomElem.setInt(5, 0);
+            psGeomElem.setInt(6, 0);
+            psGeomElem.setInt(7, 0);
+            psGeomElem.setInt(8, isXlink ? 1 : 0);
+            psGeomElem.setInt(9, reverse ? 1 : 0);
+            psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
+            psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+
+            if (parentId != 0)
+                psGeomElem.setLong(3, parentId);
+            else
+                psGeomElem.setNull(3, Types.NULL);
+
+            if (cityObjectId != 0)
+                psGeomElem.setLong(13, cityObjectId);
+            else
+                psGeomElem.setNull(13, Types.NULL);
+
+            addBatch();
+
+            // set parentId
+            parentId = id;
+
+            // get solidMember
+            if (multiSolid.isSetSolidMember()) {
+                for (SolidProperty property : multiSolid.getSolidMember()) {
+                    if (property.isSetSolid()) {
+                        doImport(property.getSolid(), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                    } else {
+                        String href = property.getHref();
+                        if (href != null && href.length() != 0)
+                            importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
+                    }
+                }
+            }
+
+            // get SolidMembers
+            if (multiSolid.isSetSolidMembers()) {
+                SolidArrayProperty property = multiSolid.getSolidMembers();
+                if (property.isSetSolid()) {
+                    for (AbstractSolid abstractSolid : property.getSolid())
+                        doImport(abstractSolid, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+                }
+            }
+        }
+
+        // GeometricComplex
+        else if (geometry instanceof GeometricComplex) {
+            GeometricComplex geometricComplex = (GeometricComplex) geometry;
+
+            if (geometricComplex.isSetElement()) {
+                for (GeometricPrimitiveProperty geometricPrimitiveProperty : geometricComplex.getElement()) {
+                    if (geometricPrimitiveProperty.isSetGeometricPrimitive()) {
+						doImport(geometricPrimitiveProperty.getGeometricPrimitive(), parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
 					} else {
-						String href = solidProperty.getHref();
-						if (href != null && href.length() != 0) {
-							importer.propagateXlink(new DBXlinkSurfaceGeometry(
-									surfaceGeometryId,
-									parentId,
-									rootId,
-									reverse,
-									href,
-									cityObjectId));
-						}
-					}
-				}
-			}
-		}
+                        String href = geometricPrimitiveProperty.getHref();
+                        if (href != null && href.length() != 0)
+                            importer.propagateXlink(new DBXlinkSurfaceGeometry(id, parentId, rootId, reverse, href, cityObjectId));
+                    }
+                }
+            }
+        }
 
-		// MultiPolygon
-		else if (surfaceGeometryType == GMLClass.MULTI_POLYGON) {
-			MultiPolygon multiPolygon = (MultiPolygon)surfaceGeometry;
+        // MultiGeometry
+        else if (geometry instanceof MultiGeometry) {
+            MultiSurface multiSurface = geometryConverter.convertToMultiSurface((MultiGeometry) geometry);
+            doImport(multiSurface, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
+        }
+    }
 
-			if (origGmlId != null && !isCopy)
-				importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
+    private void addBatch() throws CityGMLImportException, SQLException {
+        psGeomElem.addBatch();
+        if (++batchCounter == importer.getDatabaseAdapter().getMaxBatchSize())
+            importer.executeBatch(TableEnum.SURFACE_GEOMETRY);
+    }
 
-			// set root entry
-			psGeomElem.setLong(1, surfaceGeometryId);
-			psGeomElem.setString(2, gmlId);
-			psGeomElem.setLong(4, rootId);
-			psGeomElem.setInt(5, 0);
-			psGeomElem.setInt(6, 0);
-			psGeomElem.setInt(7, 0);
-			psGeomElem.setInt(8, isXlink ? 1 : 0);
-			psGeomElem.setInt(9, reverse ? 1 : 0);
-			psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+    @Override
+    public void executeBatch() throws CityGMLImportException, SQLException {
+        if (batchCounter > 0) {
+            psGeomElem.executeBatch();
+            batchCounter = 0;
+        }
+    }
 
-			if (parentId != 0)
-				psGeomElem.setLong(3, parentId);
-			else
-				psGeomElem.setNull(3, Types.NULL);
+    @Override
+    public void close() throws CityGMLImportException, SQLException {
+        psGeomElem.close();
+        psNextSeqValues.close();
+    }
 
-			if (cityObjectId != 0)
-				psGeomElem.setLong(13, cityObjectId);
-			else
-				psGeomElem.setNull(13, Types.NULL);
+    private class PrimaryKeyManager extends GeometryWalker {
+        private long[] ids;
+        private int count;
+        private int index;
 
-			addBatch();
+        @Override
+        public void visit(AbstractGeometry geometry) {
+        	if (!(geometry instanceof OrientableSurface))
+        		count++;
+        }
 
-			// set parentId
-			parentId = surfaceGeometryId;
+        @Override
+        public void visit(AbstractSurfacePatch surfacePatch) {
+            count++;
+        }
 
-			// get polygonMember
-			if (multiPolygon.isSetPolygonMember()) {
-				for (PolygonProperty polygonProperty : multiPolygon.getPolygonMember()) {
-					if (polygonProperty.isSetPolygon()) {
-						surfaceGeometryId = pkManager.nextId();
-						doImport(polygonProperty.getPolygon(), surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-					} else {
-						String href = polygonProperty.getHref();
-						if (href != null && href.length() != 0) {
-							importer.propagateXlink(new DBXlinkSurfaceGeometry(
-									surfaceGeometryId,
-									parentId,
-									rootId,
-									reverse,
-									href,
-									cityObjectId));
-						}
-					}
-				}
-			}
-		}
+        private void clear() {
+            reset();
+            ids = null;
+            count = 0;
+            index = 0;
+        }
 
-		// MultiSurface
-		else if (surfaceGeometryType == GMLClass.MULTI_SURFACE) {
-			MultiSurface multiSurface = (MultiSurface)surfaceGeometry;
+        private long retrieveIds(AbstractGeometry geometry) throws SQLException {
+            clear();
 
-			if (origGmlId != null && !isCopy)
-				importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
+            // count number of tuples to be inserted into database
+            geometry.accept(this);
+            if (count == 0)
+                return 0;
 
-			// set root entry
-			psGeomElem.setLong(1, surfaceGeometryId);
-			psGeomElem.setString(2, gmlId);
-			psGeomElem.setLong(4, rootId);
-			psGeomElem.setInt(5, 0);
-			psGeomElem.setInt(6, 0);
-			psGeomElem.setInt(7, 0);
-			psGeomElem.setInt(8, isXlink ? 1 : 0);
-			psGeomElem.setInt(9, reverse ? 1 : 0);
-			psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
+            // retrieve sequence values
+            psNextSeqValues.setInt(1, count);
+            try (ResultSet rs = psNextSeqValues.executeQuery()) {
+                ids = new long[count];
+                int i = 0;
 
-			if (parentId != 0)
-				psGeomElem.setLong(3, parentId);
-			else
-				psGeomElem.setNull(3, Types.NULL);
+                while (rs.next())
+                    ids[i++] = rs.getLong(1);
 
-			if (cityObjectId != 0)
-				psGeomElem.setLong(13, cityObjectId);
-			else
-				psGeomElem.setNull(13, Types.NULL);
+                return ids[0];
+            }
+        }
 
-			addBatch();
+        private long nextId(AbstractGeometry geometry) {
+        	long id = ids[index];
+			if (!(geometry instanceof OrientableSurface))
+				index++;
 
-			// set parentId
-			parentId = surfaceGeometryId;
-
-			// get surfaceMember
-			if (multiSurface.isSetSurfaceMember()) {
-				for (SurfaceProperty surfaceProperty : multiSurface.getSurfaceMember()) {
-					if (surfaceProperty.isSetSurface()) {
-						AbstractSurface abstractSurface = surfaceProperty.getSurface();
-
-						switch (abstractSurface.getGMLClass()) {
-						case _TEXTURED_SURFACE:
-						case ORIENTABLE_SURFACE:
-							doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-							break;
-						case POLYGON:
-						case COMPOSITE_SURFACE:
-						case SURFACE:
-						case TRIANGULATED_SURFACE:
-						case TIN:
-							surfaceGeometryId = pkManager.nextId();
-							doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-							break;
-						default:
-							importer.logOrThrowErrorMessage(importer.getObjectSignature(multiSurface, origGmlId) +
-									": " + abstractSurface.getGMLClass() + " is not supported as member surface.");
-						}
-
-					} else {
-						String href = surfaceProperty.getHref();
-						if (href != null && href.length() != 0) {
-							importer.propagateXlink(new DBXlinkSurfaceGeometry(
-									surfaceGeometryId,
-									parentId,
-									rootId,
-									reverse,
-									href,
-									cityObjectId));
-						}
-					}
-				}
-			}
-
-			// get surfaceMembers
-			if (multiSurface.isSetSurfaceMembers()) {
-				SurfaceArrayProperty surfaceArrayProperty = multiSurface.getSurfaceMembers();
-
-				if (surfaceArrayProperty.isSetSurface()) {
-					for (AbstractSurface abstractSurface : surfaceArrayProperty.getSurface()) {
-
-						switch (abstractSurface.getGMLClass()) {
-						case _TEXTURED_SURFACE:
-						case ORIENTABLE_SURFACE:
-							doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-							break;
-						case POLYGON:
-						case COMPOSITE_SURFACE:
-						case SURFACE:
-						case TRIANGULATED_SURFACE:
-						case TIN:
-							surfaceGeometryId = pkManager.nextId();
-							doImport(abstractSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-							break;
-						default:
-							importer.logOrThrowErrorMessage(importer.getObjectSignature(multiSurface, origGmlId) +
-									abstractSurface.getGMLClass() + " is not supported as member surface.");
-							return;
-						}
-					}
-				}
-			}
-		}
-
-		// MultiSolid
-		else if (surfaceGeometryType == GMLClass.MULTI_SOLID) {
-			MultiSolid multiSolid = (MultiSolid)surfaceGeometry;
-
-			if (origGmlId != null && !isCopy)
-				importer.putGeometryUID(origGmlId, surfaceGeometryId, rootId, reverse, gmlId);
-
-			// set root entry
-			psGeomElem.setLong(1, surfaceGeometryId);
-			psGeomElem.setString(2, gmlId);
-			psGeomElem.setLong(4, rootId);
-			psGeomElem.setInt(5, 0);
-			psGeomElem.setInt(6, 0);
-			psGeomElem.setInt(7, 0);
-			psGeomElem.setInt(8, isXlink ? 1 : 0);
-			psGeomElem.setInt(9, reverse ? 1 : 0);
-			psGeomElem.setNull(10, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(11, nullGeometryType, nullGeometryTypeName);
-			psGeomElem.setNull(12, nullGeometryType, nullGeometryTypeName);
-
-			if (parentId != 0)
-				psGeomElem.setLong(3, parentId);
-			else
-				psGeomElem.setNull(3, Types.NULL);
-
-			if (cityObjectId != 0)
-				psGeomElem.setLong(13, cityObjectId);
-			else
-				psGeomElem.setNull(13, Types.NULL);
-
-			addBatch();
-
-			// set parentId
-			parentId = surfaceGeometryId;
-
-			// get solidMember
-			if (multiSolid.isSetSolidMember()) {
-				for (SolidProperty solidProperty : multiSolid.getSolidMember()) {
-					if (solidProperty.isSetSolid()) {
-						surfaceGeometryId = pkManager.nextId();
-						doImport(solidProperty.getSolid(), surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-					} else {
-						String href = solidProperty.getHref();
-						if (href != null && href.length() != 0) {
-							importer.propagateXlink(new DBXlinkSurfaceGeometry(
-									surfaceGeometryId,
-									parentId,
-									rootId,
-									reverse,
-									href,
-									cityObjectId));
-						}
-					}
-				}
-			}
-
-			// get SolidMembers
-			if (multiSolid.isSetSolidMembers()) {
-				SolidArrayProperty solidArrayProperty = multiSolid.getSolidMembers();
-
-				if (solidArrayProperty.isSetSolid()) {
-					for (AbstractSolid abstractSolid : solidArrayProperty.getSolid()) {
-						surfaceGeometryId = pkManager.nextId();
-						doImport(abstractSolid, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-					}
-				}
-			}
-		}
-
-		// GeometricComplex
-		else if (surfaceGeometryType == GMLClass.GEOMETRIC_COMPLEX) {
-			GeometricComplex geometricComplex = (GeometricComplex)surfaceGeometry;
-
-			if (geometricComplex.isSetElement()) {
-				for (GeometricPrimitiveProperty geometricPrimitiveProperty : geometricComplex.getElement()) {
-					if (geometricPrimitiveProperty.isSetGeometricPrimitive())
-						doImport(geometricPrimitiveProperty.getGeometricPrimitive(), surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-					else {
-						String href = geometricPrimitiveProperty.getHref();
-						if (href != null && href.length() != 0) {
-							importer.propagateXlink(new DBXlinkSurfaceGeometry(
-									surfaceGeometryId,
-									parentId,
-									rootId,
-									reverse,
-									href,
-									cityObjectId));
-						}
-					}
-				}
-			}
-		}
-
-		// MultiGeometry
-		else if (surfaceGeometryType == GMLClass.MULTI_GEOMETRY) {
-			MultiSurface multiSurface = geometryConverter.convertToMultiSurface((MultiGeometry) surfaceGeometry);
-			doImport(multiSurface, surfaceGeometryId, parentId, rootId, reverse, isXlink, isCopy, cityObjectId);
-		}
-	}
-
-	private void addBatch() throws CityGMLImportException, SQLException {
-		psGeomElem.addBatch();
-		if (++batchCounter == importer.getDatabaseAdapter().getMaxBatchSize())
-			importer.executeBatch(TableEnum.SURFACE_GEOMETRY);
-	}
-
-	@Override
-	public void executeBatch() throws CityGMLImportException, SQLException {
-		if (batchCounter > 0) {
-			psGeomElem.executeBatch();
-			batchCounter = 0;
-		}
-	}
-
-	@Override
-	public void close() throws CityGMLImportException, SQLException {
-		psGeomElem.close();
-		psNextSeqValues.close();
-	}
-
-	private class PrimaryKeyManager extends GeometryWalker {
-		private long[] ids;
-		private int count;
-		private int index;
-
-		@Override
-		public void visit(AbstractGeometry geometry) {
-			switch (geometry.getGMLClass()) {
-				case POLYGON:
-				case COMPOSITE_SURFACE:
-				case SURFACE:
-				case TRIANGULATED_SURFACE:
-				case TIN:
-				case SOLID:
-				case COMPOSITE_SOLID:
-				case MULTI_POLYGON:
-				case MULTI_SURFACE:
-				case MULTI_SOLID:
-				case MULTI_GEOMETRY:
-					count++;
-			}
-		}
-
-		@Override
-		public void visit(AbstractSurfacePatch surfacePatch) {
-			count++;
-		}
-
-		private void clear() {
-			reset();
-			ids = null;
-			count = 0;
-			index = 0;
-		}
-
-		private boolean retrieveIds(AbstractGeometry geometry) throws SQLException {
-			clear();
-
-			// count number of tuples to be inserted into database
-			geometry.accept(this);
-			if (count == 0)
-				return false;
-
-			// retrieve sequence values
-			psNextSeqValues.setInt(1, count);
-			try (ResultSet rs = psNextSeqValues.executeQuery()) {
-				ids = new long[count];
-				int i = 0;
-
-				while (rs.next())
-					ids[i++] = rs.getLong(1);
-
-				return true;
-			}
-		}
-
-		private long nextId() {
-			return ids[index++];
-		}
-	}
-
+            return id;
+        }
+    }
 }

--- a/impexp-core/src/main/java/org/citydb/citygml/importer/database/content/GeometryConverter.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/importer/database/content/GeometryConverter.java
@@ -635,12 +635,12 @@ public class GeometryConverter {
 		return null;
 	}
 
-	public MultiSurface convertToMultiSurface(MultiGeometry multiGeometry) {
+	public MultiSurface convertToMultiSurface(AbstractGeometry geometry) {
 		MultiSurface multiSurface = new MultiSurface();
-		multiSurface.setId(multiGeometry.getId());
+		multiSurface.setId(geometry.getId());
 
 		List<SurfaceProperty> properties = multiSurface.getSurfaceMember();
-		multiGeometry.accept(new GeometryWalker() {
+		geometry.accept(new GeometryWalker() {
 			public void visit(AbstractSurface surface) {
 				properties.add(new SurfaceProperty(surface));
 			}

--- a/impexp-core/src/main/java/org/citydb/citygml/importer/database/xlink/resolver/XlinkSolidGeometry.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/importer/database/xlink/resolver/XlinkSolidGeometry.java
@@ -39,6 +39,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class XlinkSolidGeometry implements DBXlinkResolver {
 	private final Logger log = Logger.getInstance();
@@ -149,24 +150,23 @@ public class XlinkSolidGeometry implements DBXlinkResolver {
 
 		try (ResultSet rs = psSelectSurfGeom.executeQuery()) {
 			GeometryNode root = null;
-			HashMap<Long, GeometryNode> parentMap = new HashMap<>();
+			Map<Long, GeometryNode> parentMap = new HashMap<>();
 
 			// rebuild geometry hierarchy
 			while (rs.next()) {
-				int isSolid = rs.getInt("IS_SOLID");
-				int isComposite = rs.getInt("IS_COMPOSITE");
-				long id = rs.getLong("ID");
-				long parentId = rs.getInt("PARENT_ID");
-
-				GeometryObject geometry = null;
-				Object object = rs.getObject("GEOMETRY");
-				if (!rs.wasNull() && object != null)
-					geometry = manager.getDatabaseAdapter().getGeometryConverter().getPolygon(object);
+				long id = rs.getLong("id");
+				long parentId = rs.getInt("parent_id");
 
 				// constructing a geometry node
 				GeometryNode geomNode = new GeometryNode();
-				geomNode.isSolid = isSolid == 1;
-				geomNode.isComposite = isComposite == 1;
+				geomNode.isSolid = rs.getBoolean("is_solid");
+				geomNode.isComposite = rs.getBoolean("is_composite");
+
+				GeometryObject geometry = null;
+				Object object = rs.getObject("geometry");
+				if (!rs.wasNull() && object != null)
+					geometry = manager.getDatabaseAdapter().getGeometryConverter().getPolygon(object);
+
 				geomNode.geometry = geometry;
 
 				if (root != null) {


### PR DESCRIPTION
The CityGML import only supports `gml:CompositeSurface` as exterior shell of a `gml:Solid`. However, according to the GML 3.1.1 XML Schema, any surface is allowed to describe the shell of a solid. This PR proposes to adapt both the CityGML import and export to resolve this limitation.

Solves https://github.com/3dcitydb/3dcitydb/issues/52