### PR TITLE
added support for creating minimized distribution contents

### DIFF
--- a/impexp-client/build.gradle
+++ b/impexp-client/build.gradle
@@ -141,6 +141,21 @@ distributions.main {
     }
 }
 
+distributions {
+    minimized {
+        distributionBaseName = project.appName + '-Minimized'
+        contents {
+            with distributions.main.contents
+            exclude {
+                it.getFile().getParentFile().compareTo(file("$rootDir/resources/3dcitydb")) == 0 ||
+                it.getFile().getParentFile().compareTo(file("$rootDir/resources/samples")) == 0 ||
+                it.getFile().getParentFile().compareTo(file("$rootDir/resources/templates")) == 0 ||
+                it.getFile().getParentFile().compareTo(file("$rootDir/resources/3d-web-map-client")) == 0
+            }
+        }
+    }
+}
+
 task buildInstaller(dependsOn: installDist, group: 'distribution') {
     def installDir = installDist.destinationDir.toString()
     def distDir = distZip.destinationDirectory.get()

--- a/impexp-client/build.gradle
+++ b/impexp-client/build.gradle
@@ -143,7 +143,7 @@ distributions.main {
 
 distributions {
     minimized {
-        distributionBaseName = project.appName + '-Minimized'
+        distributionBaseName = project.appName
         contents {
             with distributions.main.contents
             exclude {

--- a/impexp-client/build.gradle
+++ b/impexp-client/build.gradle
@@ -142,11 +142,13 @@ distributions {
         }
     }
 
-    minimized {
-        distributionBaseName = project.appName + '-Minimized'
+    docker {
+        distributionBaseName = project.appName + '-Docker'
         contents {
             with distributions.main.contents
+            exclude ('*.bat', 'collada2gltf/*osx*', 'collada2gltf/*windows*')
             exclude {
+                it.getFile().compareTo(file("$rootDir/resources/plugins/plugin-ade-manager")) == 0 ||
                 it.getFile().getParentFile().compareTo(file("$rootDir/resources/3dcitydb")) == 0 ||
                 it.getFile().getParentFile().compareTo(file("$rootDir/resources/samples")) == 0 ||
                 it.getFile().getParentFile().compareTo(file("$rootDir/resources/templates")) == 0 ||

--- a/impexp-client/build.gradle
+++ b/impexp-client/build.gradle
@@ -99,51 +99,51 @@ application {
     }
 }
 
-distributions.main {
-    distributionBaseName = project.appName
+distributions {
+    main {
+        distributionBaseName = project.appName
 
-    contents {
-        from processReadme
-        from('resources/start') {
-            rename 'start(.*)', project.appName + '$1'
-            fileMode 0755
-            filter(ReplaceTokens, tokens: [
-                    name: project.impexpName,
-                    cliName: project.appCliName,
-                    cliDir: application.executableDir
-            ])
-        }
-        into('3dcitydb') {
-            from "$rootDir/resources/3dcitydb"
-        }
-        into('3d-web-map-client') {
-            from "$rootDir/resources/3d-web-map-client"
-        }
-        into('contribs') {
-            from 'contribs'
-        }
-        into('plugins') {
-            from "$rootDir/resources/plugins"
-        }
-        into('templates') {
-            from "$rootDir/resources/templates"
-        }
-        into('samples') {
-            from "$rootDir/resources/samples"
-        }
-        into('license') {
-            from "$rootDir/resources/license/APACHE-2.0.txt"
-            from processLicense
-        }
-        from(file("$buildDir/tmp/dir")) {
-            mkdir "$buildDir/tmp/dir/ade-extensions"
+        contents {
+            from processReadme
+            from('resources/start') {
+                rename 'start(.*)', project.appName + '$1'
+                fileMode 0755
+                filter(ReplaceTokens, tokens: [
+                        name: project.impexpName,
+                        cliName: project.appCliName,
+                        cliDir: application.executableDir
+                ])
+            }
+            into('3dcitydb') {
+                from "$rootDir/resources/3dcitydb"
+            }
+            into('3d-web-map-client') {
+                from "$rootDir/resources/3d-web-map-client"
+            }
+            into('contribs') {
+                from 'contribs'
+            }
+            into('plugins') {
+                from "$rootDir/resources/plugins"
+            }
+            into('templates') {
+                from "$rootDir/resources/templates"
+            }
+            into('samples') {
+                from "$rootDir/resources/samples"
+            }
+            into('license') {
+                from "$rootDir/resources/license/APACHE-2.0.txt"
+                from processLicense
+            }
+            from(file("$buildDir/tmp/dir")) {
+                mkdir "$buildDir/tmp/dir/ade-extensions"
+            }
         }
     }
-}
 
-distributions {
     minimized {
-        distributionBaseName = project.appName
+        distributionBaseName = project.appName + '-Minimized'
         contents {
             with distributions.main.contents
             exclude {


### PR DESCRIPTION
With this PR, a new gradle task `installMinimizedDist` is provided for generating minimized distribution contents, which are mandatorily required for running the importer-exporter. Non-mandatory folders like `3dcitydb`, `samples`, `templates`, and `3d-web-map-client` are omitted. This new task is especially useful when running the importer-exporter via Docker to keep the Docker image small.  