### PR TITLE
Add metadata options to the import and delete CLI commands

### DIFF
--- a/impexp-client/src/main/java/org/citydb/cli/DeleteCommand.java
+++ b/impexp-client/src/main/java/org/citydb/cli/DeleteCommand.java
@@ -33,9 +33,11 @@ import org.citydb.citygml.deleter.controller.Deleter;
 import org.citydb.citygml.deleter.util.DeleteListPreviewer;
 import org.citydb.cli.options.deleter.CleanupOption;
 import org.citydb.cli.options.deleter.DeleteListOption;
+import org.citydb.cli.options.deleter.MetadataOption;
 import org.citydb.cli.options.deleter.QueryOption;
 import org.citydb.config.Config;
 import org.citydb.config.project.database.DatabaseConnection;
+import org.citydb.config.project.deleter.DeleteConfig;
 import org.citydb.config.project.deleter.DeleteList;
 import org.citydb.config.project.deleter.DeleteMode;
 import org.citydb.database.DatabaseController;
@@ -63,6 +65,9 @@ public class DeleteCommand extends CliCommand {
 
     @CommandLine.ArgGroup(exclusive = false)
     private CleanupOption cleanupOption;
+
+    @CommandLine.ArgGroup(exclusive = false, heading = "Metadata options:%n")
+    private MetadataOption metadataOption;
 
     @CommandLine.ArgGroup(exclusive = false, heading = "Query and filter options:%n")
     private QueryOption queryOption;
@@ -110,17 +115,7 @@ public class DeleteCommand extends CliCommand {
             return 1;
         }
 
-        // set delete mode
-        if (mode != null) {
-            config.getDeleteConfig().setMode(mode == Mode.terminate ?
-                    DeleteMode.TERMINATE :
-                    DeleteMode.DELETE);
-        }
-
-        // set cleanup option
-        if (cleanupOption != null) {
-            config.getDeleteConfig().setCleanupGlobalAppearances(cleanupOption.isCleanupGlobalAppearances());
-        }
+        setDeleteOptions(config.getDeleteConfig());
 
         // set user-defined query options
         if (queryOption != null) {
@@ -140,5 +135,21 @@ public class DeleteCommand extends CliCommand {
         }
 
         return 0;
+    }
+
+    private void setDeleteOptions(DeleteConfig deleteConfig) {
+        if (mode != null) {
+            deleteConfig.setMode(mode == Mode.terminate ?
+                    DeleteMode.TERMINATE :
+                    DeleteMode.DELETE);
+        }
+
+        if (cleanupOption != null) {
+            deleteConfig.setCleanupGlobalAppearances(cleanupOption.isCleanupGlobalAppearances());
+        }
+
+        if (metadataOption != null) {
+            deleteConfig.setContinuation(metadataOption.toContinuation());
+        }
     }
 }

--- a/impexp-client/src/main/java/org/citydb/cli/ImportCommand.java
+++ b/impexp-client/src/main/java/org/citydb/cli/ImportCommand.java
@@ -4,6 +4,7 @@ import org.citydb.ImpExpException;
 import org.citydb.citygml.importer.CityGMLImportException;
 import org.citydb.citygml.importer.controller.Importer;
 import org.citydb.cli.options.importer.FilterOption;
+import org.citydb.cli.options.importer.MetadataOption;
 import org.citydb.config.Config;
 import org.citydb.config.project.database.DatabaseConnection;
 import org.citydb.config.project.importer.ImportConfig;
@@ -41,6 +42,9 @@ public class ImportCommand extends CliCommand {
 
     @CommandLine.ArgGroup
     private ThreadPoolOption threadPoolOption;
+
+    @CommandLine.ArgGroup(exclusive = false, heading = "Metadata options:%n")
+    private MetadataOption metadataOption;
 
     @CommandLine.ArgGroup(exclusive = false, heading = "Import filter options:%n")
     private FilterOption filterOption;
@@ -106,6 +110,10 @@ public class ImportCommand extends CliCommand {
         if (importLogFile != null) {
             importConfig.getImportLog().setLogFile(importLogFile.toAbsolutePath().toString());
             importConfig.getImportLog().setLogImportedFeatures(true);
+        }
+
+        if (metadataOption != null) {
+            importConfig.setContinuation(metadataOption.toContinuation());
         }
 
         if (filterOption != null) {

--- a/impexp-client/src/main/java/org/citydb/cli/options/deleter/MetadataOption.java
+++ b/impexp-client/src/main/java/org/citydb/cli/options/deleter/MetadataOption.java
@@ -1,0 +1,43 @@
+package org.citydb.cli.options.deleter;
+
+import org.citydb.config.project.deleter.Continuation;
+import org.citydb.config.project.global.UpdatingPersonMode;
+import org.citydb.plugin.cli.CliOption;
+import picocli.CommandLine;
+
+public class MetadataOption implements CliOption {
+    @CommandLine.Option(names = "--lineage",
+            description = "Lineage to use for the city objects.")
+    private String lineage;
+
+    @CommandLine.Option(names = "--updating-person", paramLabel = "<name>",
+            description = "Name of the user responsible for the delete (default: database user).")
+    private String updatingPerson;
+
+    @CommandLine.Option(names = "--reason-for-update", paramLabel = "<reason>",
+            description = "Reason for deleting the data.")
+    private String reasonForUpdate;
+
+    private Continuation continuation;
+
+    public Continuation toContinuation() {
+        Continuation continuation = new Continuation();
+
+        if (lineage != null) {
+            continuation.setLineage(lineage);
+        }
+
+        if (updatingPerson != null) {
+            continuation.setUpdatingPersonMode(UpdatingPersonMode.USER);
+            continuation.setUpdatingPerson(updatingPerson);
+        } else {
+            continuation.setUpdatingPersonMode(UpdatingPersonMode.DATABASE);
+        }
+
+        if (reasonForUpdate != null) {
+            continuation.setReasonForUpdate(reasonForUpdate);
+        }
+
+        return continuation;
+    }
+}

--- a/impexp-client/src/main/java/org/citydb/cli/options/importer/MetadataOption.java
+++ b/impexp-client/src/main/java/org/citydb/cli/options/importer/MetadataOption.java
@@ -34,6 +34,10 @@ public class MetadataOption implements CliOption {
             description = "Reason for importing the data.")
     private String reasonForUpdate;
 
+    @CommandLine.Option(names = "--use-metadata-from-file",
+            description = "Use lineage, updating person and reason for update from input file if available.")
+    private boolean useMetadataFromFile;
+
     private Continuation continuation;
 
     public Continuation toContinuation() {
@@ -75,6 +79,8 @@ public class MetadataOption implements CliOption {
         if (reasonForUpdate != null) {
             continuation.setReasonForUpdate(reasonForUpdate);
         }
+
+        continuation.setImportCityDBMetadata(useMetadataFromFile);
 
         return continuation;
     }

--- a/impexp-client/src/main/java/org/citydb/cli/options/importer/MetadataOption.java
+++ b/impexp-client/src/main/java/org/citydb/cli/options/importer/MetadataOption.java
@@ -1,0 +1,81 @@
+package org.citydb.cli.options.importer;
+
+import org.citydb.config.project.global.UpdatingPersonMode;
+import org.citydb.config.project.importer.Continuation;
+import org.citydb.config.project.importer.CreationDateMode;
+import org.citydb.config.project.importer.TerminationDateMode;
+import org.citydb.plugin.cli.CliOption;
+import picocli.CommandLine;
+
+public class MetadataOption implements CliOption {
+    enum DateMode {replace, complement, inherit}
+
+    @CommandLine.Option(names = "--creation-date", paramLabel = "<mode>", defaultValue = "replace",
+            description = "Creation date mode: ${COMPLETION-CANDIDATES}. Replace creation dates " +
+                    "with the current timestamp, complement missing values with the current timestamp, " +
+                    "or inherit missing values from the parent feature (default: ${DEFAULT-VALUE}).")
+    private DateMode creationDate;
+
+    @CommandLine.Option(names = "--termination-date", paramLabel = "<mode>", defaultValue = "replace",
+            description = "Termination date mode: ${COMPLETION-CANDIDATES}. Replace termination dates " +
+                    "with NULL, complement missing values with NULL, or inherit missing values from the " +
+                    "parent feature (default: ${DEFAULT-VALUE}).")
+    private DateMode terminationDate;
+
+    @CommandLine.Option(names = "--lineage",
+            description = "Lineage to use for the city objects.")
+    private String lineage;
+
+    @CommandLine.Option(names = "--updating-person", paramLabel = "<name>",
+            description = "Name of the user responsible for the import (default: database user).")
+    private String updatingPerson;
+
+    @CommandLine.Option(names = "--reason-for-update", paramLabel = "<reason>",
+            description = "Reason for importing the data.")
+    private String reasonForUpdate;
+
+    private Continuation continuation;
+
+    public Continuation toContinuation() {
+        Continuation continuation = new Continuation();
+
+        switch (creationDate) {
+            case complement:
+                continuation.setCreationDateMode(CreationDateMode.COMPLEMENT);
+                break;
+            case inherit:
+                continuation.setCreationDateMode(CreationDateMode.INHERIT);
+                break;
+            default:
+                continuation.setCreationDateMode(CreationDateMode.REPLACE);
+        }
+
+        switch (terminationDate) {
+            case complement:
+                continuation.setTerminationDateMode(TerminationDateMode.COMPLEMENT);
+                break;
+            case inherit:
+                continuation.setTerminationDateMode(TerminationDateMode.INHERIT);
+                break;
+            default:
+                continuation.setTerminationDateMode(TerminationDateMode.REPLACE);
+        }
+
+        if (lineage != null) {
+            continuation.setLineage(lineage);
+        }
+
+        if (updatingPerson != null) {
+            continuation.setUpdatingPersonMode(UpdatingPersonMode.USER);
+            continuation.setUpdatingPerson(updatingPerson);
+        } else {
+            continuation.setUpdatingPersonMode(UpdatingPersonMode.DATABASE);
+        }
+
+        if (reasonForUpdate != null) {
+            continuation.setReasonForUpdate(reasonForUpdate);
+        }
+
+        return continuation;
+    }
+}


### PR DESCRIPTION
This PR adds options to set the lineage, updating person, and reason for update for the `import` and `delete` CLI commands. For `import`, additional options have been added to set the creation date mode and termination date mode.