### PR TITLE
Resolve deprecated transformBoundingBox method

### DIFF
--- a/impexp-client/src/main/java/org/citydb/gui/components/mapviewer/validation/BoundingBoxValidator.java
+++ b/impexp-client/src/main/java/org/citydb/gui/components/mapviewer/validation/BoundingBoxValidator.java
@@ -215,7 +215,7 @@ public class BoundingBoxValidator {
 					}
 				}
 				
-				bbox.copyFrom(dbController.getActiveDatabaseAdapter().getUtil().transformBoundingBox(bbox, bbox.getSrs(), wgs84));
+				bbox.copyFrom(dbController.getActiveDatabaseAdapter().getUtil().transform2D(bbox, bbox.getSrs(), wgs84));
 				SwingUtilities.invokeLater(transform::dispose);
 				return validate(bbox);
 			} else

--- a/impexp-client/src/main/java/org/citydb/gui/modules/database/operations/BoundingBoxOperation.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/database/operations/BoundingBoxOperation.java
@@ -272,7 +272,7 @@ public class BoundingBoxOperation extends DatabaseOperationView {
 
 						if (targetSrs.isSupported() && targetSrs.getSrid() != dbSrs.getSrid()) {
 							try {
-								bbox = dbConnectionPool.getActiveDatabaseAdapter().getUtil().transformBoundingBox(bbox, dbSrs, targetSrs);
+								bbox = dbConnectionPool.getActiveDatabaseAdapter().getUtil().transform2D(bbox, dbSrs, targetSrs);
 							} catch (SQLException e) {
 								//
 							}					
@@ -373,7 +373,7 @@ public class BoundingBoxOperation extends DatabaseOperationView {
 
 						if (targetSrs.isSupported() && targetSrs.getSrid() != dbSrs.getSrid()) {
 							try {
-								bbox = dbConnectionPool.getActiveDatabaseAdapter().getUtil().transformBoundingBox(bbox, dbSrs, targetSrs);
+								bbox = dbConnectionPool.getActiveDatabaseAdapter().getUtil().transform2D(bbox, dbSrs, targetSrs);
 							} catch (SQLException e) {
 								//
 							}					

--- a/impexp-config/src/main/java/org/citydb/config/geometry/GeometryObject.java
+++ b/impexp-config/src/main/java/org/citydb/config/geometry/GeometryObject.java
@@ -291,16 +291,20 @@ public class GeometryObject {
     }
 
     public GeometryObject toEnvelope() {
-        if (geometryType == GeometryType.ENVELOPE) {
-            return this;
-        }
-
         GeometryObject envelope = new GeometryObject(GeometryType.ENVELOPE, dimension, srid);
         envelope.elementTypes = new ElementType[]{ElementType.BOUNDING_RECTANGLE};
         envelope.coordinates = new double[1][];
 
-        if (geometryType != GeometryType.POINT) {
-            double[] bbox = dimension == 2 ? new double[]{Double.MAX_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE} :
+        if (geometryType == GeometryType.ENVELOPE) {
+            envelope.coordinates[0] = new double[coordinates[0].length];
+            System.arraycopy(coordinates[0], 0, envelope.coordinates[0], 0, coordinates[0].length);
+        } else if (geometryType == GeometryType.POINT) {
+            envelope.coordinates[0] = dimension == 2 ?
+                    new double[]{coordinates[0][0], coordinates[0][1], coordinates[0][0], coordinates[0][1]} :
+                    new double[]{coordinates[0][0], coordinates[0][1], coordinates[0][2], coordinates[0][0], coordinates[0][1], coordinates[0][2]};
+        } else {
+            double[] bbox = dimension == 2 ?
+                    new double[]{Double.MAX_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE} :
                     new double[]{Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE};
 
             for (int i = 0; i < elementTypes.length; i++) {
@@ -329,12 +333,8 @@ public class GeometryObject {
             }
 
             envelope.coordinates[0] = bbox;
-        } else {
-            envelope.coordinates[0] = dimension == 2 ? new double[]{coordinates[0][0], coordinates[0][1], coordinates[0][0], coordinates[0][1]} :
-                    new double[]{coordinates[0][0], coordinates[0][1], coordinates[0][2], coordinates[0][0], coordinates[0][1], coordinates[0][2]};
         }
 
         return envelope;
     }
-
 }

--- a/impexp-config/src/main/java/org/citydb/config/geometry/GeometryObject.java
+++ b/impexp-config/src/main/java/org/citydb/config/geometry/GeometryObject.java
@@ -291,6 +291,10 @@ public class GeometryObject {
     }
 
     public GeometryObject toEnvelope() {
+        if (geometryType == GeometryType.ENVELOPE) {
+            return this;
+        }
+
         GeometryObject envelope = new GeometryObject(GeometryType.ENVELOPE, dimension, srid);
         envelope.elementTypes = new ElementType[]{ElementType.BOUNDING_RECTANGLE};
         envelope.coordinates = new double[1][];

--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/DBSplitter.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/DBSplitter.java
@@ -545,8 +545,9 @@ public class DBSplitter {
 	}
 
 	private BoundingBox getSpatialExtent(GeometryObject extentObj) throws SQLException {
-		if (internalConfig.isTransformCoordinates())
-			extentObj = databaseAdapter.getUtil().transform(extentObj, query.getTargetSrs());
+		if (internalConfig.isTransformCoordinates()) {
+			extentObj = databaseAdapter.getUtil().transform(extentObj, query.getTargetSrs()).toEnvelope();
+		}
 
 		double[] coordinates = extentObj.getCoordinates(0);
 		return new BoundingBox(

--- a/impexp-core/src/main/java/org/citydb/citygml/importer/filter/selection/spatial/SimpleBBOXFilter.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/importer/filter/selection/spatial/SimpleBBOXFilter.java
@@ -72,8 +72,6 @@ public class SimpleBBOXFilter {
 		GeometryObject transformedBbox = null;
 		try {
 			transformedBbox = databaseAdapter.getUtil().transform(extentObj, targetSrs);
-			if (transformedBbox == null)
-				throw new FilterException("Failed to transform tiling extent to SRS " + targetSrs.getDescription() + ".");
 		} catch (SQLException e) {
 			throw new FilterException("Failed to transform tiling extent to SRS " + targetSrs.getDescription() + ".", e);
 		}

--- a/impexp-core/src/main/java/org/citydb/citygml/importer/filter/selection/spatial/SimpleBBOXFilter.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/importer/filter/selection/spatial/SimpleBBOXFilter.java
@@ -28,8 +28,6 @@
 package org.citydb.citygml.importer.filter.selection.spatial;
 
 import org.citydb.config.geometry.BoundingBox;
-import org.citydb.config.geometry.GeometryObject;
-import org.citydb.config.geometry.Position;
 import org.citydb.config.project.database.DatabaseSrs;
 import org.citydb.config.project.importer.SimpleBBOXMode;
 import org.citydb.config.project.importer.SimpleBBOXOperator;
@@ -59,30 +57,12 @@ public class SimpleBBOXFilter {
 		if (targetSrs.getSrid() == bboxSrs.getSrid())
 			return;
 
-		// convert extent into polygon
-		GeometryObject extentObj = GeometryObject.createPolygon(new double[]{
-				bbox.getLowerCorner().getX(), bbox.getLowerCorner().getY(),
-				bbox.getUpperCorner().getX(), bbox.getLowerCorner().getY(),
-				bbox.getUpperCorner().getX(), bbox.getUpperCorner().getY(),
-				bbox.getLowerCorner().getX(), bbox.getUpperCorner().getY(),
-				bbox.getLowerCorner().getX(), bbox.getLowerCorner().getY(),
-		}, 2, bboxSrs.getSrid());
-
-		// transform polygon to new srs
-		GeometryObject transformedBbox = null;
 		try {
-			transformedBbox = databaseAdapter.getUtil().transform(extentObj, targetSrs);
+			bbox = databaseAdapter.getUtil().transform2D(bbox, bboxSrs, targetSrs);
 		} catch (SQLException e) {
-			throw new FilterException("Failed to transform tiling extent to SRS " + targetSrs.getDescription() + ".", e);
+			throw new FilterException("Failed to transform bounding box to SRS " + targetSrs.getDescription() + ".", e);
 		}
-
-		// create new extent from transformed polygon
-		double[] coordinates = transformedBbox.getCoordinates(0);		
-		bbox = new BoundingBox(
-				new Position(Math.min(coordinates[0], coordinates[6]), Math.min(coordinates[1], coordinates[3])),
-				new Position(Math.max(coordinates[2], coordinates[4]), Math.max(coordinates[5], coordinates[7])),
-				targetSrs
-				);	}
+	}
 
 	public boolean isSatisfiedBy(AbstractFeature feature) throws FilterException {
 		if (!feature.isSetBoundedBy() || !feature.getBoundedBy().isSetEnvelope())

--- a/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
+++ b/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
@@ -351,10 +351,32 @@ public abstract class AbstractUtilAdapter {
         return isIndexed;
     }
 
-    @Deprecated
-    public BoundingBox transformBoundingBox(BoundingBox bbox, DatabaseSrs sourceSrs, DatabaseSrs targetSrs) throws SQLException {
-        try (Connection conn = databaseAdapter.connectionPool.getConnection()) {
-            return transformBoundingBox(bbox, sourceSrs, targetSrs, conn);
+    public BoundingBox transform2D(BoundingBox bbox, DatabaseSrs sourceSrs, DatabaseSrs targetSrs) throws SQLException {
+        return transform(bbox, 2, sourceSrs, targetSrs);
+    }
+
+    public BoundingBox transform(BoundingBox bbox, DatabaseSrs sourceSrs, DatabaseSrs targetSrs) throws SQLException {
+        return transform(bbox, bbox.is3D() ? 3 : 2, sourceSrs, targetSrs);
+    }
+
+    public BoundingBox transform(BoundingBox bbox, int dimension, DatabaseSrs sourceSrs, DatabaseSrs targetSrs) throws SQLException {
+        GeometryObject geometryObject = GeometryObject.createEnvelope(bbox, dimension, sourceSrs.getSrid());
+        GeometryObject transformed = transform(geometryObject, targetSrs);
+
+        // create new bounding box from transformed polygon
+        double[] coordinates = transformed.getCoordinates(0);
+        if (dimension == 2) {
+            return new BoundingBox(
+                    new Position(coordinates[0], coordinates[1]),
+                    new Position(coordinates[2], coordinates[3]),
+                    targetSrs
+            );
+        } else {
+            return new BoundingBox(
+                    new Position(coordinates[0], coordinates[1], coordinates[2]),
+                    new Position(coordinates[3], coordinates[4], coordinates[5]),
+                    targetSrs
+            );
         }
     }
 

--- a/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
+++ b/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
@@ -29,7 +29,6 @@ package org.citydb.database.adapter;
 
 import org.citydb.config.geometry.BoundingBox;
 import org.citydb.config.geometry.GeometryObject;
-import org.citydb.config.geometry.GeometryType;
 import org.citydb.config.geometry.Position;
 import org.citydb.config.project.database.DatabaseSrs;
 import org.citydb.config.project.database.Workspace;
@@ -361,9 +360,9 @@ public abstract class AbstractUtilAdapter {
 
     public BoundingBox transform(BoundingBox bbox, int dimension, DatabaseSrs sourceSrs, DatabaseSrs targetSrs) throws SQLException {
         GeometryObject geometryObject = GeometryObject.createEnvelope(bbox, dimension, sourceSrs.getSrid());
-        GeometryObject transformed = transform(geometryObject, targetSrs);
+        GeometryObject transformed = transform(geometryObject, targetSrs).toEnvelope();
 
-        // create new bounding box from transformed polygon
+        // create new bounding box from transformed envelope
         double[] coordinates = transformed.getCoordinates(0);
         if (dimension == 2) {
             return new BoundingBox(
@@ -382,12 +381,7 @@ public abstract class AbstractUtilAdapter {
 
     public GeometryObject transform(GeometryObject geometry, DatabaseSrs targetSrs) throws SQLException {
         try (Connection conn = databaseAdapter.connectionPool.getConnection()) {
-            GeometryObject transformed = transform(geometry, targetSrs, conn);
-            if (geometry.getGeometryType() == GeometryType.ENVELOPE && transformed != null) {
-                transformed = transformed.toEnvelope();
-            }
-
-            return transformed;
+            return transform(geometry, targetSrs, conn);
         }
     }
 

--- a/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
+++ b/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
@@ -381,7 +381,13 @@ public abstract class AbstractUtilAdapter {
 
     public GeometryObject transform(GeometryObject geometry, DatabaseSrs targetSrs) throws SQLException {
         try (Connection conn = databaseAdapter.connectionPool.getConnection()) {
-            return transform(geometry, targetSrs, conn);
+            GeometryObject transformed = transform(geometry, targetSrs, conn);
+            if (transformed == null) {
+                throw new SQLException("Failed to transform " + geometry.getGeometryType() + " geometry from " +
+                        "source SRID " + geometry.getSrid() + " to target SRID " + targetSrs.getSrid() + ".");
+            }
+
+            return transformed;
         }
     }
 

--- a/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
+++ b/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
@@ -87,7 +87,6 @@ public abstract class AbstractUtilAdapter {
     protected abstract String[] createDatabaseReport(String schema, Connection connection) throws SQLException;
     protected abstract BoundingBox calcBoundingBox(String schema, List<Integer> classIds, Connection connection) throws SQLException;
     protected abstract BoundingBox createBoundingBoxes(List<Integer> classIds, boolean onlyIfNull, Connection connection) throws SQLException;
-    @Deprecated protected abstract BoundingBox transformBoundingBox(BoundingBox bbox, DatabaseSrs sourceSrs, DatabaseSrs targetSrs, Connection connection) throws SQLException;
     protected abstract GeometryObject transform(GeometryObject geometry, DatabaseSrs targetSrs, Connection connection) throws SQLException;
     protected abstract int get2DSrid(DatabaseSrs srs, Connection connection) throws SQLException;
     protected abstract IndexStatusInfo manageIndexes(String operation, IndexType type, String schema, Connection connection) throws SQLException;

--- a/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
+++ b/impexp-core/src/main/java/org/citydb/database/adapter/AbstractUtilAdapter.java
@@ -218,7 +218,7 @@ public abstract class AbstractUtilAdapter {
 
                         DatabaseSrs targetSrs = query.getTargetSrs();
                         if (targetSrs != null && extent.getSrid() != targetSrs.getSrid()) {
-                            extent = transform(extent, targetSrs);
+                            extent = transform(extent, targetSrs).toEnvelope();
                         }
 
                         double[] coordinates = extent.getCoordinates(0);

--- a/impexp-core/src/main/java/org/citydb/database/adapter/postgis/UtilAdapter.java
+++ b/impexp-core/src/main/java/org/citydb/database/adapter/postgis/UtilAdapter.java
@@ -337,41 +337,6 @@ public class UtilAdapter extends AbstractUtilAdapter {
     }
 
     @Override
-    protected BoundingBox transformBoundingBox(BoundingBox bbox, DatabaseSrs sourceSrs, DatabaseSrs targetSrs, Connection connection) throws SQLException {
-        BoundingBox result = new BoundingBox(bbox);
-        int sourceSrid = sourceSrs.getSrid();
-        int targetSrid = targetSrs.getSrid();
-
-        StringBuilder boxGeom = new StringBuilder()
-                .append("SRID=").append(sourceSrid).append(";POLYGON((")
-                .append(bbox.getLowerCorner().getX()).append(" ").append(bbox.getLowerCorner().getY()).append(",")
-                .append(bbox.getLowerCorner().getX()).append(" ").append(bbox.getUpperCorner().getY()).append(",")
-                .append(bbox.getUpperCorner().getX()).append(" ").append(bbox.getUpperCorner().getY()).append(",")
-                .append(bbox.getUpperCorner().getX()).append(" ").append(bbox.getLowerCorner().getY()).append(",")
-                .append(bbox.getLowerCorner().getX()).append(" ").append(bbox.getLowerCorner().getY()).append("))");
-
-        try (PreparedStatement psQuery = connection.prepareStatement("select ST_Transform(ST_GeomFromEWKT(?), " + targetSrid + ')')) {
-            psQuery.setString(1, boxGeom.toString());
-
-            try (ResultSet rs = psQuery.executeQuery()) {
-                if (rs.next()) {
-                    PGgeometry pgGeom = (PGgeometry) rs.getObject(1);
-                    if (!rs.wasNull() && pgGeom != null) {
-                        Geometry geom = pgGeom.getGeometry();
-                        result.getLowerCorner().setX(geom.getPoint(0).x);
-                        result.getLowerCorner().setY(geom.getPoint(0).y);
-                        result.getUpperCorner().setX(geom.getPoint(2).x);
-                        result.getUpperCorner().setY(geom.getPoint(2).y);
-                        result.setSrs(targetSrs);
-                    }
-                }
-            }
-
-            return result;
-        }
-    }
-
-    @Override
     protected GeometryObject transform(GeometryObject geometry, DatabaseSrs targetSrs, Connection connection) throws SQLException {
         Object unconverted = databaseAdapter.getGeometryConverter().getDatabaseObject(geometry, connection);
         if (unconverted != null) {

--- a/impexp-core/src/main/java/org/citydb/query/builder/config/TilingFilterBuilder.java
+++ b/impexp-core/src/main/java/org/citydb/query/builder/config/TilingFilterBuilder.java
@@ -61,7 +61,7 @@ public class TilingFilterBuilder {
 					DatabaseSrs extentSrs = extent.isSetSrs() ? extent.getSrs() : databaseAdapter.getConnectionMetaData().getReferenceSystem();			
 					if (extentSrs.getSrid() != dbSrs.getSrid()) {
 						try {
-							extent = databaseAdapter.getUtil().transformBoundingBox(extent, extent.getSrs(), dbSrs);
+							extent = databaseAdapter.getUtil().transform2D(extent, extent.getSrs(), dbSrs);
 						} catch (SQLException e) {
 							throw new QueryBuildException("Failed to automatically calculate tile size.", e);
 						}

--- a/impexp-core/src/main/java/org/citydb/query/filter/tiling/Tile.java
+++ b/impexp-core/src/main/java/org/citydb/query/filter/tiling/Tile.java
@@ -86,8 +86,6 @@ public class Tile {
 			GeometryObject transformedExtent = null;
 			try {
 				transformedExtent = databaseAdapter.getUtil().transform(extentObj, dbSrs);
-				if (transformedExtent == null)
-					throw new FilterException("Failed to transform tiling extent to SRS " + dbSrs.getDescription() + ".");
 			} catch (SQLException e) {
 				throw new FilterException("Failed to transform tiling extent to SRS " + dbSrs.getDescription() + ".", e);
 			}
@@ -124,9 +122,6 @@ public class Tile {
 		if (pointSrs.getSrid() != extentSrs.getSrid()) {			
 			try {
 				GeometryObject transformed = databaseAdapter.getUtil().transform(GeometryObject.createPoint(new double[]{point.getX(), point.getY()}, 2, pointSrs.getSrid()), extentSrs);
-				if (transformed == null)
-					throw new FilterException("Failed to convert input geometry to tile SRS.");
-					
 				pos = new Position(transformed.getCoordinates(0)[0], transformed.getCoordinates(0)[1]);
 			} catch (SQLException e) {
 				throw new FilterException("Failed to convert input geometry to tile SRS.", e);

--- a/impexp-core/src/main/java/org/citydb/query/filter/tiling/Tiling.java
+++ b/impexp-core/src/main/java/org/citydb/query/filter/tiling/Tiling.java
@@ -111,9 +111,6 @@ public class Tiling {
 		GeometryObject transformedExtent;
 		try {
 			transformedExtent = databaseAdapter.getUtil().transform(extentObj, targetSrs);
-			if (transformedExtent == null) {
-				throw new FilterException("Failed to transform tiling extent to SRS " + targetSrs.getDescription() + ".");
-			}
 		} catch (SQLException e) {
 			throw new FilterException("Failed to transform tiling extent to SRS " + targetSrs.getDescription() + ".", e);
 		}

--- a/impexp-core/src/main/java/org/citydb/query/filter/tiling/Tiling.java
+++ b/impexp-core/src/main/java/org/citydb/query/filter/tiling/Tiling.java
@@ -28,7 +28,6 @@
 package org.citydb.query.filter.tiling;
 
 import org.citydb.config.geometry.BoundingBox;
-import org.citydb.config.geometry.GeometryObject;
 import org.citydb.config.geometry.Position;
 import org.citydb.config.project.database.DatabaseSrs;
 import org.citydb.database.adapter.AbstractDatabaseAdapter;
@@ -98,30 +97,11 @@ public class Tiling {
 			return;
 		}
 
-		// convert extent into polygon
-		GeometryObject extentObj = GeometryObject.createPolygon(new double[]{
-				extent.getLowerCorner().getX(), extent.getLowerCorner().getY(),
-				extent.getUpperCorner().getX(), extent.getLowerCorner().getY(),
-				extent.getUpperCorner().getX(), extent.getUpperCorner().getY(),
-				extent.getLowerCorner().getX(), extent.getUpperCorner().getY(),
-				extent.getLowerCorner().getX(), extent.getLowerCorner().getY(),
-		}, 2, extentSrs.getSrid());
-
-		// transform polygon to new srs
-		GeometryObject transformedExtent;
 		try {
-			transformedExtent = databaseAdapter.getUtil().transform(extentObj, targetSrs);
+			extent = databaseAdapter.getUtil().transform2D(extent, extentSrs, targetSrs);
 		} catch (SQLException e) {
 			throw new FilterException("Failed to transform tiling extent to SRS " + targetSrs.getDescription() + ".", e);
 		}
-
-		// create new extent from transformed polygon
-		double[] coordinates = transformedExtent.getCoordinates(0);
-		extent = new BoundingBox(
-				new Position(Math.min(coordinates[0], coordinates[6]), Math.min(coordinates[1], coordinates[3])),
-				new Position(Math.max(coordinates[2], coordinates[4]), Math.max(coordinates[5], coordinates[7])),
-				targetSrs
-		);
 		
 		// adapt tiling scheme
 		calculateTilingScheme();

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlGenericObject.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlGenericObject.java
@@ -2915,9 +2915,11 @@ public abstract class KmlGenericObject {
 	}
 
 	protected GeometryObject convertToWGS84(GeometryObject geomObj) throws SQLException {
-		GeometryObject convertedGeomObj = null;
+		GeometryObject convertedGeomObj;
 		try {
-			DatabaseSrs targetSrs = dbSrs.is3D() ? databaseAdapter.getUtil().getWGS843D() : DatabaseConfig.PREDEFINED_SRS.get(DatabaseConfig.PredefinedSrsName.WGS84_2D);
+			DatabaseSrs targetSrs = dbSrs.is3D() ?
+					databaseAdapter.getUtil().getWGS843D() :
+					DatabaseConfig.PREDEFINED_SRS.get(DatabaseConfig.PredefinedSrsName.WGS84_2D);
 			convertedGeomObj = databaseAdapter.getUtil().transform(geomObj, targetSrs);
 		} catch (SQLException e) {
 			log.warn("SQL exception when converting geometry to WGS84.", e);

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlSplitter.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlSplitter.java
@@ -239,23 +239,13 @@ public class KmlSplitter {
 		}
 	}
 
-	private double[] getEnvelopeInWGS84(GeometryObject envelope) throws SQLException {
+	private BoundingBox getEnvelopeInWGS84(GeometryObject envelope) throws SQLException {
 		if (envelope == null)
 			return null;
 
 		double[] coordinates = envelope.getCoordinates(0);
 		BoundingBox bbox = new BoundingBox(new Position(coordinates[0], coordinates[1]), new Position(coordinates[3], coordinates[4]));
-		BoundingBox wgs84 = databaseAdapter.getUtil().transformBoundingBox(bbox, dbSrs, DatabaseConfig.PREDEFINED_SRS.get(PredefinedSrsName.WGS84_2D));
-
-		double[] result = new double[6];
-		result[0] = wgs84.getLowerCorner().getX();
-		result[1] = wgs84.getLowerCorner().getY();
-		result[2] = 0;
-		result[3] = wgs84.getUpperCorner().getX();
-		result[4] = wgs84.getUpperCorner().getY();
-		result[5] = 0;
-
-		return result;
+		return databaseAdapter.getUtil().transform2D(bbox, dbSrs, DatabaseConfig.PREDEFINED_SRS.get(PredefinedSrsName.WGS84_2D));
 	}
 
 }

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/util/CityObject4JSON.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/util/CityObject4JSON.java
@@ -27,15 +27,12 @@
  */
 package org.citydb.modules.kml.util;
 
-public class CityObject4JSON {
+import org.citydb.config.geometry.BoundingBox;
 
+public class CityObject4JSON {
 	private String gmlId;
 
-	private double envelopeXmin;
-	private double envelopeXmax;
-	private double envelopeYmin;
-	private double envelopeYmax;
-
+	private BoundingBox envelope;
 	private int tileRow = 0;
 	private int tileColumn = 0;
 
@@ -45,72 +42,33 @@ public class CityObject4JSON {
 
 	@Override
 	public String toString() {
-
-		return "\t\"" + gmlId + "\": {" +
-				"\n\t\"envelope\": [" + envelopeXmin + ", " + envelopeYmin + ", " + envelopeXmax + ", " + envelopeYmax +
-				"],\n\t\"tile\": [" + tileRow + ", " + tileColumn + "]}";
-		/*
-		return "\n\t\"envelope\": [" + envelopeXmin + ", " + envelopeYmin + ", " + envelopeXmax + ", " + envelopeYmax +
-		   	   "],\n\t\"tile\": [" + tileRow + ", " + tileColumn + "]}";
-		 */
+		return " \"" + gmlId + "\": {" +
+				"\"envelope\": [" + getEnvelopeXmin() + "," + getEnvelopeYmin() + "," + getEnvelopeXmax() + "," + getEnvelopeYmax() + "]," +
+				"\"tile\": [" + tileRow + "," + tileColumn + "]}";
 	}
 
-	/*
-	@Override
-	public boolean equals(Object obj) {
-
-		try {
-			CityObject4JSON cityObject4Json = (CityObject4JSON) obj;
-			return this.gmlId.equals(cityObject4Json.getGmlId());
-		}
-		catch (Exception e) {}
-		return false;
+	public String getGmlId() {
+		return gmlId;
 	}
 
-	@Override
-	public int hashCode(){
-		return this.gmlId.hashCode();
-	}
-	 */
-
-	public void setEnvelope (double[] ordinatesArray) {
-		if (ordinatesArray == null) return;
-		envelopeXmin = ordinatesArray[0];
-		envelopeYmin = ordinatesArray[1];
-		envelopeXmax = ordinatesArray[3];
-		envelopeYmax = ordinatesArray[4];
-	}
-
-	public void setEnvelopeXmin(double envelopeXmin) {
-		this.envelopeXmin = envelopeXmin;
+	public void setEnvelope(BoundingBox envelope) {
+		this.envelope = envelope;
 	}
 
 	public double getEnvelopeXmin() {
-		return envelopeXmin;
-	}
-
-	public void setEnvelopeXmax(double envelopeXmax) {
-		this.envelopeXmax = envelopeXmax;
+		return envelope != null ? envelope.getLowerCorner().getX() : 0;
 	}
 
 	public double getEnvelopeXmax() {
-		return envelopeXmax;
-	}
-
-	public void setEnvelopeYmin(double envelopeYmin) {
-		this.envelopeYmin = envelopeYmin;
+		return envelope != null ? envelope.getUpperCorner().getX() : 0;
 	}
 
 	public double getEnvelopeYmin() {
-		return envelopeYmin;
-	}
-
-	public void setEnvelopeYmax(double envelopeYmax) {
-		this.envelopeYmax = envelopeYmax;
+		return envelope != null ? envelope.getLowerCorner().getY() : 0;
 	}
 
 	public double getEnvelopeYmax() {
-		return envelopeYmax;
+		return envelope != null ? envelope.getUpperCorner().getY() : 0;
 	}
 
 	public void setTileRow(int tileRow) {
@@ -128,9 +86,4 @@ public class CityObject4JSON {
 	public int getTileColumn() {
 		return tileColumn;
 	}
-	/*
-	public String getGmlId() {
-		return gmlId;
-	}
-	 */
 }


### PR DESCRIPTION
This PR solves #154

* Removed deprecated `transformBoundingBox` method
* Harmonized the transformation of bounding boxes: 1) the bounding box is converted into a polygon, 2) the polygon is transformed, 3) the extent of the transformed polygon is returned as new bounding box.