### PR TITLE
Fix inconsistent behaviour of feature version filter when using the CLI

### DIFF
--- a/impexp-client-cli/src/main/java/org/citydb/cli/options/deleter/QueryOption.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/options/deleter/QueryOption.java
@@ -48,7 +48,6 @@ import org.citydb.plugin.cli.XMLQueryOption;
 import org.citydb.registry.ObjectRegistry;
 import picocli.CommandLine;
 
-import javax.xml.datatype.DatatypeFactory;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -92,14 +91,14 @@ public class QueryOption implements CliOption {
                 queryConfig.setFeatureTypeFilter(typeNamesOption.toFeatureTypeFilter());
             }
 
-            if (featureVersionOption != null) {
-                DatatypeFactory datatypeFactory = ObjectRegistry.getInstance().getDatatypeFactory();
-                SimpleFeatureVersionFilter versionFilter = featureVersionOption.toFeatureVersionFilter(datatypeFactory);
-                if (versionFilter != null) {
-                    AbstractPredicate predicate = versionFilter.toPredicate();
-                    if (predicate != null) {
-                        predicates.add(predicate);
-                    }
+            SimpleFeatureVersionFilter versionFilter = featureVersionOption != null ?
+                    featureVersionOption.toFeatureVersionFilter(ObjectRegistry.getInstance().getDatatypeFactory()) :
+                    FeatureVersionOption.defaultFeatureVersionFilter();
+
+            if (versionFilter != null) {
+                AbstractPredicate predicate = versionFilter.toPredicate();
+                if (predicate != null) {
+                    predicates.add(predicate);
                 }
             }
 

--- a/impexp-client-cli/src/main/java/org/citydb/cli/options/exporter/QueryOption.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/options/exporter/QueryOption.java
@@ -48,7 +48,6 @@ import org.citydb.plugin.cli.XMLQueryOption;
 import org.citydb.registry.ObjectRegistry;
 import picocli.CommandLine;
 
-import javax.xml.datatype.DatatypeFactory;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -104,14 +103,14 @@ public class QueryOption implements CliOption {
                 queryConfig.setFeatureTypeFilter(typeNamesOption.toFeatureTypeFilter());
             }
 
-            if (featureVersionOption != null) {
-                DatatypeFactory datatypeFactory = ObjectRegistry.getInstance().getDatatypeFactory();
-                SimpleFeatureVersionFilter versionFilter = featureVersionOption.toFeatureVersionFilter(datatypeFactory);
-                if (versionFilter != null) {
-                    AbstractPredicate predicate = versionFilter.toPredicate();
-                    if (predicate != null) {
-                        predicates.add(predicate);
-                    }
+            SimpleFeatureVersionFilter versionFilter = featureVersionOption != null ?
+                    featureVersionOption.toFeatureVersionFilter(ObjectRegistry.getInstance().getDatatypeFactory()) :
+                    FeatureVersionOption.defaultFeatureVersionFilter();
+
+            if (versionFilter != null) {
+                AbstractPredicate predicate = versionFilter.toPredicate();
+                if (predicate != null) {
+                    predicates.add(predicate);
                 }
             }
 

--- a/impexp-config/src/main/java/org/citydb/config/project/query/simple/SimpleFeatureVersionFilter.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/simple/SimpleFeatureVersionFilter.java
@@ -53,7 +53,7 @@ public class SimpleFeatureVersionFilter {
     private XMLGregorianCalendar endDate;
 
     public SimpleFeatureVersionFilterMode getMode() {
-        return mode;
+        return mode != null ? mode : SimpleFeatureVersionFilterMode.LATEST;
     }
 
     public void setMode(SimpleFeatureVersionFilterMode mode) {

--- a/impexp-plugin-api/src/main/java/org/citydb/plugin/cli/FeatureVersionOption.java
+++ b/impexp-plugin-api/src/main/java/org/citydb/plugin/cli/FeatureVersionOption.java
@@ -46,8 +46,8 @@ import java.time.format.ResolverStyle;
 import java.time.temporal.ChronoField;
 
 public class FeatureVersionOption implements CliOption {
-    @CommandLine.Option(names = {"-r", "--feature-version"}, required = true,
-            description = "Feature version: ${COMPLETION-CANDIDATES}.")
+    @CommandLine.Option(names = {"-r", "--feature-version"}, required = true, defaultValue = "latest",
+            description = "Feature version: ${COMPLETION-CANDIDATES} (default: ${DEFAULT-VALUE}).")
     private Version version;
 
     @CommandLine.Option(names = {"-R", "--feature-version-timestamp"}, paramLabel = "<timestamp[,timestamp]>",
@@ -59,6 +59,10 @@ public class FeatureVersionOption implements CliOption {
     private OffsetDateTime startDateTime;
     private OffsetDateTime endDateTime;
     private SimpleFeatureVersionFilter featureVersionFilter;
+
+    public static SimpleFeatureVersionFilter defaultFeatureVersionFilter() {
+        return new SimpleFeatureVersionFilter();
+    }
 
     public SimpleFeatureVersionFilter toFeatureVersionFilter(DatatypeFactory datatypeFactory) {
         if (featureVersionFilter != null) {


### PR DESCRIPTION
The feature version filter behaves differently for different CLI commands. To reproduce the following examples, load a small dataset into an empty database and terminate all features right afterwards.

1. `export -H localhost -u user -p password -d db -o test.gml` 

    When doing a CityGML export from the database with the above command, no features will be exported because the 
    command only works on non-terminated features by default.

2. `export -H localhost -u user -p password -d db -o test.gml -t Building` 

    When changing the command by adding a filter (like the feature type filter above), the behaviour changes. The command 
    does not use a default feature version filter anymore and, thus, all buildings are exported. If you only want to export non- 
    terminated features in this case, you must explicitly add `-r latest`.

3. `export-vis -H localhost -u user -p password -d db -o test.kml -D collada -l halod` 

    A simple visualization export behaves like the first CityGML export example. Only non-terminated feature get exported.

4. `export-vis -H localhost -u user -p password -d db -o test.kml -D collada -l halod -t Building` 

    Adding another filter does not change the behaviour - again only non-terminated features are exported. Thus, `export` and 
   `export-vis` behave differently.

Note that the `delete` command behaves like the `export` command. The different behaviours of the commands are at least unexpected. This PR proposes that all commands should behave the same and use a default feature version filter for non-terminated features.
