### PR TITLE
Add environment variables for database connections

### DIFF
--- a/impexp-client-cli/src/main/java/org/citydb/cli/ImpExpCli.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/ImpExpCli.java
@@ -260,12 +260,6 @@ public class ImpExpCli extends CliCommand implements CommandLine.IVersionProvide
                     useDefaultLogLevel = false;
                 }
 
-                // read password from keyboard
-                CommandLine.Model.OptionSpec passwordOption = subParseResult.matchedOption("-p");
-                if (passwordOption != null && passwordOption.getValue().equals("")) {
-                    passwordOption.setValue(readPassword(subParseResult));
-                }
-
                 // preprocess options
                 Object command = commandLine.getCommand();
                 for (Field field : command.getClass().getDeclaredFields()) {
@@ -281,6 +275,12 @@ public class ImpExpCli extends CliCommand implements CommandLine.IVersionProvide
                 // preprocess command
                 if (command instanceof CliCommand) {
                     ((CliCommand) command).preprocess(commandLine);
+                }
+
+                // read password from keyboard
+                CommandLine.Model.OptionSpec passwordOption = subParseResult.matchedOption("-p");
+                if (passwordOption != null && passwordOption.getValue().equals("")) {
+                    passwordOption.setValue(readPassword(subParseResult));
                 }
             }
 
@@ -582,7 +582,8 @@ public class ImpExpCli extends CliCommand implements CommandLine.IVersionProvide
     }
 
     private String readPassword(CommandLine.ParseResult parseResult) {
-        String prompt = "Enter password for " + parseResult.matchedOptionValue("-u", "") + ": ";
+        String prompt = "Enter password for " +
+                parseResult.matchedOptionValue("-u", System.getenv(CoreConstants.ENV_CITYDB_USERNAME)) + ": ";
         Console console = System.console();
         if (console != null) {
             char[] input = console.readPassword(prompt);

--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/deleter/DeleteCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/deleter/DeleteCommand.java
@@ -79,7 +79,7 @@ public class DeleteCommand extends CliCommand {
     private DeleteListOption deleteListOption;
 
     @CommandLine.ArgGroup(exclusive = false, heading = "Database connection options:%n")
-    private DatabaseOption databaseOption;
+    private final DatabaseOption databaseOption = new DatabaseOption();
 
     private final Logger log = Logger.getInstance();
 
@@ -109,7 +109,7 @@ public class DeleteCommand extends CliCommand {
 
         // connect to database
         DatabaseController database = ObjectRegistry.getInstance().getDatabaseController();
-        DatabaseConnection connection = databaseOption != null ?
+        DatabaseConnection connection = databaseOption.hasUserInput() ?
                 databaseOption.toDatabaseConnection() :
                 config.getDatabaseConfig().getActiveConnection();
 

--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/exporter/ExportCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/exporter/ExportCommand.java
@@ -72,7 +72,7 @@ public class ExportCommand extends CliCommand {
     private QueryOption queryOption;
 
     @CommandLine.ArgGroup(exclusive = false, heading = "Database connection options:%n")
-    private DatabaseOption databaseOption;
+    private final DatabaseOption databaseOption = new DatabaseOption();
 
     private final Logger log = Logger.getInstance();
 
@@ -82,7 +82,7 @@ public class ExportCommand extends CliCommand {
 
         // connect to database
         DatabaseController database = ObjectRegistry.getInstance().getDatabaseController();
-        DatabaseConnection connection = databaseOption != null ?
+        DatabaseConnection connection = databaseOption.hasUserInput() ?
                 databaseOption.toDatabaseConnection() :
                 config.getDatabaseConfig().getActiveConnection();
 

--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportCommand.java
@@ -82,7 +82,7 @@ public class ImportCommand extends CliCommand {
     private ImportListOption importListOption;
 
     @CommandLine.ArgGroup(exclusive = false, heading = "Database connection options:%n")
-    private DatabaseOption databaseOption;
+    private final DatabaseOption databaseOption = new DatabaseOption();
 
     private final Logger log = Logger.getInstance();
 
@@ -125,7 +125,7 @@ public class ImportCommand extends CliCommand {
 
         // connect to database
         DatabaseController database = ObjectRegistry.getInstance().getDatabaseController();
-        DatabaseConnection connection = databaseOption != null ?
+        DatabaseConnection connection = databaseOption.hasUserInput() ?
                 databaseOption.toDatabaseConnection() :
                 config.getDatabaseConfig().getActiveConnection();
 

--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/visExporter/ExportVisCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/visExporter/ExportVisCommand.java
@@ -29,15 +29,15 @@
 package org.citydb.cli.operation.visExporter;
 
 import org.citydb.cli.ImpExpCli;
+import org.citydb.cli.option.DatabaseOption;
+import org.citydb.cli.option.ThreadPoolOption;
 import org.citydb.config.Config;
 import org.citydb.config.project.database.DatabaseConnection;
 import org.citydb.config.project.visExporter.VisExportConfig;
 import org.citydb.core.database.DatabaseController;
-import org.citydb.util.log.Logger;
 import org.citydb.core.plugin.CliCommand;
-import org.citydb.cli.option.DatabaseOption;
-import org.citydb.cli.option.ThreadPoolOption;
 import org.citydb.core.registry.ObjectRegistry;
+import org.citydb.util.log.Logger;
 import org.citydb.vis.controller.VisExportException;
 import org.citydb.vis.controller.VisExporter;
 import picocli.CommandLine;
@@ -81,7 +81,7 @@ public class ExportVisCommand extends CliCommand {
     private final ElevationOption elevationOption = new ElevationOption();
 
     @CommandLine.ArgGroup(exclusive = false, heading = "Database connection options:%n")
-    private DatabaseOption databaseOption;
+    private final DatabaseOption databaseOption = new DatabaseOption();
 
     private final Logger log = Logger.getInstance();
 
@@ -91,7 +91,7 @@ public class ExportVisCommand extends CliCommand {
 
         // connect to database
         DatabaseController database = ObjectRegistry.getInstance().getDatabaseController();
-        DatabaseConnection connection = databaseOption != null ?
+        DatabaseConnection connection = databaseOption.hasUserInput() ?
                 databaseOption.toDatabaseConnection() :
                 config.getDatabaseConfig().getActiveConnection();
 

--- a/impexp-core/src/main/java/org/citydb/core/util/CoreConstants.java
+++ b/impexp-core/src/main/java/org/citydb/core/util/CoreConstants.java
@@ -35,6 +35,14 @@ public class CoreConstants {
     public static final Path IMPEXP_HOME;
     public static final Path WORKING_DIR;
 
+    public static final String ENV_CITYDB_TYPE = "CITYDB_TYPE";
+    public static final String ENV_CITYDB_HOST = "CITYDB_HOST";
+    public static final String ENV_CITYDB_PORT = "CITYDB_PORT";
+    public static final String ENV_CITYDB_NAME = "CITYDB_NAME";
+    public static final String ENV_CITYDB_SCHEMA = "CITYDB_SCHEMA";
+    public static final String ENV_CITYDB_USERNAME = "CITYDB_USERNAME";
+    public static final String ENV_CITYDB_PASSWORD = "CITYDB_PASSWORD";
+
     public static final Path IMPEXP_DATA_DIR = Paths.get(System.getProperty("user.home"), "3dcitydb", "importer-exporter").toAbsolutePath();
     public static final String IMPORT_LOG_DIR = "imported-features";
     public static final String DELETE_LOG_DIR = "deleted-features";


### PR DESCRIPTION
This PR adds support for the following environment variables: `CITYDB_TYPE`, `CITYDB_HOST`, `CITYDB_PORT`, `CITYDB_NAME`, `CITYDB_SCHEMA`, `CITYDB_USERNAME`, and `CITYDB_PASSWORD`. 

When running the Importer/Exporter on the command line, the values of these variables will be used as input if a corresponding CLI option *is not available*. Thus, the CLI options always take precedence. In case the Importer/Exporter is started in GUI mode, the environment variables are ignored.

With the new environment variables, you can, for example, define all database connection details except the password as options on the command line and provide the password using the `CITYDB_PASSWORD` variable.