### PR TITLE
move FilterView classes to common package

### DIFF
--- a/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/AttributeFilterView.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/AttributeFilterView.java
@@ -26,20 +26,19 @@
  * limitations under the License.
  */
 
-package org.citydb.gui.modules.exporter.view.filter;
+package org.citydb.gui.modules.common.filter;
 
-import org.citydb.config.Config;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.exporter.SimpleQuery;
 import org.citydb.config.project.query.filter.selection.comparison.LikeOperator;
 import org.citydb.config.project.query.filter.selection.id.ResourceIdOperator;
-import org.citydb.gui.components.common.TitledPanel;
 import org.citydb.gui.factory.PopupMenuDecorator;
 import org.citydb.gui.util.GuiUtil;
 import org.citydb.util.Util;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.function.Supplier;
 
 public class AttributeFilterView extends FilterView {
     private JPanel component;
@@ -51,8 +50,8 @@ public class AttributeFilterView extends FilterView {
     private JLabel lineageLabel;
     private JTextField lineageText;
 
-    public AttributeFilterView(Config config) {
-        super(config);
+    public AttributeFilterView(Supplier<SimpleQuery> simpleQuerySupplier) {
+        super(simpleQuerySupplier);
         init();
     }
 
@@ -122,7 +121,7 @@ public class AttributeFilterView extends FilterView {
 
     @Override
     public void loadSettings() {
-        SimpleQuery query = config.getExportConfig().getSimpleQuery();
+        SimpleQuery query = simpleQuerySupplier.get();
 
         // gml:id filter
         ResourceIdOperator gmlIdFilter = query.getSelectionFilter().getGmlIdFilter();
@@ -139,7 +138,7 @@ public class AttributeFilterView extends FilterView {
 
     @Override
     public void setSettings() {
-        SimpleQuery query = config.getExportConfig().getSimpleQuery();
+        SimpleQuery query = simpleQuerySupplier.get();
 
         // gml:id filter
         ResourceIdOperator gmlIdFilter = query.getSelectionFilter().getGmlIdFilter();

--- a/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/FilterView.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/FilterView.java
@@ -26,20 +26,22 @@
  * limitations under the License.
  */
 
-package org.citydb.gui.modules.exporter.view.filter;
+package org.citydb.gui.modules.common.filter;
 
-import org.citydb.config.Config;
+import org.citydb.config.project.exporter.SimpleQuery;
 import org.citydb.plugin.extension.view.View;
 
+import java.util.function.Supplier;
+
 public abstract class FilterView extends View {
-    final Config config;
+    final Supplier<SimpleQuery> simpleQuerySupplier;
 
     public abstract void doTranslation();
     public abstract void setEnabled(boolean enable);
     public abstract void loadSettings();
     public abstract void setSettings();
 
-    public FilterView(Config config) {
-        this.config = config;
+    public FilterView(Supplier<SimpleQuery> simpleQuerySupplier) {
+        this.simpleQuerySupplier = simpleQuerySupplier;
     }
 }

--- a/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/SQLFilterView.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/SQLFilterView.java
@@ -26,10 +26,10 @@
  * limitations under the License.
  */
 
-package org.citydb.gui.modules.exporter.view.filter;
+package org.citydb.gui.modules.common.filter;
 
 import com.formdev.flatlaf.extras.FlatSVGIcon;
-import org.citydb.config.Config;
+import org.citydb.config.gui.components.SQLExportFilterComponent;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.exporter.SimpleQuery;
 import org.citydb.config.project.query.filter.selection.sql.SelectOperator;
@@ -42,6 +42,7 @@ import org.fife.ui.rtextarea.RTextScrollPane;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.function.Supplier;
 
 public class SQLFilterView extends FilterView {
     private JPanel component;
@@ -53,8 +54,11 @@ public class SQLFilterView extends FilterView {
     private int additionalRows;
     private int rowHeight;
 
-    public SQLFilterView(Config config) {
-        super(config);
+    private final Supplier<SQLExportFilterComponent> sqlFilterComponentSupplier;
+
+    public SQLFilterView(Supplier<SimpleQuery> simpleQuerySupplier, Supplier<SQLExportFilterComponent> sqlFilterComponentSupplier) {
+        super(simpleQuerySupplier);
+        this.sqlFilterComponentSupplier = sqlFilterComponentSupplier;
         init();
     }
 
@@ -153,12 +157,12 @@ public class SQLFilterView extends FilterView {
 
     @Override
     public void loadSettings() {
-        SimpleQuery query = config.getExportConfig().getSimpleQuery();
+        SimpleQuery query = simpleQuerySupplier.get();
 
         SelectOperator sql = query.getSelectionFilter().getSQLFilter();
         sqlText.setText(sql.getValue());
 
-        additionalRows = config.getGuiConfig().getSQLExportFilterComponent().getAdditionalRows();
+        additionalRows = sqlFilterComponentSupplier.get().getAdditionalRows();
         SwingUtilities.invokeLater(() -> {
             if (additionalRows > 0) {
                 Dimension size = scrollPane.getPreferredSize();
@@ -176,7 +180,7 @@ public class SQLFilterView extends FilterView {
 
     @Override
     public void setSettings() {
-        SimpleQuery query = config.getExportConfig().getSimpleQuery();
+        SimpleQuery query = simpleQuerySupplier.get();
 
         SelectOperator sql = query.getSelectionFilter().getSQLFilter();
         sql.reset();
@@ -184,6 +188,6 @@ public class SQLFilterView extends FilterView {
         if (!value.isEmpty())
             sql.setValue(value.replaceAll(";", " "));
 
-        config.getGuiConfig().getSQLExportFilterComponent().setAdditionalRows(additionalRows);
+        sqlFilterComponentSupplier.get().setAdditionalRows(additionalRows);
     }
 }

--- a/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/XMLQueryView.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/XMLQueryView.java
@@ -26,11 +26,10 @@
  * limitations under the License.
  */
 
-package org.citydb.gui.modules.exporter.view.filter;
+package org.citydb.gui.modules.common.filter;
 
 import com.formdev.flatlaf.extras.FlatSVGIcon;
 import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
-import org.citydb.config.Config;
 import org.citydb.config.ConfigUtil;
 import org.citydb.config.geometry.BoundingBox;
 import org.citydb.config.i18n.Language;
@@ -59,13 +58,13 @@ import org.citydb.config.project.query.filter.type.FeatureTypeFilter;
 import org.citydb.config.project.query.simple.SimpleFeatureVersionFilter;
 import org.citydb.config.project.query.simple.SimpleFeatureVersionFilterMode;
 import org.citydb.config.project.query.simple.SimpleSelectionFilter;
+import org.citydb.config.util.ConfigNamespaceFilter;
 import org.citydb.config.util.QueryWrapper;
 import org.citydb.database.connection.DatabaseConnectionPool;
 import org.citydb.database.schema.mapping.FeatureType;
 import org.citydb.database.schema.mapping.SchemaMapping;
 import org.citydb.gui.factory.PopupMenuDecorator;
 import org.citydb.gui.factory.RSyntaxTextAreaHelper;
-import org.citydb.gui.modules.exporter.view.FilterPanel;
 import org.citydb.gui.util.GuiUtil;
 import org.citydb.log.Logger;
 import org.citydb.plugin.extension.view.ViewController;
@@ -103,13 +102,15 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 public class XMLQueryView extends FilterView {
     private final Logger log = Logger.getInstance();
-    private final FilterPanel filterPanel;
     private final ViewController viewController;
     private final SchemaMapping schemaMapping;
     private final DatabaseConnectionPool connectionPool;
+    private final Supplier<QueryConfig> queryConfigSupplier;
+    private final Supplier<ConfigNamespaceFilter> configNamespaceFilterSupplier;
 
     private JPanel component;
     private RSyntaxTextArea xmlText;
@@ -118,10 +119,14 @@ public class XMLQueryView extends FilterView {
     private JButton duplicateButton;
     private JButton validateButton;
 
-    public XMLQueryView(FilterPanel filterPanel, ViewController viewController, Config config) {
-        super(config);
-        this.filterPanel = filterPanel;
+    public XMLQueryView(ViewController viewController,
+                        Supplier<SimpleQuery> simpleQuerySupplier,
+                        Supplier<QueryConfig> queryConfigSupplier,
+                        Supplier<ConfigNamespaceFilter> configNamespaceFilterSupplier) {
+        super(simpleQuerySupplier);
         this.viewController = viewController;
+        this.queryConfigSupplier = queryConfigSupplier;
+        this.configNamespaceFilterSupplier = configNamespaceFilterSupplier;
 
         schemaMapping = ObjectRegistry.getInstance().getSchemaMapping();
         connectionPool = DatabaseConnectionPool.getInstance();
@@ -184,8 +189,7 @@ public class XMLQueryView extends FilterView {
     }
 
     private void setSimpleSettings() {
-        filterPanel.setSimpleQuerySettings();
-        SimpleQuery simpleQuery = config.getExportConfig().getSimpleQuery();
+        SimpleQuery simpleQuery = simpleQuerySupplier.get();
         CityGMLVersion version = Util.toCityGMLVersion(simpleQuery.getVersion());
 
         QueryConfig query = new QueryConfig();
@@ -463,14 +467,22 @@ public class XMLQueryView extends FilterView {
 
     @Override
     public void loadSettings() {
-        QueryConfig query = config.getExportConfig().getQuery();
-        xmlText.setText(marshalQuery(query, config.getNamespaceFilter()));
+        QueryConfig query = queryConfigSupplier.get();
+        xmlText.setText(marshalQuery(query, configNamespaceFilterSupplier.get()));
     }
 
     @Override
     public void setSettings() {
         QueryConfig query = unmarshalQuery();
-        config.getExportConfig().setQuery(query);
+        queryConfigSupplier.get().setTargetSrs(query.getTargetSrs());
+        queryConfigSupplier.get().setFeatureTypeFilter(query.getFeatureTypeFilter());
+        queryConfigSupplier.get().setAppearanceFilter(query.getAppearanceFilter());
+        queryConfigSupplier.get().setCounterFilter(query.getCounterFilter());
+        queryConfigSupplier.get().setLodFilter(query.getLodFilter());
+        queryConfigSupplier.get().setProjectionFilter(query.getProjectionFilter());
+        queryConfigSupplier.get().setSelectionFilter(query.getSelectionFilter());
+        queryConfigSupplier.get().setSorting(query.getSorting());
+        queryConfigSupplier.get().setTiling(query.getTiling());
     }
 
     private boolean isDefaultDatabaseSrs(DatabaseSrs srs) {

--- a/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/XMLQueryView.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/XMLQueryView.java
@@ -58,7 +58,6 @@ import org.citydb.config.project.query.filter.type.FeatureTypeFilter;
 import org.citydb.config.project.query.simple.SimpleFeatureVersionFilter;
 import org.citydb.config.project.query.simple.SimpleFeatureVersionFilterMode;
 import org.citydb.config.project.query.simple.SimpleSelectionFilter;
-import org.citydb.config.util.ConfigNamespaceFilter;
 import org.citydb.config.util.QueryWrapper;
 import org.citydb.database.connection.DatabaseConnectionPool;
 import org.citydb.database.schema.mapping.FeatureType;
@@ -110,7 +109,6 @@ public class XMLQueryView extends FilterView {
     private final SchemaMapping schemaMapping;
     private final DatabaseConnectionPool connectionPool;
     private final Supplier<QueryConfig> queryConfigSupplier;
-    private final Supplier<ConfigNamespaceFilter> configNamespaceFilterSupplier;
 
     private JPanel component;
     private RSyntaxTextArea xmlText;
@@ -121,12 +119,10 @@ public class XMLQueryView extends FilterView {
 
     public XMLQueryView(ViewController viewController,
                         Supplier<SimpleQuery> simpleQuerySupplier,
-                        Supplier<QueryConfig> queryConfigSupplier,
-                        Supplier<ConfigNamespaceFilter> configNamespaceFilterSupplier) {
+                        Supplier<QueryConfig> queryConfigSupplier) {
         super(simpleQuerySupplier);
         this.viewController = viewController;
         this.queryConfigSupplier = queryConfigSupplier;
-        this.configNamespaceFilterSupplier = configNamespaceFilterSupplier;
 
         schemaMapping = ObjectRegistry.getInstance().getSchemaMapping();
         connectionPool = DatabaseConnectionPool.getInstance();
@@ -468,21 +464,13 @@ public class XMLQueryView extends FilterView {
     @Override
     public void loadSettings() {
         QueryConfig query = queryConfigSupplier.get();
-        xmlText.setText(marshalQuery(query, configNamespaceFilterSupplier.get()));
+        xmlText.setText(marshalQuery(query, ObjectRegistry.getInstance().getConfig().getNamespaceFilter()));
     }
 
     @Override
     public void setSettings() {
         QueryConfig query = unmarshalQuery();
-        queryConfigSupplier.get().setTargetSrs(query.getTargetSrs());
-        queryConfigSupplier.get().setFeatureTypeFilter(query.getFeatureTypeFilter());
-        queryConfigSupplier.get().setAppearanceFilter(query.getAppearanceFilter());
-        queryConfigSupplier.get().setCounterFilter(query.getCounterFilter());
-        queryConfigSupplier.get().setLodFilter(query.getLodFilter());
-        queryConfigSupplier.get().setProjectionFilter(query.getProjectionFilter());
-        queryConfigSupplier.get().setSelectionFilter(query.getSelectionFilter());
-        queryConfigSupplier.get().setSorting(query.getSorting());
-        queryConfigSupplier.get().setTiling(query.getTiling());
+        queryConfigSupplier.get().copyFrom(query);
     }
 
     private boolean isDefaultDatabaseSrs(DatabaseSrs srs) {

--- a/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/XMLQueryView.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/XMLQueryView.java
@@ -101,6 +101,7 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public class XMLQueryView extends FilterView {
@@ -109,6 +110,7 @@ public class XMLQueryView extends FilterView {
     private final SchemaMapping schemaMapping;
     private final DatabaseConnectionPool connectionPool;
     private final Supplier<QueryConfig> queryConfigSupplier;
+    private final Consumer<QueryConfig> queryConfigConsumer;
 
     private JPanel component;
     private RSyntaxTextArea xmlText;
@@ -119,10 +121,12 @@ public class XMLQueryView extends FilterView {
 
     public XMLQueryView(ViewController viewController,
                         Supplier<SimpleQuery> simpleQuerySupplier,
-                        Supplier<QueryConfig> queryConfigSupplier) {
+                        Supplier<QueryConfig> queryConfigSupplier,
+                        Consumer<QueryConfig> queryConfigConsumer) {
         super(simpleQuerySupplier);
         this.viewController = viewController;
         this.queryConfigSupplier = queryConfigSupplier;
+        this.queryConfigConsumer = queryConfigConsumer;
 
         schemaMapping = ObjectRegistry.getInstance().getSchemaMapping();
         connectionPool = DatabaseConnectionPool.getInstance();
@@ -470,7 +474,7 @@ public class XMLQueryView extends FilterView {
     @Override
     public void setSettings() {
         QueryConfig query = unmarshalQuery();
-        queryConfigSupplier.get().copyFrom(query);
+        queryConfigConsumer.accept(query);
     }
 
     private boolean isDefaultDatabaseSrs(DatabaseSrs srs) {

--- a/impexp-client/src/main/java/org/citydb/gui/modules/exporter/view/FilterPanel.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/exporter/view/FilterPanel.java
@@ -194,8 +194,7 @@ public class FilterPanel extends JPanel implements EventHandler {
 		JPanel guiPanel = new JPanel();
 		xmlQuery = new XMLQueryView(viewController,
 				() -> config.getExportConfig().getSimpleQuery(),
-				() -> config.getExportConfig().getQuery(),
-				() -> config.getNamespaceFilter());
+				() -> config.getExportConfig().getQuery());
 		mainPanel.add(guiPanel, "simple");
 		mainPanel.add(xmlQuery.getViewComponent(), "advanced");
 

--- a/impexp-client/src/main/java/org/citydb/gui/modules/exporter/view/FilterPanel.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/exporter/view/FilterPanel.java
@@ -194,7 +194,8 @@ public class FilterPanel extends JPanel implements EventHandler {
 		JPanel guiPanel = new JPanel();
 		xmlQuery = new XMLQueryView(viewController,
 				() -> config.getExportConfig().getSimpleQuery(),
-				() -> config.getExportConfig().getQuery());
+				() -> config.getExportConfig().getQuery(),
+				(query) -> config.getExportConfig().setQuery(query));
 		mainPanel.add(guiPanel, "simple");
 		mainPanel.add(xmlQuery.getViewComponent(), "advanced");
 

--- a/impexp-config/src/main/java/org/citydb/config/project/query/QueryConfig.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/QueryConfig.java
@@ -230,4 +230,18 @@ public class QueryConfig {
         return localProperties != null && localProperties.containsKey(name);
     }
 
+    public void copyFrom(QueryConfig other) {
+        targetSrs = other.targetSrs;
+        targetSrid = other.targetSrid;
+        targetSrsName = other.targetSrsName;
+        featureTypeFilter = other.featureTypeFilter;
+        appearanceFilter = other.appearanceFilter;
+        counterFilter = other.counterFilter;
+        lodFilter = other.lodFilter;
+        projectionFilter = other.projectionFilter;
+        selectionFilter = other.selectionFilter;
+        sorting = other.sorting;
+        tiling = other.tiling;
+        localProperties = other.localProperties;
+    }
 }


### PR DESCRIPTION
This PR uncouples the FilterView APIs from the exporter package, so that the APIs can be used in external modules e.g. plugins. 