### PR TITLE
[vis-export] added warning of unsupported ADEs

### DIFF
--- a/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/FeatureTypeFilterView.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/common/filter/FeatureTypeFilterView.java
@@ -1,6 +1,7 @@
 package org.citydb.gui.modules.common.filter;
 
 import com.formdev.flatlaf.extras.FlatSVGIcon;
+import org.citydb.ade.ADEExtension;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.query.filter.type.FeatureTypeFilter;
 import org.citydb.config.project.query.filter.version.CityGMLVersionType;
@@ -19,14 +20,27 @@ import org.citygml4j.model.module.citygml.CityGMLVersion;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.function.Predicate;
 
 public class FeatureTypeFilterView extends FilterView<FeatureTypeFilter> implements EventHandler {
     private JPanel component;
     private FeatureTypeTree featureTypeTree;
     private boolean enabled = true;
 
+    public FeatureTypeFilterView(CityGMLVersion version, Predicate<ADEExtension> adeFilter) {
+        init(version, adeFilter);
+    }
+
+    public FeatureTypeFilterView(CityGMLVersionType version, Predicate<ADEExtension> adeFilter) {
+        this(Util.toCityGMLVersion(version), adeFilter);
+    }
+
+    public FeatureTypeFilterView(Predicate<ADEExtension> adeFilter) {
+        this(CityGMLVersion.v2_0_0, adeFilter);
+    }
+
     public FeatureTypeFilterView(CityGMLVersion version) {
-        init(version);
+        this(version, e -> true);
     }
 
     public FeatureTypeFilterView(CityGMLVersionType version) {
@@ -34,7 +48,7 @@ public class FeatureTypeFilterView extends FilterView<FeatureTypeFilter> impleme
     }
 
     public FeatureTypeFilterView() {
-        this(CityGMLVersionType.v2_0_0);
+        this(CityGMLVersion.v2_0_0);
     }
 
     public FeatureTypeFilterView adaptToCityGMLVersionChange(boolean adapt) {
@@ -52,11 +66,11 @@ public class FeatureTypeFilterView extends FilterView<FeatureTypeFilter> impleme
         return featureTypeTree;
     }
 
-    private void init(CityGMLVersion version) {
+    private void init(CityGMLVersion version, Predicate<ADEExtension> adeFilter) {
         component = new JPanel();
         component.setLayout(new GridBagLayout());
 
-        featureTypeTree = new FeatureTypeTree(version);
+        featureTypeTree = new FeatureTypeTree(version, adeFilter);
         featureTypeTree.setRowHeight((int)(new JCheckBox().getPreferredSize().getHeight()) - 1);
 
         // get rid of standard icons

--- a/impexp-client/src/main/java/org/citydb/gui/modules/kml/view/KmlExportPanel.java
+++ b/impexp-client/src/main/java/org/citydb/gui/modules/kml/view/KmlExportPanel.java
@@ -29,6 +29,7 @@ package org.citydb.gui.modules.kml.view;
 
 import com.formdev.flatlaf.extras.FlatSVGIcon;
 import org.citydb.ade.ADEExtension;
+import org.citydb.ade.kmlExporter.ADEKmlExportExtension;
 import org.citydb.ade.kmlExporter.ADEKmlExportExtensionManager;
 import org.citydb.config.Config;
 import org.citydb.config.geometry.BoundingBox;
@@ -97,7 +98,6 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -366,7 +366,7 @@ public class KmlExportPanel extends JPanel implements EventHandler {
             mainPanel.add(bboxFilterPanel, GuiUtil.setConstraints(0, 5, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
         }
         {
-            featureTypeFilter = new FeatureTypeFilterView();
+            featureTypeFilter = new FeatureTypeFilterView(e -> e instanceof ADEKmlExportExtension);
 
             featureFilterPanel = new TitledPanel()
                     .withIcon(featureTypeFilter.getIcon())

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -231,6 +231,8 @@ kmlExport.dialog.error.collada2gltf.notExists=<html><body width="300px">Das COLL
 kmlExport.dialog.error.collada2gltf.notExecutable=<html><body width="300px">Das COLLADA2glTF-Tool {0} kann nicht ausgeführt werden.<br><br>Stellen Sie sicher, dass ausreichende Ausführungsberechtigungen bestehen.</body></html>
 kmlExport.dialog.error.elevation=Google Elevation API Fehler
 kmlExport.dialog.error.elevation.apiKey=<html>Der Google Elevation API benötigt einen API Key.<br><br><b>Hinweis:</b> Bitte geben Sie einen API Key in den allgemeinen Voreinstellungen ein<br>oder ändern Sie die Export-Einstellungen.</html>
+kmlExport.dialog.warn.ade.unsupported=<html><body width="300px">Die nachfolgenden CityGML ADEs werden von diesem VIS-Exporter nicht unterstützt:<br><br>{0}<br><br><b>Hinweis:</b> Bitte prüfen \
+  Sie, ob ein entsprechendes Modul in der ADE Erweiterung implementiert ist.</body></html>
 
 #DatabasePanel
 db.border.connectionDetails=Verbindungsdaten

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -231,7 +231,7 @@ kmlExport.dialog.error.collada2gltf.notExists=<html><body width="300px">Das COLL
 kmlExport.dialog.error.collada2gltf.notExecutable=<html><body width="300px">Das COLLADA2glTF-Tool {0} kann nicht ausgeführt werden.<br><br>Stellen Sie sicher, dass ausreichende Ausführungsberechtigungen bestehen.</body></html>
 kmlExport.dialog.error.elevation=Google Elevation API Fehler
 kmlExport.dialog.error.elevation.apiKey=<html>Der Google Elevation API benötigt einen API Key.<br><br><b>Hinweis:</b> Bitte geben Sie einen API Key in den allgemeinen Voreinstellungen ein<br>oder ändern Sie die Export-Einstellungen.</html>
-kmlExport.dialog.warn.ade.unsupported=<html><body width="300px">Die nachfolgenden CityGML ADEs werden von diesem VIS-Exporter nicht unterstützt:<br><br>{0}<br><br><b>Hinweis:</b> Bitte prüfen \
+kmlExport.dialog.warn.ade.unsupported=<html><body width="300px">Die nachfolgenden CityGML ADEs werden von diesem VIS Exporter nicht unterstützt:<br><br>{0}<br><br><b>Hinweis:</b> Bitte prüfen \
   Sie, ob ein entsprechendes Modul in der ADE Erweiterung implementiert ist.</body></html>
 
 #DatabasePanel

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -231,7 +231,7 @@ kmlExport.dialog.error.collada2gltf.notExists=<html><body width="300px">The COLL
 kmlExport.dialog.error.collada2gltf.notExecutable=<html><body width="300px">The COLLADA2glTF tool at {0} cannot be executed.<br><br>Make sure the tool has sufficient execute permissions.</body></html>
 kmlExport.dialog.error.elevation=Google Elevation API error
 kmlExport.dialog.error.elevation.apiKey=<html>The Google Elevation API requires an API key.<br><br><b>Note:</b> Please enter an API key in the general preferences<br>or change the export settings.</html>
-kmlExport.dialog.warn.ade.unsupported=<html><body width="300px">The following CityGML ADEs are not supported by this VIS-Exporter:<br><br>{0}<br><br><b>Note:</b> Please check that a corresponding \
+kmlExport.dialog.warn.ade.unsupported=<html><body width="300px">The following CityGML ADEs are not supported by this VIS Exporter:<br><br>{0}<br><br><b>Note:</b> Please check that a corresponding \
   module is implemented in the ADE extension.</body></html>
 
 #DatabasePanel

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -231,6 +231,8 @@ kmlExport.dialog.error.collada2gltf.notExists=<html><body width="300px">The COLL
 kmlExport.dialog.error.collada2gltf.notExecutable=<html><body width="300px">The COLLADA2glTF tool at {0} cannot be executed.<br><br>Make sure the tool has sufficient execute permissions.</body></html>
 kmlExport.dialog.error.elevation=Google Elevation API error
 kmlExport.dialog.error.elevation.apiKey=<html>The Google Elevation API requires an API key.<br><br><b>Note:</b> Please enter an API key in the general preferences<br>or change the export settings.</html>
+kmlExport.dialog.warn.ade.unsupported=<html><body width="300px">The following CityGML ADEs are not supported by this VIS-Exporter:<br><br>{0}<br><br><b>Note:</b> Please check that a corresponding \
+  module is implemented in the ADE extension.</body></html>
 
 #DatabasePanel
 db.border.connectionDetails=Connection details

--- a/impexp-core/src/main/java/org/citydb/ade/kmlExporter/ADEBalloonExtensionManager.java
+++ b/impexp-core/src/main/java/org/citydb/ade/kmlExporter/ADEBalloonExtensionManager.java
@@ -32,6 +32,8 @@ import org.citydb.ade.ADEExtensionManager;
 import org.citydb.registry.ObjectRegistry;
 
 import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class ADEBalloonExtensionManager {
 	private static ADEBalloonExtensionManager instance;
@@ -49,7 +51,13 @@ public class ADEBalloonExtensionManager {
 			return ((ADEBalloonExtension) extension);
 
 		return null;
-}
+	}
+
+	public List<ADEExtension> getUnsupportedADEExtensions() {
+		return ADEExtensionManager.getInstance().getEnabledExtensions()
+				.stream().filter(ade -> getBalloonExtension(ade) == null)
+				.collect(Collectors.toList());
+	}
 
 	public synchronized ADEBalloonManager getBalloonManager(ADEExtension adeExtension) {
 		ADEBalloonManager adeBalloonManager = null;

--- a/impexp-core/src/main/java/org/citydb/ade/kmlExporter/ADEKmlExportExtensionManager.java
+++ b/impexp-core/src/main/java/org/citydb/ade/kmlExporter/ADEKmlExportExtensionManager.java
@@ -35,6 +35,9 @@ import org.citydb.config.project.kmlExporter.ADEPreferences;
 import org.citydb.database.schema.mapping.FeatureType;
 import org.citydb.registry.ObjectRegistry;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class ADEKmlExportExtensionManager {
 	private static ADEKmlExportExtensionManager instance;
 
@@ -50,6 +53,12 @@ public class ADEKmlExportExtensionManager {
 			return ((ADEKmlExportExtension) extension);
 
 		return null;
+	}
+
+	public List<ADEExtension> getUnsupportedADEExtensions() {
+		return ADEExtensionManager.getInstance().getEnabledExtensions()
+				.stream().filter(ade -> getADEKmlExportExtension(ade) == null)
+				.collect(Collectors.toList());
 	}
 
 	public ADEPreference getPreference(Config config, FeatureType featureType) {

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/controller/KmlExporter.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/controller/KmlExporter.java
@@ -195,7 +195,7 @@ public class KmlExporter implements EventHandler {
 
 		List<ADEExtension> unsupported = ADEKmlExportExtensionManager.getInstance().getUnsupportedADEExtensions();
 		if (!unsupported.isEmpty()) {
-			log.warn("The following CityGML ADEs are not supported by this VIS-Exporter:\n" +
+			log.warn("The following CityGML ADEs are not supported by this VIS Exporter:\n" +
 					Util.collection2string(unsupported.stream().map(ade -> ade.getMetadata().getName()).collect(Collectors.toList()), "\n"));
 		}
 

--- a/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/controller/KmlExporter.java
+++ b/impexp-kml-collada-plugin/src/main/java/org/citydb/modules/kml/controller/KmlExporter.java
@@ -50,6 +50,7 @@ import net.opengis.kml._2.StyleMapType;
 import net.opengis.kml._2.StyleStateEnumType;
 import net.opengis.kml._2.StyleType;
 import net.opengis.kml._2.ViewRefreshModeEnumType;
+import org.citydb.ade.ADEExtension;
 import org.citydb.ade.kmlExporter.ADEKmlExportExtensionManager;
 import org.citydb.concurrent.PoolSizeAdaptationStrategy;
 import org.citydb.concurrent.SingleWorkerPool;
@@ -150,6 +151,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -189,6 +191,12 @@ public class KmlExporter implements EventHandler {
 	public boolean doExport(Path outputFile) throws KmlExportException {
 		if (outputFile == null || outputFile.getFileName() == null) {
 			throw new KmlExportException("The output file '" + outputFile + "' is invalid.");
+		}
+
+		List<ADEExtension> unsupported = ADEKmlExportExtensionManager.getInstance().getUnsupportedADEExtensions();
+		if (!unsupported.isEmpty()) {
+			log.warn("The following CityGML ADEs are not supported by this VIS-Exporter:\n" +
+					Util.collection2string(unsupported.stream().map(ade -> ade.getMetadata().getName()).collect(Collectors.toList()), "\n"));
 		}
 
 		eventDispatcher.addEventHandler(EventType.OBJECT_COUNTER, this);


### PR DESCRIPTION
With this PR, the unsupported ADEs can now be printed in console and a warning dialog during VIS export.  