### PR TITLE
Make StatementFinalizer thread-safe or remove it

### DIFF
--- a/impexp-core/src/main/java/org/citydb/citygml/common/cache/CacheTableManager.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/common/cache/CacheTableManager.java
@@ -168,7 +168,7 @@ public class CacheTableManager {
 				cacheConnection.rollback();
 				cacheConnection.close();
 			} catch (SQLException e) {
-				//
+				log.error("Failed to close temporary cache connection.", e);
 			}
 
 			if (databaseConnection != null) {
@@ -178,7 +178,7 @@ public class CacheTableManager {
 						databaseConnection.close();
 					}
 				} catch (SQLException e) {
-					//
+					log.error("Failed to close temporary cache connection.", e);
 				} finally {
 					databaseConnection = null;
 					databaseAdapter = null;

--- a/impexp-core/src/main/java/org/citydb/database/connection/ConcurrentStatementFinalizer.java
+++ b/impexp-core/src/main/java/org/citydb/database/connection/ConcurrentStatementFinalizer.java
@@ -1,0 +1,13 @@
+package org.citydb.database.connection;
+
+import org.apache.tomcat.jdbc.pool.interceptor.StatementFinalizer;
+
+import java.lang.reflect.Method;
+
+public class ConcurrentStatementFinalizer extends StatementFinalizer {
+
+    @Override
+    public synchronized Object createStatement(Object proxy, Method method, Object[] args, Object statement, long time) {
+        return super.createStatement(proxy, method, args, statement, time);
+    }
+}

--- a/impexp-core/src/main/java/org/citydb/database/connection/DatabaseConnectionPool.java
+++ b/impexp-core/src/main/java/org/citydb/database/connection/DatabaseConnectionPool.java
@@ -135,7 +135,7 @@ public class DatabaseConnectionPool implements ConnectionManager {
 		if (connection.getSuspectTimeout() != null) properties.setSuspectTimeout(connection.getSuspectTimeout());
 
 		// pool maintenance
-		properties.setJdbcInterceptors("StatementFinalizer");
+		properties.setJdbcInterceptors("org.citydb.database.connection.ConcurrentStatementFinalizer");
 
 		// create new data source
 		dataSource = new DataSource(properties);


### PR DESCRIPTION
The `DatabaseConnectionPool` uses the `StatementFinalizer` interceptor of the Tomcat JDBC Connection Pool, which is used to keep track of all created statements  and to close these statements when the connection is returned to the pool. The implementation of `StatementFinalizer` is not thread-safe and assumes that all statements for a connection are created within the same thread.

The Importer/Exporter generally observes this rule with one exception: temporary tables of the internal cache are populated during imports by `DBImportXlinkWorker` but are queried from `DBImportXlinkResolverWorker`. Thus, statements are created from different threads. This leads to an NPE in `StatementFinalizer` when closing the connection of a temporary table and, even worse, the connection cannot be released from the pool.   

This PR adds the class `ConcurrentStatementFinalizer`, which is a thread-safe version of `StatementFinalizer` and resolves the above issue. The issue could alternatively be solved by not using `StatementFinalizer` at all. It is only an optional utility class that makes sure that all statements are closed to avoid resource leaks. However, I personally like this automatic pool maintenance and would therefore not drop  `StatementFinalizer`.