### PR TITLE
Improve export performance of local geometry XLinks

### DIFF
--- a/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/DBSurfaceGeometry.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/exporter/database/content/DBSurfaceGeometry.java
@@ -33,6 +33,7 @@ import org.citydb.citygml.exporter.util.GeometrySetter;
 import org.citydb.citygml.exporter.util.GeometrySetterHandler;
 import org.citydb.config.geometry.GeometryObject;
 import org.citydb.database.schema.TableEnum;
+import org.citydb.database.schema.XlinkType;
 import org.citydb.sqlbuilder.expression.LiteralSelectExpression;
 import org.citydb.sqlbuilder.expression.PlaceHolder;
 import org.citydb.sqlbuilder.schema.Table;
@@ -257,7 +258,7 @@ public class DBSurfaceGeometry implements DBExporter, SurfaceGeometryExporter {
 		geomNode.isSolid = rs.getBoolean(4);
 		geomNode.isComposite = rs.getBoolean(5);
 		geomNode.isTriangulated = rs.getBoolean(6);
-		geomNode.isXlink = rs.getBoolean(7);
+		geomNode.isXlink = rs.getInt(7);
 		geomNode.isReverse = rs.getBoolean(8);
 
 		GeometryObject geometry = null;
@@ -315,16 +316,16 @@ public class DBSurfaceGeometry implements DBExporter, SurfaceGeometryExporter {
 		}
 
 		// check for xlinks
-		if (geomNode.gmlId != null && geomNode.isXlink) {
+		if (geomNode.gmlId != null && geomNode.isXlink > 0) {
 			if (useXLink) {
-				if (exporter.lookupAndPutGeometryUID(geomNode.gmlId, geomNode.id)) {
+				if (exporter.lookupAndPutGeometryUID(geomNode.gmlId, geomNode.id, geomNode.isXlink == XlinkType.LOCAL.value())) {
 					// check whether we have to embrace the geometry with an orientableSurface
 					return geomNode.isReverse != isSetOrientableSurface ?
 							new SurfaceGeometry(reverseSurface("#" + geomNode.gmlId)) :
 							new SurfaceGeometry("#" + geomNode.gmlId, surfaceGeometryType);
 				}
 			} else {
-				geomNode.isXlink = false;
+				geomNode.isXlink = XlinkType.NONE.value();
 				String gmlId = DefaultGMLIdManager.getInstance().generateUUID(gmlIdPrefix);
 				if (appendOldGmlId)
 					gmlId = gmlId + "-" + geomNode.gmlId;
@@ -600,7 +601,7 @@ public class DBSurfaceGeometry implements DBExporter, SurfaceGeometryExporter {
 		boolean isSolid;
 		boolean isComposite;
 		boolean isTriangulated;
-		boolean isXlink;
+		int isXlink;
 		boolean isReverse;
 		GeometryObject geometry;
 		List<GeometryNode> childNodes;

--- a/impexp-core/src/main/java/org/citydb/database/schema/XlinkType.java
+++ b/impexp-core/src/main/java/org/citydb/database/schema/XlinkType.java
@@ -1,0 +1,50 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * http://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2020
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.gis.bgu.tum.de/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * virtualcitySYSTEMS GmbH, Berlin <http://www.virtualcitysystems.de/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.database.schema;
+
+public enum XlinkType {
+    NONE,
+    GLOBAL,
+    LOCAL;
+
+    public int value() {
+        return ordinal();
+    }
+
+    public static XlinkType fromValue(int value) {
+        switch (value) {
+            case 1:
+                return GLOBAL;
+            case 2:
+                return LOCAL;
+            default:
+                return NONE;
+        }
+    }
+}

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlGenericObject.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/database/KmlGenericObject.java
@@ -1569,7 +1569,7 @@ public abstract class KmlGenericObject {
 				while (rs.next()) {
 					// skip duplicate geometries
 					String gmlId = rs.getString("gmlid");
-					boolean isXlink = rs.getBoolean("is_xlink");
+					boolean isXlink = rs.getInt("is_xlink") > 0;
 					if (isXlink && gmlId != null && !exportedGmlIds.add(gmlId))
 						continue;
 
@@ -2195,7 +2195,7 @@ public abstract class KmlGenericObject {
 					if (previousSurfaceId != surfaceId) {
 						// skip duplicate geometries
 						String gmlId = rs.getString("gmlid");
-						boolean isXlink = rs.getBoolean("is_xlink");
+						boolean isXlink = rs.getInt("is_xlink") > 0;
 						if (isXlink && gmlId != null && !exportedGmlIds.add(gmlId))
 							continue;
 
@@ -2480,7 +2480,7 @@ public abstract class KmlGenericObject {
 				while (rs.next()) {
 					// skip duplicate geometries
 					String gmlId = rs.getString("gmlid");
-					boolean isXlink = rs.getBoolean("is_xlink");
+					boolean isXlink = rs.getInt("is_xlink") > 0;
 					if (isXlink && gmlId != null && !exportedGmlIds.add(gmlId))
 						continue;
 


### PR DESCRIPTION
The `IS_XLINK` column of `SURFACE_GEOMETRY` carries the value `1` if the surface is reused by another geometry and `0` otherwise. When exporting to CityGML, the exporter makes use of this information for setting XLinks in the output dataset. If it comes across a surface for which `IS_XLINK=1`, it checks its cache whether the surface has already been exported and, if so, creates an XLink. Otherwise, the surface is put on the cache. To avoid memory issues, the cache can only hold a predefined number of surfaces in main memory. If this number is reached, the cache is drained to either the database or a local file-based storage. After the cache has been drained, every further lookup requires checking the main memory and, additionally, the database or the local storage. This significantly slows down the export performance.

Most (or all) XLinks in typical CityGML datasets point to geometries within the same top-level feature (mostly from a solid geometry to a boundary surface). Since the exporter works on top-level features, such "local" XLinks can be completely resolved in main memory. Only XLinks across top-level features require a "global" cache as described above. The problem is that the exporter cannot tell the difference between a "local" and a "global" XLink based on the current values of the `IS_XLINK` column.

For this reason, this PR proposes to store one more value in the `IS_XLINK` column of `SURFACE_GEOMETRY` and to slightly change the meaning of the values:
- `0`: The surface is not reused by another geometry
- `1`: The surface is reused by a geometry of another top-level feature ("global")
- `2`: The surface is reused by a geometry within the same top-level feature ("local")

The importer and exporter classes have been adapted accordingly in this PR. Thus, the importer correctly sets the `IS_XLINK` value for local and global XLinks, and the CityGML exporter now only uses a global cache for global XLinks. For typical CityGML datasets, this means that no global cache is required at all, which substantially improves the export performance.

Note that this PR might have an impact on existing implementations because the current 3DCityDB specification only talks about storing the values `0` and `1` in the `IS_XLINK` column. The Importer/Exporter remains backwards-compatible though. It can still correctly export from existing 3DCityDBs that only use `0` and `1` for `IS_XLINK` - there is simply no performance benefit in this case. Consequently, to benefit from the changes in this PR, you must either set up a new 3DCityDB instance and import your CityGML with the new importer, or you manually change the `IS_XLINK` value from `1` to `2` for local XLinks on your database (again, for most CityGML models this can simply be done for all entries having `IS_XLINK=1` in `SURFACE_GEOMETRY`...).