### PR TITLE
Avoid pollution of 3DCityDB schema with temporary tables

### DIFF
--- a/impexp-core/src/main/java/org/citydb/citygml/common/cache/model/AbstractCacheTableModel.java
+++ b/impexp-core/src/main/java/org/citydb/citygml/common/cache/model/AbstractCacheTableModel.java
@@ -47,14 +47,12 @@ public abstract class AbstractCacheTableModel {
     public void create(Connection conn, String tableName, AbstractSQLAdapter sqlAdapter) throws SQLException {
         try (Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sqlAdapter.getCreateUnloggedTable(tableName, getColumns(sqlAdapter)));
-            conn.commit();
         }
     }
 
     public void createAsSelect(Connection conn, String tableName, String select, AbstractSQLAdapter sqlAdapter) throws SQLException {
         try (Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sqlAdapter.getCreateUnloggedTableAsSelect(tableName, select));
-            conn.commit();
         }
     }
 
@@ -68,14 +66,12 @@ public abstract class AbstractCacheTableModel {
     public void truncate(Connection conn, String tableName) throws SQLException {
         try (Statement stmt = conn.createStatement()) {
             stmt.executeUpdate("delete from " + tableName);
-            conn.commit();
         }
     }
 
     public void drop(Connection conn, String tableName) throws SQLException {
         try (Statement stmt = conn.createStatement()) {
             stmt.executeUpdate("drop table " + tableName);
-            conn.commit();
         }
     }
 


### PR DESCRIPTION
Whenever the Importer/Exporter terminates abnormally, the last executed operation might not be able to clean up temporary tables anymore. Thus, temporary tables of name `TMP_*` remain in the 3DCityDB database schema. They don't contain data but nevertheless pollute the schema over time. This PR proposes to solve this issue by simply not committing the DDL statements that are used for creating temporary tables. Thus, they only "live" during the session they are created in.