### PR TITLE
PostGIS as default database connection

### DIFF
--- a/impexp-config/src/main/java/org/citydb/config/project/database/DatabaseConnection.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/database/DatabaseConnection.java
@@ -55,13 +55,13 @@ public class DatabaseConnection implements Comparable<DatabaseConnection> {
     private String id;
     private String description;
     @XmlElement(required = true)
-    private DatabaseType type = DatabaseType.ORACLE;
+    private DatabaseType type = DatabaseType.POSTGIS;
     @XmlSchemaType(name = "anyURI")
     @XmlElement(required = true)
     private String server;
     @XmlSchemaType(name = "positiveInteger")
     @XmlElement(required = true)
-    private Integer port = 1521;
+    private Integer port = 5432;
     @XmlElement(required = true)
     private String sid;
     private String schema;


### PR DESCRIPTION
As far as I am aware, the majority use the Importer/Exporter for a PostgreSQL/PostGIS database solution.
Could the PostGIS option in the GUI be the default selection for a new database connection?