### PR TITLE
fixed tiled CityGML and KML export

### DIFF
--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/controller/Exporter.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/controller/Exporter.java
@@ -315,7 +315,7 @@ public class Exporter implements EventHandler {
 				if (useTiling) {
 					Tile tile;
 					try {
-						tile = tiling.getTileAt(i, j);
+						tile = tiling.getTileAt(j, i);
 						tiling.setActiveTile(tile);
 
 						Predicate bboxFilter = tile.getFilterPredicate(databaseAdapter);

--- a/impexp-core/src/main/java/org/citydb/query/filter/tiling/Tiling.java
+++ b/impexp-core/src/main/java/org/citydb/query/filter/tiling/Tiling.java
@@ -130,8 +130,14 @@ public class Tiling {
 		calculateTilingScheme();
 	}
 
+	/**
+	 * @param x column index
+	 * @param y row index
+	 * @return a Tile at the target position
+	 * @throws FilterException
+	 */
 	public Tile getTileAt(int x, int y) throws FilterException {
-		if (x < 0 || y < 0 || x >= getRows() || y >= getColumns()) {
+		if (x < 0 || y < 0 || x >= getColumns() || y >= getRows()) {
 			throw new FilterException("Tile coordinates are out of bounds.");
 		}
 

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/controller/KmlExporter.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/controller/KmlExporter.java
@@ -371,7 +371,7 @@ public class KmlExporter implements EventHandler {
 				Tile tile = null;
 				if (useTiling) {
 					try {
-						tile = tiling.getTileAt(i, j);
+						tile = tiling.getTileAt(j, i);
 						tiling.setActiveTile(tile);
 
 						Predicate bboxFilter = tile.getFilterPredicate(databaseAdapter);


### PR DESCRIPTION
Both tiled CityGML and KML export are not working, because the mapping of `x -> column` and `y -> row` are not interpreted correctly. This PR solves this issue. 