### PR TITLE
Enhance LoD export filter

### DIFF
--- a/impexp-config/build.gradle
+++ b/impexp-config/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api 'org.citygml4j:citygml4j:2.11.0'
+    api 'org.citygml4j:citygml4j:2.11.2-b20200917-1733'
 }
 
 bintray {

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/lod/LodFilterMode.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/lod/LodFilterMode.java
@@ -37,7 +37,11 @@ public enum LodFilterMode {
 	@XmlEnumValue("or")
 	OR("Or"),
 	@XmlEnumValue("and")
-	AND("And");
+	AND("And"),
+    @XmlEnumValue("minimum")
+    MINIMUM("Minimum LoD"),
+    @XmlEnumValue("maximum")
+    MAXIMUM("Maximum LoD");
 	
 	private final String value;
 

--- a/impexp-core/build.gradle
+++ b/impexp-core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':impexp-plugin-api')
     api 'org.citydb:sqlbuilder:2.2.1'
     api 'org.citydb:3dcitydb-ade-citygml4j:1.1.1'
-    api 'org.citygml4j:citygml4j:2.11.0'
+    api 'org.citygml4j:citygml4j:2.11.2-b20200917-1733'
     api 'org.geotools:gt-epsg-extension:23.1'
     api 'org.geotools:gt-epsg-hsql:23.1'
     api 'org.geotools:gt-referencing:23.1'

--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/CityGMLExportManager.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/CityGMLExportManager.java
@@ -226,13 +226,17 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 		// execute batch export
 		executeBatch();
 
-		// remove empty city objects
+		// remove empty city objects in case we filter LoDs
 		if (lodGeometryChecker != null)
 			lodGeometryChecker.cleanupCityObjects(object);
 
-		// clean up appearances
+		// remove local appearances in case we filter LoDs
 		if (appearanceRemover != null)
 			appearanceRemover.cleanupAppearances(object);
+
+		// cache geometry ids in case we export global appearances
+		if (config.getInternal().isExportGlobalAppearances())
+			getExporter(DBGlobalAppearance.class).cacheGeometryIds(object);
 
 		if (object instanceof AbstractFeature) {
 			AbstractFeature feature = (AbstractFeature) object;

--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/CityGMLExportManager.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/CityGMLExportManager.java
@@ -203,7 +203,7 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 		exportCounter = new ExportCounter(schemaMapping);
 
 		if (!query.getLodFilter().preservesGeometry()) {
-			lodGeometryChecker = new LodGeometryChecker(query.getLodFilter(), schemaMapping);
+			lodGeometryChecker = new LodGeometryChecker(this, schemaMapping);
 			if (config.getProject().getExporter().getAppearances().isSetExportAppearance())
 				appearanceRemover = new AppearanceRemover();
 		}

--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/CityGMLExportManager.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/CityGMLExportManager.java
@@ -203,7 +203,7 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 		exportCounter = new ExportCounter(schemaMapping);
 
 		if (!query.getLodFilter().preservesGeometry()) {
-			lodGeometryChecker = new LodGeometryChecker(schemaMapping);
+			lodGeometryChecker = new LodGeometryChecker(query.getLodFilter(), schemaMapping);
 			if (config.getProject().getExporter().getAppearances().isSetExportAppearance())
 				appearanceRemover = new AppearanceRemover();
 		}

--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/util/LodGeometryChecker.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/util/LodGeometryChecker.java
@@ -29,6 +29,8 @@ package org.citydb.citygml.exporter.util;
 
 import org.citydb.database.schema.mapping.FeatureType;
 import org.citydb.database.schema.mapping.SchemaMapping;
+import org.citydb.query.filter.lod.LodFilter;
+import org.citydb.query.filter.lod.LodFilterMode;
 import org.citydb.util.Util;
 import org.citygml4j.model.citygml.core.AbstractCityObject;
 import org.citygml4j.model.citygml.core.LodRepresentation;
@@ -36,6 +38,7 @@ import org.citygml4j.model.common.base.ModelObject;
 import org.citygml4j.model.common.base.ModelObjects;
 import org.citygml4j.model.common.child.Child;
 import org.citygml4j.model.gml.base.AbstractGML;
+import org.citygml4j.model.gml.geometry.GeometryProperty;
 import org.citygml4j.util.child.ChildInfo;
 import org.citygml4j.util.walker.FeatureWalker;
 import org.citygml4j.util.walker.GMLWalker;
@@ -46,9 +49,12 @@ import java.util.Set;
 
 public class LodGeometryChecker extends FeatureWalker {
 	private final SchemaMapping schemaMapping;
+	private final int targetLoD;
 
-	public LodGeometryChecker(SchemaMapping schemaMapping) {
+	public LodGeometryChecker(LodFilter lodFilter, SchemaMapping schemaMapping) {
 		this.schemaMapping = schemaMapping;
+		targetLoD = lodFilter.getFilterMode() == LodFilterMode.MINIMUM ? lodFilter.getMinimumLod() :
+				lodFilter.getFilterMode() == LodFilterMode.MAXIMUM ? lodFilter.getMaximumLod() : -1;
 	}
 
 	public void cleanupCityObjects(AbstractGML object) {
@@ -59,20 +65,30 @@ public class LodGeometryChecker extends FeatureWalker {
 
 			@Override
 			public void visit(AbstractCityObject cityObject) {
-				if (cityObject != object) {
-					FeatureType featureType = schemaMapping.getFeatureType(Util.getObjectClassId(cityObject.getClass()));
-					if (featureType.hasLodProperties()) {
-						LodRepresentation representation = cityObject.getLodRepresentation();
-						if (!representation.hasRepresentations())
+				FeatureType featureType = schemaMapping.getFeatureType(Util.getObjectClassId(cityObject.getClass()));
+				if (featureType.hasLodProperties()) {
+					LodRepresentation representation = cityObject.getLodRepresentation();
+					if (!representation.hasRepresentations())
+						return;
+
+					if (targetLoD != -1) {
+						for (int lod = 0; lod < 5; lod++) {
+							if (lod != targetLoD) {
+								for (GeometryProperty<?> property : representation.getGeometry(lod))
+									ModelObjects.unsetProperty(cityObject, property);
+							}
+						}
+
+						if (representation.getGeometry(targetLoD).isEmpty())
 							return;
 					}
-
-					do {
-						// keep the city object and its parents
-						if (!keep.add(cityObject))
-							break;
-					} while ((cityObject = childInfo.getParentCityObject(cityObject)) != object);
 				}
+
+				do {
+					// keep the city object and its parents
+					if (!keep.add(cityObject))
+						break;
+				} while ((cityObject = childInfo.getParentCityObject(cityObject)) != object);
 			}
 		});
 

--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/util/LodGeometryChecker.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/util/LodGeometryChecker.java
@@ -27,125 +27,233 @@
  */
 package org.citydb.citygml.exporter.util;
 
+import org.citydb.citygml.exporter.database.content.CityGMLExportManager;
 import org.citydb.database.schema.mapping.FeatureType;
 import org.citydb.database.schema.mapping.SchemaMapping;
 import org.citydb.query.filter.lod.LodFilter;
 import org.citydb.query.filter.lod.LodFilterMode;
 import org.citydb.query.filter.lod.LodIterator;
 import org.citydb.util.Util;
+import org.citygml4j.model.citygml.bridge.AbstractBridge;
+import org.citygml4j.model.citygml.building.AbstractBuilding;
 import org.citygml4j.model.citygml.core.AbstractCityObject;
 import org.citygml4j.model.citygml.core.LodRepresentation;
+import org.citygml4j.model.citygml.tunnel.AbstractTunnel;
+import org.citygml4j.model.citygml.waterbody.AbstractWaterBoundarySurface;
+import org.citygml4j.model.citygml.waterbody.WaterBody;
 import org.citygml4j.model.common.base.ModelObject;
 import org.citygml4j.model.common.base.ModelObjects;
 import org.citygml4j.model.common.child.Child;
 import org.citygml4j.model.gml.base.AbstractGML;
+import org.citygml4j.model.gml.geometry.AbstractGeometry;
 import org.citygml4j.model.gml.geometry.GeometryProperty;
+import org.citygml4j.model.module.citygml.CityGMLVersion;
 import org.citygml4j.util.child.ChildInfo;
 import org.citygml4j.util.walker.FeatureWalker;
 import org.citygml4j.util.walker.GMLWalker;
+import org.citygml4j.util.walker.GeometryWalker;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class LodGeometryChecker extends FeatureWalker {
 	private final SchemaMapping schemaMapping;
+	private final LodFilter lodFilter;
 	private final ChildInfo childInfo;
+	private final CityGMLVersion targetVersion;
 	private final LodFilterMode mode;
-	private final boolean removeGeometries;
+	private final boolean deleteGeometries;
 
 	private LodIterator lodIterator;
-	private int selectedLod;
 
-	public LodGeometryChecker(LodFilter lodFilter, SchemaMapping schemaMapping) {
+	public LodGeometryChecker(CityGMLExportManager manager, SchemaMapping schemaMapping) {
 		this.schemaMapping = schemaMapping;
 
+		lodFilter = manager.getLodFilter();
 		childInfo = new ChildInfo();
+		targetVersion = manager.getTargetCityGMLVersion();
 		mode = lodFilter.getFilterMode();
-		removeGeometries = mode == LodFilterMode.MINIMUM || mode == LodFilterMode.MAXIMUM;
+		deleteGeometries = mode == LodFilterMode.MINIMUM || mode == LodFilterMode.MAXIMUM;
 
-		if (removeGeometries) {
+		if (deleteGeometries)
 			lodIterator = lodFilter.iterator(0, 4, mode == LodFilterMode.MAXIMUM);
-			selectedLod = mode == LodFilterMode.MINIMUM ?
-					lodFilter.getMinimumLod() :
-					lodFilter.getMaximumLod();
-		}
 	}
 
-	public void cleanupCityObjects(AbstractGML object) {
+	public void cleanupCityObjects(AbstractGML parent) {
 		Map<AbstractCityObject, LodRepresentation> cityObjects = new IdentityHashMap<>();
-		Set<AbstractCityObject> keep = Collections.newSetFromMap(new IdentityHashMap<>());
+		Map<String, AbstractGeometry> deletedGeometries = null;
 		int targetLod = -1;
 
-		// collect all city objects with their LoD representations
-		object.accept(new GMLWalker() {
+		// collect all city objects and their LoD representations
+		parent.accept(new GMLWalker() {
 			@Override
 			public void visit(AbstractCityObject cityObject) {
 				cityObjects.put(cityObject, cityObject.getLodRepresentation());
 			}
 		});
 
-		if (removeGeometries) {
-			// determine target LoD
-			targetLod = mode == LodFilterMode.MINIMUM ? Integer.MAX_VALUE : -Integer.MAX_VALUE;
-			for (LodRepresentation representation : cityObjects.values()) {
-				lodIterator.reset();
-				while (lodIterator.hasNext()) {
-					int lod = lodIterator.next();
-					if (!representation.getGeometry(lod).isEmpty()) {
-						if ((mode == LodFilterMode.MINIMUM && lod < targetLod)
-								|| (mode == LodFilterMode.MAXIMUM && lod > targetLod))
-							targetLod = lod;
+		// delete all geometries not belonging to the target LoD
+		if (deleteGeometries) {
+			targetLod = getTargetLod(cityObjects);
+			deletedGeometries = deleteGeometries(cityObjects, targetLod);
+		}
 
-						break;
-					}
-				}
+		// delete city objects not having a matching LoD
+		deleteCityObjects(cityObjects, targetLod, parent);
 
-				if (targetLod == selectedLod)
+		// resolve cross-LoD-XLinks
+		if (deleteGeometries)
+			resolveCrossLodReferences(deletedGeometries, parent);
+	}
+
+	private int getTargetLod(Map<AbstractCityObject, LodRepresentation> cityObjects) {
+		int targetLod = mode == LodFilterMode.MINIMUM ? Integer.MAX_VALUE : -Integer.MAX_VALUE;
+		int selectedLod = mode == LodFilterMode.MINIMUM ?
+				lodFilter.getMinimumLod() :
+				lodFilter.getMaximumLod();
+
+		for (LodRepresentation representation : cityObjects.values()) {
+			lodIterator.reset();
+
+			while (lodIterator.hasNext()) {
+				int lod = lodIterator.next();
+				if (!representation.getGeometry(lod).isEmpty()) {
+					if ((mode == LodFilterMode.MINIMUM && lod < targetLod)
+							|| (mode == LodFilterMode.MAXIMUM && lod > targetLod))
+						targetLod = lod;
+
 					break;
+				}
 			}
 
-			// remove all LoDs besides the target LoD
-			for (Map.Entry<AbstractCityObject, LodRepresentation> entry : cityObjects.entrySet()) {
-				LodRepresentation representation = entry.getValue();
-				lodIterator.reset();
-				while (lodIterator.hasNext()) {
-					int lod = lodIterator.next();
-					if (lod != targetLod) {
-						for (GeometryProperty<?> property : representation.getGeometry(lod))
-							ModelObjects.unsetProperty(entry.getKey(), property);
+			if (targetLod == selectedLod)
+				break;
+		}
+
+		return targetLod;
+	}
+
+	private Map<String, AbstractGeometry> deleteGeometries(Map<AbstractCityObject, LodRepresentation> cityObjects, int targetLod) {
+		Map<String, AbstractGeometry> geometries = new HashMap<>();
+		for (Map.Entry<AbstractCityObject, LodRepresentation> entry : cityObjects.entrySet()) {
+			LodRepresentation representation = entry.getValue();
+			lodIterator.reset();
+
+			while (lodIterator.hasNext()) {
+				int lod = lodIterator.next();
+				if (lod != targetLod) {
+					for (GeometryProperty<?> property : representation.getGeometry(lod)) {
+						if (property.isSetGeometry()) {
+							// the target LoD might referece geometries that we are about to delete.
+							// Thus, we must keep the deleted geometries to be able to resolve them later.
+							property.getGeometry().accept(new GeometryWalker() {
+								@Override
+								public void visit(AbstractGeometry geometry) {
+									if (geometry.isSetId())
+										geometries.put("#" + geometry.getId(), geometry);
+								}
+							});
+						}
+
+						ModelObjects.unsetProperty(entry.getKey(), property);
 					}
 				}
 			}
 		}
 
-		// build list of city objects that can be kept
+		return geometries;
+	}
+
+	private void deleteCityObjects(Map<AbstractCityObject, LodRepresentation> cityObjects, int targetLod, AbstractGML parent) {
+		// filter city objects that have a matching LoD and thus can be kept
+		Set<AbstractCityObject> keep = Collections.newSetFromMap(new IdentityHashMap<>());
 		for (Map.Entry<AbstractCityObject, LodRepresentation> entry : cityObjects.entrySet()) {
 			AbstractCityObject cityObject = entry.getKey();
 			LodRepresentation representation = entry.getValue();
 			FeatureType featureType = schemaMapping.getFeatureType(Util.getObjectClassId(cityObject.getClass()));
 
 			if (!featureType.hasLodProperties()
-					|| (!removeGeometries && representation.hasRepresentations())
+					|| (!deleteGeometries && representation.hasRepresentations())
 					|| !representation.getGeometry(targetLod).isEmpty()) {
 				do {
 					// keep the city object and its parents
 					if (!keep.add(cityObject))
 						break;
-				} while ((cityObject = childInfo.getParentCityObject(cityObject)) != object);
+				} while ((cityObject = childInfo.getParentCityObject(cityObject)) != parent);
 			}
 		}
 
-		// clean up city objects
+		// delete all other city objects
 		for (AbstractCityObject cityObject : cityObjects.keySet()) {
-			if (cityObject != object) {
+			if (cityObject != parent) {
 				if (!keep.contains(cityObject)) {
 					ModelObject property = cityObject.getParent();
 					if (property instanceof Child)
 						ModelObjects.unsetProperty(((Child) property).getParent(), property);
 				}
 			}
+		}
+	}
+
+	private void resolveCrossLodReferences(Map<String, AbstractGeometry> deletedGeometries, AbstractGML parent) {
+		// collect all properties with XLink references to deleted geometries
+		Map<AbstractGeometry, List<GeometryProperty<?>>> properties = new IdentityHashMap<>();
+		parent.accept(new GMLWalker() {
+			@Override
+			public <T extends AbstractGeometry> void visit(GeometryProperty<T> property) {
+				if (!property.isSetGeometry()) {
+					AbstractGeometry geometry = deletedGeometries.get(property.getHref());
+					if (geometry != null && property.getAssociableClass().isInstance(geometry))
+						properties.computeIfAbsent(geometry, v -> new ArrayList<>()).add(property);
+				}
+
+				super.visit(property);
+			}
+		});
+
+		// resolve the references
+		for (Map.Entry<AbstractGeometry, List<GeometryProperty<?>>> entry : properties.entrySet()) {
+			GeometryProperty<?> property = null;
+
+			// CityGML enforces the direction of XLinks if a feature has boundary surfaces.
+			// So, if we find more than one property referencing the same geometry, we must check this.
+			if (entry.getValue().size() > 1) {
+				Class<? extends AbstractCityObject> type = null;
+				boolean assignToBoundarySurface = true;
+
+				if (parent instanceof AbstractBuilding)
+					type = org.citygml4j.model.citygml.building.AbstractBoundarySurface.class;
+				else if (parent instanceof AbstractBridge)
+					type = org.citygml4j.model.citygml.bridge.AbstractBoundarySurface.class;
+				else if (parent instanceof AbstractTunnel)
+					type = org.citygml4j.model.citygml.tunnel.AbstractBoundarySurface.class;
+				else if (parent instanceof WaterBody) {
+					type = AbstractWaterBoundarySurface.class;
+					assignToBoundarySurface = targetVersion != CityGMLVersion.v1_0_0;
+				}
+
+				if (type != null) {
+					for (GeometryProperty<?> candidate : entry.getValue()) {
+						AbstractCityObject boundarySurface = childInfo.getParentCityObject(candidate, type);
+						if ((boundarySurface != null && assignToBoundarySurface)
+								|| (boundarySurface == null && !assignToBoundarySurface)) {
+							property = candidate;
+							break;
+						}
+					}
+				}
+			}
+
+			if (property == null)
+				property = entry.getValue().get(0);
+
+			property.setObjectIfValid(entry.getKey());
+			property.unsetHref();
 		}
 	}
 }

--- a/impexp-core/src/main/java/org/citydb/query/builder/config/LodFilterBuilder.java
+++ b/impexp-core/src/main/java/org/citydb/query/builder/config/LodFilterBuilder.java
@@ -45,12 +45,18 @@ public class LodFilterBuilder {
 		LodFilter lodFilter = new LodFilter(LodFilterMode.OR);
 
 		switch (lodFilterConfig.getMode()) {
-		case OR:
-			lodFilter.setFilterMode(LodFilterMode.OR);
-			break;
-		case AND:
-			lodFilter.setFilterMode(LodFilterMode.AND);
-			break;
+			case OR:
+				lodFilter.setFilterMode(LodFilterMode.OR);
+				break;
+			case AND:
+				lodFilter.setFilterMode(LodFilterMode.AND);
+				break;
+			case MINIMUM:
+				lodFilter.setFilterMode(LodFilterMode.MINIMUM);
+				break;
+			case MAXIMUM:
+				lodFilter.setFilterMode(LodFilterMode.MAXIMUM);
+				break;
 		}
 
 		for (int lod = 0; lod < 5; lod++)

--- a/impexp-core/src/main/java/org/citydb/query/builder/sql/LodFilterBuilder.java
+++ b/impexp-core/src/main/java/org/citydb/query/builder/sql/LodFilterBuilder.java
@@ -250,7 +250,7 @@ public class LodFilterBuilder {
 					if (!lodMatcher.matches())
 						continue;
 
-					lod = Integer.valueOf(lodMatcher.group(1));
+					lod = Integer.parseInt(lodMatcher.group(1));
 				}
 
 				if (!lodFilter.isEnabled(lod))

--- a/impexp-core/src/main/java/org/citydb/query/builder/sql/SQLQueryBuilder.java
+++ b/impexp-core/src/main/java/org/citydb/query/builder/sql/SQLQueryBuilder.java
@@ -125,7 +125,7 @@ public class SQLQueryBuilder {
 		// lod filter
 		if (query.isSetLodFilter()) {
 			LodFilter lodFilter = query.getLodFilter();
-			if (lodFilter.getFilterMode() != LodFilterMode.OR || !lodFilter.areAllEnabled()) {
+			if (lodFilter.getFilterMode() == LodFilterMode.AND || !lodFilter.areAllEnabled()) {
 				LodFilterBuilder lodFilterBuilder = new LodFilterBuilder(schemaMapping, schemaName);
 				lodFilterBuilder.buildLodFilter(query.getLodFilter(), typeFilter, query.getTargetVersion(), queryContext);
 			}

--- a/impexp-core/src/main/java/org/citydb/query/filter/lod/LodFilter.java
+++ b/impexp-core/src/main/java/org/citydb/query/filter/lod/LodFilter.java
@@ -30,7 +30,7 @@ package org.citydb.query.filter.lod;
 import java.util.Arrays;
 
 public class LodFilter {
-	private boolean[] lods;
+	private final boolean[] lods;
 	private LodFilterMode mode;
 	private Integer searchDepth;	
 		
@@ -115,7 +115,7 @@ public class LodFilter {
 		
 		return false;
 	}
-	
+
 	public LodFilterMode getFilterMode() {
 		return mode;
 	}
@@ -123,9 +123,11 @@ public class LodFilter {
 	public void setFilterMode(LodFilterMode mode) {
 		this.mode = mode;
 	}
-	
+
 	public boolean preservesGeometry() {
-		return areAllEnabled();
+		return mode != LodFilterMode.MINIMUM
+				&& mode != LodFilterMode.MAXIMUM
+				&& areAllEnabled();
 	}
 	
 	public LodIterator iterator(int fromLod, int toLod, boolean reverse) {

--- a/impexp-core/src/main/java/org/citydb/query/filter/lod/LodFilterMode.java
+++ b/impexp-core/src/main/java/org/citydb/query/filter/lod/LodFilterMode.java
@@ -29,7 +29,9 @@ package org.citydb.query.filter.lod;
 
 public enum LodFilterMode {
 	AND("AND"),
-	OR("OR");
+	OR("OR"),
+	MINIMUM("MIN"),
+	MAXIMUM("MAX");
 
 	final String symbol;
 


### PR DESCRIPTION
This PR proposes to enhance the LoD export filter with the option to only export the minimum or maximum LoD from the list of selected LoDs. For this purpose, two new filter modes `minimum` and `maximum` are added to the filter configuration.

The following snippet shows an example of how to use the new LoD filter modes:
```xml
<query xmlns="http://www.3dcitydb.org/importer-exporter/config">
  <typeNames>
    <typeName xmlns:bldg="http://www.opengis.net/citygml/building/2.0">bldg:Building</typeName>
  </typeNames>
  <lods mode="minimum" searchMode="depth" searchDepth="1">
    <lod>1</lod>
    <lod>2</lod>
    <lod>3</lod>
  </lods>
</query>
```
In this example, the exporter will query all `Building` objects having a spatial representation in LoD 1, 2 or 3. If a building has a representation in more than one of these LoDs, only the `minimum` LoD is kept and exported.

**Note that PR #126 is a mandatory prerequisite for this PR**