### PR TITLE
Add CLI options for feature version filter

### DIFF
--- a/impexp-client/src/main/java/org/citydb/cli/options/exporter/QueryOption.java
+++ b/impexp-client/src/main/java/org/citydb/cli/options/exporter/QueryOption.java
@@ -106,9 +106,9 @@ public class QueryOption implements CliOption {
 
             if (featureVersionOption != null) {
                 DatatypeFactory datatypeFactory = ObjectRegistry.getInstance().getDatatypeFactory();
-                SimpleFeatureVersionFilter filter = featureVersionOption.toFeatureVersionFilter(datatypeFactory);
-                if (filter != null) {
-                    AbstractPredicate predicate = filter.toPredicate();
+                SimpleFeatureVersionFilter versionFilter = featureVersionOption.toFeatureVersionFilter(datatypeFactory);
+                if (versionFilter != null) {
+                    AbstractPredicate predicate = versionFilter.toPredicate();
                     if (predicate != null) {
                         predicates.add(predicate);
                     }

--- a/impexp-client/src/main/java/org/citydb/cli/options/exporter/QueryOption.java
+++ b/impexp-client/src/main/java/org/citydb/cli/options/exporter/QueryOption.java
@@ -36,21 +36,28 @@ import org.citydb.config.project.query.filter.selection.id.ResourceIdOperator;
 import org.citydb.config.project.query.filter.selection.logical.AndOperator;
 import org.citydb.config.project.query.filter.selection.spatial.AbstractSpatialOperator;
 import org.citydb.config.project.query.filter.selection.sql.SelectOperator;
+import org.citydb.config.project.query.simple.SimpleFeatureVersionFilter;
 import org.citydb.plugin.cli.CliOption;
 import org.citydb.plugin.cli.CounterOption;
 import org.citydb.plugin.cli.DatabaseIdOption;
+import org.citydb.plugin.cli.FeatureVersionOption;
 import org.citydb.plugin.cli.ResourceIdOption;
 import org.citydb.plugin.cli.SQLSelectOption;
 import org.citydb.plugin.cli.TypeNamesOption;
 import org.citydb.plugin.cli.XMLQueryOption;
+import org.citydb.registry.ObjectRegistry;
 import picocli.CommandLine;
 
+import javax.xml.datatype.DatatypeFactory;
 import java.util.ArrayList;
 import java.util.List;
 
 public class QueryOption implements CliOption {
     @CommandLine.ArgGroup(exclusive = false)
     private TypeNamesOption typeNamesOption;
+
+    @CommandLine.ArgGroup(exclusive = false)
+    private FeatureVersionOption featureVersionOption;
 
     @CommandLine.ArgGroup
     private ResourceIdOption resourceIdOption;
@@ -82,6 +89,7 @@ public class QueryOption implements CliOption {
 
     public QueryConfig toQueryConfig() {
         if (typeNamesOption != null
+                || featureVersionOption != null
                 || resourceIdOption != null
                 || databaseIdOption != null
                 || boundingBoxOption != null
@@ -94,6 +102,17 @@ public class QueryOption implements CliOption {
 
             if (typeNamesOption != null) {
                 queryConfig.setFeatureTypeFilter(typeNamesOption.toFeatureTypeFilter());
+            }
+
+            if (featureVersionOption != null) {
+                DatatypeFactory datatypeFactory = ObjectRegistry.getInstance().getDatatypeFactory();
+                SimpleFeatureVersionFilter filter = featureVersionOption.toFeatureVersionFilter(datatypeFactory);
+                if (filter != null) {
+                    AbstractPredicate predicate = filter.toPredicate();
+                    if (predicate != null) {
+                        predicates.add(predicate);
+                    }
+                }
             }
 
             if (resourceIdOption != null) {
@@ -162,6 +181,9 @@ public class QueryOption implements CliOption {
             if (typeNamesOption != null) {
                 throw new CommandLine.ParameterException(commandLine,
                         "Error: --type-name and --xml-query are mutually exclusive (specify only one)");
+            } else if (featureVersionOption != null) {
+                throw new CommandLine.ParameterException(commandLine,
+                        "Error: --feature-version and --xml-query are mutually exclusive (specify only one)");
             } else if (resourceIdOption != null) {
                 throw new CommandLine.ParameterException(commandLine,
                         "Error: --gml-id and --xml-query are mutually exclusive (specify only one)");
@@ -187,6 +209,10 @@ public class QueryOption implements CliOption {
 
         if (typeNamesOption != null) {
             typeNamesOption.preprocess(commandLine);
+        }
+
+        if (featureVersionOption != null) {
+            featureVersionOption.preprocess(commandLine);
         }
 
         if (databaseIdOption != null) {

--- a/impexp-client/src/main/java/org/citydb/cli/options/vis/GltfOption.java
+++ b/impexp-client/src/main/java/org/citydb/cli/options/vis/GltfOption.java
@@ -60,7 +60,7 @@ public class GltfOption implements CliOption {
             description = "Output meshes using Draco compression (requires glTF version 2.0).")
     private boolean dracoCompression;
 
-    @CommandLine.Option(names = {"-r", "--remove-collada"},
+    @CommandLine.Option(names = {"-m", "--remove-collada"},
             description = "Only keep glTF and remove the COLLADA output.")
     private boolean removeCollada;
 

--- a/impexp-client/src/main/java/org/citydb/cli/options/vis/QueryOption.java
+++ b/impexp-client/src/main/java/org/citydb/cli/options/vis/QueryOption.java
@@ -32,15 +32,23 @@ import org.citydb.config.project.kmlExporter.SimpleKmlQuery;
 import org.citydb.config.project.query.filter.selection.id.ResourceIdOperator;
 import org.citydb.config.project.query.filter.selection.sql.SelectOperator;
 import org.citydb.config.project.query.simple.SimpleAttributeFilter;
+import org.citydb.config.project.query.simple.SimpleFeatureVersionFilter;
 import org.citydb.plugin.cli.CliOption;
+import org.citydb.plugin.cli.FeatureVersionOption;
 import org.citydb.plugin.cli.ResourceIdOption;
 import org.citydb.plugin.cli.SQLSelectOption;
 import org.citydb.plugin.cli.TypeNamesOption;
+import org.citydb.registry.ObjectRegistry;
 import picocli.CommandLine;
+
+import javax.xml.datatype.DatatypeFactory;
 
 public class QueryOption implements CliOption {
     @CommandLine.ArgGroup(exclusive = false)
     private TypeNamesOption typeNamesOption;
+
+    @CommandLine.ArgGroup(exclusive = false)
+    private FeatureVersionOption featureVersionOption;
 
     @CommandLine.ArgGroup
     private ResourceIdOption resourceIdOption;
@@ -60,6 +68,15 @@ public class QueryOption implements CliOption {
         if (typeNamesOption != null) {
             query.setUseTypeNames(true);
             query.setFeatureTypeFilter(typeNamesOption.toFeatureTypeFilter());
+        }
+
+        if (featureVersionOption != null) {
+            DatatypeFactory datatypeFactory = ObjectRegistry.getInstance().getDatatypeFactory();
+            SimpleFeatureVersionFilter versionFilter = featureVersionOption.toFeatureVersionFilter(datatypeFactory);
+            if (versionFilter != null) {
+                query.setUseFeatureVersionFilter(true);
+                query.setFeatureVersionFilter(versionFilter);
+            }
         }
 
         if (resourceIdOption != null) {
@@ -96,6 +113,10 @@ public class QueryOption implements CliOption {
     public void preprocess(CommandLine commandLine) throws Exception {
         if (typeNamesOption != null) {
             typeNamesOption.preprocess(commandLine);
+        }
+
+        if (featureVersionOption != null) {
+            featureVersionOption.preprocess(commandLine);
         }
 
         if (boundingBoxOption != null) {

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/cli/FeatureVersionOption.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/cli/FeatureVersionOption.java
@@ -1,0 +1,155 @@
+package org.citydb.plugin.cli;
+
+import org.citydb.config.project.query.simple.SimpleFeatureVersionFilter;
+import org.citydb.config.project.query.simple.SimpleFeatureVersionFilterMode;
+import picocli.CommandLine;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
+
+public class FeatureVersionOption implements CliOption {
+    @CommandLine.Option(names = {"-r", "--feature-version"}, required = true,
+            description = "Feature version: ${COMPLETION-CANDIDATES}.")
+    private Version version;
+
+    @CommandLine.Option(names = {"-R", "--feature-version-timestamp"}, paramLabel = "<timestamp[,timestamp]>",
+            description = "Timestamp given as date <YYYY-MM-DD> or date-time <YYYY-MM-DDThh:mm:ss>. " +
+                    "Use one timestamp with 'at' and two defining a time range with 'between'.")
+    private String timestamp;
+
+    private OffsetDateTime startDateTime;
+    private OffsetDateTime endDateTime;
+    private SimpleFeatureVersionFilter featureVersionFilter;
+
+    public SimpleFeatureVersionFilter toFeatureVersionFilter(DatatypeFactory datatypeFactory) {
+        if (featureVersionFilter != null) {
+            if (startDateTime != null) {
+                featureVersionFilter.setStartDate(toCalendar(startDateTime, datatypeFactory));
+            }
+
+            if (endDateTime != null) {
+                featureVersionFilter.setEndDate(toCalendar(endDateTime, datatypeFactory));
+            }
+        }
+
+        return featureVersionFilter;
+    }
+
+    enum Version {
+        latest(SimpleFeatureVersionFilterMode.LATEST),
+        at(SimpleFeatureVersionFilterMode.AT),
+        between(SimpleFeatureVersionFilterMode.BETWEEN),
+        all(null);
+
+        private final SimpleFeatureVersionFilterMode mode;
+
+        Version(SimpleFeatureVersionFilterMode mode) {
+            this.mode = mode;
+        }
+    }
+
+    @Override
+    public void preprocess(CommandLine commandLine) throws Exception {
+        if (version == Version.all) {
+            if (timestamp != null) {
+                throw new CommandLine.ParameterException(commandLine,
+                        "Error: The feature version '" + version + "' does not take a timestamp");
+            } else {
+                // no filter is required to query all feature versions
+                return;
+            }
+        }
+
+        featureVersionFilter = new SimpleFeatureVersionFilter();
+        featureVersionFilter.setMode(version.mode);
+
+        if (timestamp != null) {
+            if (version == Version.latest) {
+                throw new CommandLine.ParameterException(commandLine,
+                        "Error: The feature version '" + version + "' does not take a timestamp");
+            }
+
+            String[] timestamps = timestamp.split(",");
+
+            if (version == Version.at && timestamps.length != 1) {
+                throw new CommandLine.ParameterException(commandLine,
+                        "Error: The feature version '" + version + "' requires a timestamp");
+            } else if (version == Version.between && timestamps.length != 2) {
+                throw new CommandLine.ParameterException(commandLine,
+                        "Error: The feature version '" + version + "' requires two timestamps defining a time range");
+            }
+
+            DateTimeFormatter formatter = buildDateTimeFormatter();
+            for (int i = 0; i < timestamps.length; i++) {
+                try {
+                    OffsetDateTime dateTime = OffsetDateTime.parse(timestamps[i], formatter);
+                    if (i == 0) {
+                        startDateTime = dateTime;
+                    } else {
+                        if (!dateTime.isAfter(startDateTime)) {
+                            throw new CommandLine.ParameterException(commandLine,
+                                    "Error: The start timestamp must be lesser than the end timestamp");
+                        }
+
+                        endDateTime = dateTime;
+                    }
+                } catch (DateTimeParseException e) {
+                    throw new CommandLine.ParameterException(commandLine,
+                            "A feature version timestamp must be in YYYY-MM-DD[Thh:mm:ss] format but was '" + timestamp + "'");
+                }
+            }
+        } else {
+            if (version == Version.at) {
+                throw new CommandLine.ParameterException(commandLine,
+                        "Error: The feature version '" + version + "' requires a timestamp");
+            } else if (version == Version.between) {
+                throw new CommandLine.ParameterException(commandLine,
+                        "Error: The feature version '" + version + "' requires a start and an end timestamp");
+            }
+        }
+    }
+
+    private DateTimeFormatter buildDateTimeFormatter() {
+        return new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .append(DateTimeFormatter.ISO_LOCAL_DATE)
+                .optionalStart()
+                .appendLiteral('T')
+                .append(DateTimeFormatter.ISO_LOCAL_TIME)
+                .optionalStart()
+                .appendOffsetId()
+                .optionalEnd()
+                .optionalEnd()
+                .parseDefaulting(ChronoField.HOUR_OF_DAY, LocalTime.MAX.getHour())
+                .parseDefaulting(ChronoField.MINUTE_OF_HOUR, LocalTime.MAX.getMinute())
+                .parseDefaulting(ChronoField.SECOND_OF_MINUTE, LocalTime.MAX.getSecond())
+                .parseDefaulting(ChronoField.OFFSET_SECONDS, OffsetDateTime.now().getOffset().getTotalSeconds())
+                .toFormatter()
+                .withResolverStyle(ResolverStyle.STRICT)
+                .withChronology(IsoChronology.INSTANCE);
+    }
+
+    private XMLGregorianCalendar toCalendar(OffsetDateTime dateTime, DatatypeFactory datatypeFactory) {
+        return datatypeFactory.newXMLGregorianCalendar(
+                dateTime.getYear(),
+                dateTime.getMonthValue(),
+                dateTime.getDayOfMonth(),
+                dateTime.getHour(),
+                dateTime.getMinute(),
+                dateTime.getSecond(),
+                DatatypeConstants.FIELD_UNDEFINED,
+                dateTime.getOffset() != ZoneOffset.UTC ?
+                        dateTime.getOffset().getTotalSeconds() / 60 :
+                        DatatypeConstants.FIELD_UNDEFINED);
+    }
+}

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/cli/FeatureVersionOption.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/cli/FeatureVersionOption.java
@@ -23,8 +23,9 @@ public class FeatureVersionOption implements CliOption {
     private Version version;
 
     @CommandLine.Option(names = {"-R", "--feature-version-timestamp"}, paramLabel = "<timestamp[,timestamp]>",
-            description = "Timestamp given as date <YYYY-MM-DD> or date-time <YYYY-MM-DDThh:mm:ss>. " +
-                    "Use one timestamp with 'at' and two timestamps defining a time range with 'between'.")
+            description = "Timestamp given as date <YYYY-MM-DD> or date-time <YYYY-MM-DDThh:mm:ss[(+|-)hh:mm]> with " +
+                    "optional UTC offset. Use one timestamp with 'at' and two timestamps defining a time range " +
+                    "with 'between'.")
     private String timestamp;
 
     private OffsetDateTime startDateTime;
@@ -105,7 +106,8 @@ public class FeatureVersionOption implements CliOption {
                     }
                 } catch (DateTimeParseException e) {
                     throw new CommandLine.ParameterException(commandLine,
-                            "A feature version timestamp must be in YYYY-MM-DD[Thh:mm:ss] format but was '" + timestamp + "'");
+                            "A feature version timestamp must be in YYYY-MM-DD or YYYY-MM-DDThh:mm:ss[(+|-)hh:mm] " +
+                                    "format but was '" + timestamps[i] + "'");
                 }
             }
         } else {

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/cli/FeatureVersionOption.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/cli/FeatureVersionOption.java
@@ -24,7 +24,7 @@ public class FeatureVersionOption implements CliOption {
 
     @CommandLine.Option(names = {"-R", "--feature-version-timestamp"}, paramLabel = "<timestamp[,timestamp]>",
             description = "Timestamp given as date <YYYY-MM-DD> or date-time <YYYY-MM-DDThh:mm:ss>. " +
-                    "Use one timestamp with 'at' and two defining a time range with 'between'.")
+                    "Use one timestamp with 'at' and two timestamps defining a time range with 'between'.")
     private String timestamp;
 
     private OffsetDateTime startDateTime;
@@ -65,7 +65,7 @@ public class FeatureVersionOption implements CliOption {
                 throw new CommandLine.ParameterException(commandLine,
                         "Error: The feature version '" + version + "' does not take a timestamp");
             } else {
-                // no filter is required to query all feature versions
+                // no filter required to query all feature versions
                 return;
             }
         }
@@ -83,7 +83,7 @@ public class FeatureVersionOption implements CliOption {
 
             if (version == Version.at && timestamps.length != 1) {
                 throw new CommandLine.ParameterException(commandLine,
-                        "Error: The feature version '" + version + "' requires a timestamp");
+                        "Error: The feature version '" + version + "' requires only one timestamp");
             } else if (version == Version.between && timestamps.length != 2) {
                 throw new CommandLine.ParameterException(commandLine,
                         "Error: The feature version '" + version + "' requires two timestamps defining a time range");


### PR DESCRIPTION
This PR adds CLI options to the `export`, `export-vis` and `delete` commands that allow to control the feature version filter.

One breaking change: 
* The glTF export option `--remove-collada` had a shortcut option  `-r` before. Since `-r` is now used by the feature version filter, the new shortcurt option for removing collada files is `-m`.