### PR TITLE
Add fail fast option to the CityGML import and export operations

### DIFF
--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/exporter/ExportCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/exporter/ExportCommand.java
@@ -29,18 +29,18 @@
 package org.citydb.cli.operation.exporter;
 
 import org.citydb.cli.ImpExpCli;
+import org.citydb.cli.option.DatabaseOption;
+import org.citydb.cli.option.ThreadPoolOption;
 import org.citydb.config.Config;
 import org.citydb.config.project.database.DatabaseConnection;
 import org.citydb.config.project.exporter.ExportConfig;
 import org.citydb.config.project.exporter.OutputFormat;
 import org.citydb.core.database.DatabaseController;
-import org.citydb.util.log.Logger;
 import org.citydb.core.operation.exporter.CityGMLExportException;
 import org.citydb.core.operation.exporter.controller.Exporter;
 import org.citydb.core.plugin.CliCommand;
-import org.citydb.cli.option.DatabaseOption;
-import org.citydb.cli.option.ThreadPoolOption;
 import org.citydb.core.registry.ObjectRegistry;
+import org.citydb.util.log.Logger;
 import picocli.CommandLine;
 
 import java.nio.file.Path;
@@ -64,6 +64,10 @@ public class ExportCommand extends CliCommand {
     @CommandLine.Option(names = "--compressed-format", paramLabel = "<format>",
             description = "Output format to use for compressed exports: ${COMPLETION-CANDIDATES}.")
     private CompressedFormat compressedFormat;
+
+    @CommandLine.Option(names = "--fail-fast", negatable = true,
+            description = "Fail fast on errors (default: true).")
+    private Boolean failFast;
 
     @CommandLine.ArgGroup
     private ThreadPoolOption threadPoolOption;
@@ -121,6 +125,10 @@ public class ExportCommand extends CliCommand {
             exportConfig.getGeneralOptions().setCompressedOutputFormat(compressedFormat == CompressedFormat.cityjson ?
                     OutputFormat.CITYJSON :
                     OutputFormat.CITYGML);
+        }
+
+        if (failFast != null) {
+            exportConfig.getGeneralOptions().setFailFastOnErrors(failFast);
         }
 
         if (queryOption != null) {

--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportCommand.java
@@ -69,6 +69,10 @@ public class ImportCommand extends CliCommand {
             description = "Record imported top-level features to this file.")
     private Path importLogFile;
 
+    @CommandLine.Option(names = "--fail-fast", negatable = true,
+            description = "Fail fast on errors (default: true).")
+    private Boolean failFast;
+
     @CommandLine.ArgGroup
     private ThreadPoolOption threadPoolOption;
 
@@ -166,6 +170,10 @@ public class ImportCommand extends CliCommand {
         if (importLogFile != null) {
             importConfig.getImportLog().setLogFile(importLogFile.toAbsolutePath().toString());
             importConfig.getImportLog().setLogImportedFeatures(true);
+        }
+
+        if (failFast != null) {
+            importConfig.getGeneralOptions().setFailFastOnErrors(failFast);
         }
 
         if (metadataOption != null) {

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/GeneralPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/GeneralPanel.java
@@ -33,21 +33,22 @@ import org.citydb.config.project.exporter.FeatureEnvelopeMode;
 import org.citydb.config.project.exporter.GeneralOptions;
 import org.citydb.config.project.exporter.OutputFormat;
 import org.citydb.config.project.query.filter.version.CityGMLVersionType;
-import org.citydb.util.event.global.PropertyChangeEvent;
+import org.citydb.core.registry.ObjectRegistry;
+import org.citydb.core.util.Util;
 import org.citydb.gui.components.TitledPanel;
 import org.citydb.gui.operation.common.DefaultPreferencesComponent;
 import org.citydb.gui.util.GuiUtil;
-import org.citydb.core.registry.ObjectRegistry;
-import org.citydb.core.util.Util;
+import org.citydb.util.event.global.PropertyChangeEvent;
 
 import javax.swing.*;
 import java.awt.*;
 
 public class GeneralPanel extends DefaultPreferencesComponent {
-	private TitledPanel versionPanel;
+	private TitledPanel generalPanel;
 	private JRadioButton cityGMLv2;
 	private JRadioButton cityGMLv1;
 	private JLabel versionHintLabel;
+	private JCheckBox failFastOnErrors;
 	private JLabel compressedOutputFormatLabel;
 	private JComboBox<OutputFormat> compressedOutputFormat;
 
@@ -69,6 +70,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 		if (cityGMLv1.isSelected() && version != CityGMLVersionType.v1_0_0) return true;
 
 		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
+		if (failFastOnErrors.isSelected() != generalOptions.isFailFastOnErrors()) return true;
 		if (compressedOutputFormat.getSelectedItem() != generalOptions.getCompressedOutputFormat()) return true;
 		if (featureEnvelope.getSelectedItem() != generalOptions.getEnvelope().getFeatureMode()) return true;
 		if (cityModelEnvelope.isSelected() != generalOptions.getEnvelope().isUseEnvelopeOnCityModel()) return true;
@@ -88,6 +90,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 		versionHintLabel = new JLabel();
 		versionHintLabel.setFont(versionHintLabel.getFont().deriveFont(Font.ITALIC));
 
+		failFastOnErrors = new JCheckBox();
 		compressedOutputFormatLabel = new JLabel();
 		compressedOutputFormat = new JComboBox<>();
 		for (OutputFormat outputFormat : OutputFormat.values()) {
@@ -127,10 +130,11 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 			content.add(cityGMLv2, GuiUtil.setConstraints(0, 0, 2, 1, 1, 1, GridBagConstraints.BOTH, 0, 0, 0, 0));
 			content.add(versionHintLabel, GuiUtil.setConstraints(0, 1, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, lmargin, 0, 0));
 			content.add(cityGMLv1, GuiUtil.setConstraints(0, 2, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
-			content.add(compressedOutputFormatLabel, GuiUtil.setConstraints(0, 3, 0, 0, GridBagConstraints.HORIZONTAL, 5, 0, 0, 5));
-			content.add(compressedOutputFormat, GuiUtil.setConstraints(1, 3, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 0));
+			content.add(failFastOnErrors, GuiUtil.setConstraints(0, 3, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
+			content.add(compressedOutputFormatLabel, GuiUtil.setConstraints(0, 4, 0, 0, GridBagConstraints.HORIZONTAL, 5, 0, 0, 5));
+			content.add(compressedOutputFormat, GuiUtil.setConstraints(1, 4, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 0));
 
-			versionPanel = new TitledPanel().build(content);
+			generalPanel = new TitledPanel().build(content);
 		}
 		{
 			JPanel content = new JPanel();
@@ -145,7 +149,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 			envelopePanel = new TitledPanel().build(content);
 		}
 
-		add(versionPanel, GuiUtil.setConstraints(0, 0, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
+		add(generalPanel, GuiUtil.setConstraints(0, 0, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
 		add(envelopePanel, GuiUtil.setConstraints(0, 1, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
 
 		cityModelEnvelope.addActionListener(e -> setEnabledEnvelopeOptions());
@@ -153,10 +157,11 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 
 	@Override
 	public void doTranslation() {
-		versionPanel.setTitle(Language.I18N.getString("pref.export.general.border.general"));
+		generalPanel.setTitle(Language.I18N.getString("pref.export.general.border.general"));
 		cityGMLv2.setText(Language.I18N.getString("pref.export.general.label.citygmlv2"));
 		cityGMLv1.setText(Language.I18N.getString("pref.export.general.label.citygmlv1"));
 		versionHintLabel.setText(Language.I18N.getString("pref.export.general.label.versionHint"));
+		failFastOnErrors.setText(Language.I18N.getString("pref.export.general.failFastOnError"));
 		compressedOutputFormatLabel.setText(Language.I18N.getString("pref.export.general.label.compressedFormat"));
 		envelopePanel.setTitle(Language.I18N.getString("pref.export.general.border.bbox"));
 		featureEnvelopeLabel.setText(Language.I18N.getString("pref.export.general.label.feature"));
@@ -176,6 +181,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 		firePropertyChange(version);
 
 		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
+		failFastOnErrors.setSelected(generalOptions.isFailFastOnErrors());
 		compressedOutputFormat.setSelectedItem(generalOptions.getCompressedOutputFormat());
 		featureEnvelope.setSelectedItem(generalOptions.getEnvelope().getFeatureMode());
 		cityModelEnvelope.setSelected(generalOptions.getEnvelope().isUseEnvelopeOnCityModel());
@@ -191,6 +197,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 		firePropertyChange(version);
 
 		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
+		generalOptions.setFailFastOnErrors(failFastOnErrors.isSelected());
 		generalOptions.setCompressedOutputFormat((OutputFormat) compressedOutputFormat.getSelectedItem());
 		generalOptions.getEnvelope().setFeatureMode((FeatureEnvelopeMode) featureEnvelope.getSelectedItem());
 		generalOptions.getEnvelope().setUseEnvelopeOnCityModel(cityModelEnvelope.isSelected());

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/CityGMLImportPreferences.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/CityGMLImportPreferences.java
@@ -37,7 +37,8 @@ public class CityGMLImportPreferences extends DefaultPreferences {
 	
 	public CityGMLImportPreferences(Config config) {
 		super(new CityGMLImportEntry());
-		
+
+		root.addChildEntry(new DefaultPreferencesEntry(new GeneralPanel(config)));
 		root.addChildEntry(new DefaultPreferencesEntry(new ContinuationPanel(config)));
 		root.addChildEntry(new DefaultPreferencesEntry(new ResourceIdPanel(config)));
 		root.addChildEntry(new DefaultPreferencesEntry(new AppearancePanel(config)));

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/GeneralPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/GeneralPanel.java
@@ -1,0 +1,70 @@
+package org.citydb.gui.operation.importer.preferences;
+
+import org.citydb.config.Config;
+import org.citydb.config.i18n.Language;
+import org.citydb.config.project.importer.GeneralOptions;
+import org.citydb.gui.components.TitledPanel;
+import org.citydb.gui.operation.common.DefaultPreferencesComponent;
+import org.citydb.gui.util.GuiUtil;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class GeneralPanel extends DefaultPreferencesComponent {
+    private TitledPanel generalPanel;
+    private JCheckBox failFastOnErrors;
+
+    public GeneralPanel(Config config) {
+        super(config);
+        initGui();
+    }
+
+    @Override
+    public boolean isModified() {
+        GeneralOptions generalOptions = config.getImportConfig().getGeneralOptions();
+
+        if (failFastOnErrors.isSelected() != generalOptions.isFailFastOnErrors()) return true;
+
+        return false;
+    }
+
+    private void initGui() {
+        failFastOnErrors = new JCheckBox();
+
+        setLayout(new GridBagLayout());
+        {
+            JPanel content = new JPanel();
+            content.setLayout(new GridBagLayout());
+            {
+                content.add(failFastOnErrors, GuiUtil.setConstraints(0, 0, 2, 1, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
+            }
+
+            generalPanel = new TitledPanel().build(content);
+        }
+
+        add(generalPanel, GuiUtil.setConstraints(0, 0, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
+    }
+
+    @Override
+    public void setSettings() {
+        GeneralOptions generalOptions = config.getImportConfig().getGeneralOptions();
+        generalOptions.setFailFastOnErrors(failFastOnErrors.isSelected());
+    }
+
+    @Override
+    public void loadSettings() {
+        GeneralOptions generalOptions = config.getImportConfig().getGeneralOptions();
+        failFastOnErrors.setSelected(generalOptions.isFailFastOnErrors());
+    }
+
+    @Override
+    public void doTranslation() {
+        generalPanel.setTitle(Language.I18N.getString("pref.import.general.border.general"));
+        failFastOnErrors.setText(Language.I18N.getString("pref.import.general.failFastOnError"));
+    }
+
+    @Override
+    public String getTitle() {
+        return Language.I18N.getString("pref.tree.import.general");
+    }
+}

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/GeneralOptions.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/GeneralOptions.java
@@ -33,12 +33,21 @@ import java.nio.charset.StandardCharsets;
 
 @XmlType(name="GeneralExportOptionsType", propOrder={})
 public class GeneralOptions {
+    private Boolean failFastOnErrors = true;
     private String fileEncoding;
     private OutputFormat compressedOutputFormat = OutputFormat.CITYGML;
     private ExportEnvelope envelope;
 
     public GeneralOptions() {
         envelope = new ExportEnvelope();
+    }
+
+    public boolean isFailFastOnErrors() {
+        return failFastOnErrors != null ? failFastOnErrors : true;
+    }
+
+    public void setFailFastOnErrors(boolean failFastOnErrors) {
+        this.failFastOnErrors = failFastOnErrors;
     }
 
     public boolean isSetFileEncoding() {

--- a/impexp-config/src/main/java/org/citydb/config/project/importer/GeneralOptions.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/importer/GeneralOptions.java
@@ -33,7 +33,16 @@ import java.nio.charset.StandardCharsets;
 
 @XmlType(name="GeneralImportOptionsType", propOrder={})
 public class GeneralOptions {
+    private Boolean failFastOnErrors = true;
     private String fileEncoding;
+
+    public boolean isFailFastOnErrors() {
+        return failFastOnErrors != null ? failFastOnErrors : true;
+    }
+
+    public void setFailFastOnErrors(boolean failFastOnErrors) {
+        this.failFastOnErrors = failFastOnErrors;
+    }
 
     public boolean isSetFileEncoding() {
         return fileEncoding != null;

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -381,6 +381,7 @@ pref.tree.export=Export
 pref.tree.database=Datenbank
 pref.tree.plugins=Plugins
 pref.tree.general=Allgemein
+pref.tree.import.general=Allgemein
 pref.tree.import.continuation=Fortschreibung
 pref.tree.import.id=Objekt-Identifier
 pref.tree.import.cityGMLOptions=CityGML Optionen
@@ -437,6 +438,9 @@ pref.tree.general.path=Dateipfade
 pref.tree.general.language=Sprachauswahl
 pref.tree.general.proxies=Netzwerk-Proxies
 pref.tree.general.apiKeys=API Keys
+
+pref.import.general.border.general=Allgemeine Optionen
+pref.import.general.failFastOnError=Import bei Fehlern sofort abbrechen
 
 pref.import.continuation.border.lineage=Fortschreibungsinformationen
 pref.import.continuation.label.lineage=Datenabstammung
@@ -501,6 +505,7 @@ pref.export.general.border.general=Allgemeine Optionen
 pref.export.general.label.citygmlv2=CityGML 2.0 verwenden
 pref.export.general.label.citygmlv1=CityGML 1.0 verwenden
 pref.export.general.label.versionHint=Diese Version wird für CityJSON Exporte empfohlen
+pref.export.general.failFastOnError=Export bei Fehlern sofort abbrechen
 pref.export.general.label.compressedFormat=Ausgabeformat für komprimierte Exporte
 pref.export.general.border.bbox=Bounding Box Optionen
 pref.export.general.label.feature=Bounding Box exportieren

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -381,6 +381,7 @@ pref.tree.export=Export
 pref.tree.database=Database
 pref.tree.plugins=Plugins
 pref.tree.general=General
+pref.tree.import.general=General
 pref.tree.import.continuation=Continuation
 pref.tree.import.id=Object identifier
 pref.tree.import.cityGMLOptions=CityGML options
@@ -437,6 +438,9 @@ pref.tree.general.path=Import and export path
 pref.tree.general.language=Language selection
 pref.tree.general.proxies=Network proxies
 pref.tree.general.apiKeys=API Keys
+
+pref.import.general.border.general=General options
+pref.import.general.failFastOnError=Cancel import immediately in case of errors
 
 pref.import.continuation.border.lineage=Continuation information
 pref.import.continuation.label.lineage=Data lineage
@@ -501,6 +505,7 @@ pref.export.general.border.general=General options
 pref.export.general.label.citygmlv2=Use CityGML 2.0
 pref.export.general.label.citygmlv1=Use CityGML 1.0
 pref.export.general.label.versionHint=This version is recommended when exporting to CityJSON
+pref.export.general.failFastOnError=Cancel export immediately in case of errors
 pref.export.general.label.compressedFormat=Output format for compressed exports
 pref.export.general.border.bbox=Bounding box options
 pref.export.general.label.feature=Export bounding box

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/CityGMLExportManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/CityGMLExportManager.java
@@ -124,6 +124,7 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 	private final InternalConfig internalConfig;
 	private final Config config;
 
+	private final boolean failOnError;
 	private final Set<String> localGeometryCache;
 	private final AttributeValueSplitter attributeValueSplitter;
 	private final ExportCounter exportCounter;
@@ -135,7 +136,6 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 	private AppearanceRemover appearanceRemover;
 	private AffineTransformer affineTransformer;
 	private Document document;
-	private boolean failOnError;
 
 	public CityGMLExportManager(Connection connection,
 			Query query,
@@ -165,6 +165,7 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 		hasADESupport = !adeManager.getEnabledExtensions().isEmpty();
 		plugins = PluginManager.getInstance().getEnabledExternalPlugins(FeatureExportExtension.class);
 
+		failOnError = config.getExportConfig().getGeneralOptions().isFailFastOnErrors();
 		localGeometryCache = new HashSet<>();
 		attributeValueSplitter = new AttributeValueSplitter();
 		exportCounter = new ExportCounter(schemaMapping);
@@ -784,10 +785,6 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 
 	protected String getPropertyName(AbstractProperty property) {
 		return property.getSchema().getXMLPrefix() + ":" + property.getPath();
-	}
-
-	public void setFailOnError(boolean failOnError) {
-		this.failOnError = failOnError;
 	}
 
 	protected boolean hasADESupport() {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/CityGMLImportManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/CityGMLImportManager.java
@@ -126,6 +126,7 @@ public class CityGMLImportManager implements CityGMLImportHelper {
 	private final InternalConfig internalConfig;
 	private final Config config;
 
+	private final boolean failOnError;
 	private final TableHelper tableHelper;
 	private final SequenceHelper sequenceHelper;
 	private final GeometryConverter geometryConverter;
@@ -142,7 +143,6 @@ public class CityGMLImportManager implements CityGMLImportHelper {
 	private CityGMLVersion cityGMLVersion;
 	private JAXBMarshaller jaxbMarshaller;
 	private SAXWriter saxWriter;
-	private boolean failOnError = false;
 
 	public CityGMLImportManager(Connection connection,
 			AbstractDatabaseAdapter databaseAdapter, 
@@ -165,6 +165,7 @@ public class CityGMLImportManager implements CityGMLImportHelper {
 		adeManager = ADEExtensionManager.getInstance();		
 		hasADESupport = !adeManager.getEnabledExtensions().isEmpty();
 
+		failOnError = config.getImportConfig().getGeneralOptions().isFailFastOnErrors();
 		tableHelper = new TableHelper(schemaMapping);
 		sequenceHelper = new SequenceHelper(connection, databaseAdapter, config);
 		geometryConverter = new GeometryConverter(databaseAdapter, failOnError);
@@ -525,10 +526,6 @@ public class CityGMLImportManager implements CityGMLImportHelper {
 
 	public InternalConfig getInternalConfig() {
 		return internalConfig;
-	}
-
-	public void setFailOnError(boolean failOnError) {
-		this.failOnError = failOnError;
 	}
 
 	protected boolean hasADESupport() {


### PR DESCRIPTION
This PR adds a *fail fast* option to the CityGML import and export operations in both CLI and GUI mode. This option is in the code for quite some time but we never made it available to the user.

The option does not affect the general behaviour when internal exceptions are thrown. Both operations are always aborted on internal exceptions. It rather controls the behaviour in case the method `logOrThrowErrorMessage` is used in the code, which is also exposed to developers by our ADE API.

Besides making the option available to users, this PR also proposes to change its default value to `true` (was `false` in the past).