### PR TITLE
Change import log file behavior

### DIFF
--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportCommand.java
@@ -36,6 +36,7 @@ import org.citydb.config.Config;
 import org.citydb.config.project.database.DatabaseConnection;
 import org.citydb.config.project.importer.ImportConfig;
 import org.citydb.config.project.importer.ImportList;
+import org.citydb.config.project.importer.ImportLogFileMode;
 import org.citydb.core.database.DatabaseController;
 import org.citydb.core.operation.common.csv.IdListPreviewer;
 import org.citydb.core.operation.importer.CityGMLImportException;
@@ -168,6 +169,7 @@ public class ImportCommand extends CliCommand {
         if (importLogFile != null) {
             importConfig.getImportLog().setLogFile(importLogFile.toAbsolutePath().toString());
             importConfig.getImportLog().setLogImportedFeatures(true);
+            importConfig.getImportLog().setLogFileMode(ImportLogFileMode.TRUNCATE);
         }
 
         if (failFast != null) {

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/ImportLogPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/ImportLogPanel.java
@@ -30,6 +30,7 @@ package org.citydb.gui.operation.importer.preferences;
 import org.citydb.config.Config;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.importer.ImportLog;
+import org.citydb.config.project.importer.ImportLogMode;
 import org.citydb.core.util.CoreConstants;
 import org.citydb.gui.components.TitledPanel;
 import org.citydb.gui.components.popup.PopupMenuDecorator;
@@ -38,6 +39,7 @@ import org.citydb.gui.util.GuiUtil;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.ItemEvent;
 import java.io.File;
 
 public class ImportLogPanel extends DefaultPreferencesComponent {
@@ -46,6 +48,8 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 	private JLabel logFileLabel;
 	private JTextField logFile;
 	private JButton browseButton;
+	private JCheckBox truncateLogFile;
+	private JCheckBox uniqueFileName;
 	
 	public ImportLogPanel(Config config) {
 		super(config);
@@ -57,6 +61,8 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 		ImportLog log = config.getImportConfig().getImportLog();
 		if (logFeatures.isSelected() != log.isSetLogImportedFeatures()) return true;
 		if (!logFile.getText().equals(log.getLogFile())) return true;
+		if (truncateLogFile.isSelected() != (log.getLogMode() == ImportLogMode.TRUNCATE)) return true;
+		if (uniqueFileName.isSelected() != (log.getLogMode() == ImportLogMode.UNIQUE)) return true;
 		return false;
 	}
 
@@ -65,13 +71,27 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 		logFileLabel = new JLabel();
 		logFile = new JTextField();
 		browseButton = new JButton();
-		
+		truncateLogFile = new JCheckBox();
+		uniqueFileName = new JCheckBox();
+
 		PopupMenuDecorator.getInstance().decorate(logFile);
 		
 		browseButton.addActionListener(e -> {
 			String dir = browseFile(Language.I18N.getString("pref.tree.import.log"), logFile.getText());
 			if (!dir.isEmpty())
 				logFile.setText(dir);
+		});
+
+		truncateLogFile.addItemListener(e -> {
+			if (e.getStateChange() == ItemEvent.SELECTED) {
+				uniqueFileName.setSelected(false);
+			}
+		});
+
+		uniqueFileName.addItemListener(e -> {
+			if (e.getStateChange() == ItemEvent.SELECTED) {
+				truncateLogFile.setSelected(false);
+			}
 		});
 
 		setLayout(new GridBagLayout());
@@ -83,6 +103,8 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 				content.add(logFileLabel, GuiUtil.setConstraints(0, 0, 0, 0, GridBagConstraints.BOTH, 0, 0, 0, 5));
 				content.add(logFile, GuiUtil.setConstraints(1, 0, 1, 1, GridBagConstraints.BOTH, 0, 5, 0, 5));
 				content.add(browseButton, GuiUtil.setConstraints(2, 0, 0, 0, GridBagConstraints.BOTH, 0, 5, 0, 0));
+				content.add(truncateLogFile, GuiUtil.setConstraints(0, 1, 3, 1, 0, 0, GridBagConstraints.BOTH, 5, 0, 0, 0));
+				content.add(uniqueFileName, GuiUtil.setConstraints(0, 2, 3, 1, 0, 0, GridBagConstraints.BOTH, 5, 0, 0, 0));
 			}
 
 			importLogPanel = new TitledPanel()
@@ -106,6 +128,8 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 		importLogPanel.setTitle(Language.I18N.getString("pref.import.log.label.useLog"));
 		logFileLabel.setText(Language.I18N.getString("pref.import.log.label.logFile"));
 		browseButton.setText(Language.I18N.getString("common.button.browse"));
+		truncateLogFile.setText(Language.I18N.getString("pref.import.log.label.truncate"));
+		uniqueFileName.setText(Language.I18N.getString("pref.import.log.label.unique"));
 	}
 
 	@Override
@@ -119,6 +143,12 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 			String defaultDir = CoreConstants.IMPEXP_DATA_DIR.resolve(CoreConstants.IMPORT_LOG_DIR).toString();
 			logFile.setText(defaultDir);
 			log.setLogFile(defaultDir);
+		}
+
+		if (log.getLogMode() == ImportLogMode.UNIQUE) {
+			uniqueFileName.setSelected(true);
+		} else {
+			truncateLogFile.setSelected(log.getLogMode() == ImportLogMode.TRUNCATE);
 		}
 		
 		setEnabledLocalCachePath();
@@ -136,6 +166,14 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 			logFile.setText(defaultDir);
 			log.setLogFile(defaultDir);
 		}
+
+		if (uniqueFileName.isSelected()) {
+			log.setLogMode(ImportLogMode.UNIQUE);
+		} else {
+			log.setLogMode(truncateLogFile.isSelected() ?
+					ImportLogMode.TRUNCATE :
+					ImportLogMode.APPEND);
+		}
 	}
 	
 	@Override
@@ -146,7 +184,7 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 	private String browseFile(String title, String currentFile) {
 		JFileChooser chooser = new JFileChooser();
 		chooser.setDialogTitle(title);
-		chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+		chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
 		chooser.setCurrentDirectory(new File(currentFile));
 
 		int result = chooser.showSaveDialog(getTopLevelAncestor());

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/ImportLogPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/ImportLogPanel.java
@@ -121,6 +121,8 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 		logFileLabel.setEnabled(logFeatures.isSelected());
 		logFile.setEnabled(logFeatures.isSelected());
 		browseButton.setEnabled(logFeatures.isSelected());
+		truncateLogFile.setEnabled(logFeatures.isSelected());
+		uniqueFileName.setEnabled(logFeatures.isSelected());
 	}
 	
 	@Override

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/ImportLogPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/preferences/ImportLogPanel.java
@@ -30,7 +30,7 @@ package org.citydb.gui.operation.importer.preferences;
 import org.citydb.config.Config;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.importer.ImportLog;
-import org.citydb.config.project.importer.ImportLogMode;
+import org.citydb.config.project.importer.ImportLogFileMode;
 import org.citydb.core.util.CoreConstants;
 import org.citydb.gui.components.TitledPanel;
 import org.citydb.gui.components.popup.PopupMenuDecorator;
@@ -61,8 +61,8 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 		ImportLog log = config.getImportConfig().getImportLog();
 		if (logFeatures.isSelected() != log.isSetLogImportedFeatures()) return true;
 		if (!logFile.getText().equals(log.getLogFile())) return true;
-		if (truncateLogFile.isSelected() != (log.getLogMode() == ImportLogMode.TRUNCATE)) return true;
-		if (uniqueFileName.isSelected() != (log.getLogMode() == ImportLogMode.UNIQUE)) return true;
+		if (truncateLogFile.isSelected() != (log.getLogFileMode() == ImportLogFileMode.TRUNCATE)) return true;
+		if (uniqueFileName.isSelected() != (log.getLogFileMode() == ImportLogFileMode.UNIQUE)) return true;
 		return false;
 	}
 
@@ -145,10 +145,10 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 			log.setLogFile(defaultDir);
 		}
 
-		if (log.getLogMode() == ImportLogMode.UNIQUE) {
+		if (log.getLogFileMode() == ImportLogFileMode.UNIQUE) {
 			uniqueFileName.setSelected(true);
 		} else {
-			truncateLogFile.setSelected(log.getLogMode() == ImportLogMode.TRUNCATE);
+			truncateLogFile.setSelected(log.getLogFileMode() == ImportLogFileMode.TRUNCATE);
 		}
 		
 		setEnabledLocalCachePath();
@@ -168,11 +168,11 @@ public class ImportLogPanel extends DefaultPreferencesComponent {
 		}
 
 		if (uniqueFileName.isSelected()) {
-			log.setLogMode(ImportLogMode.UNIQUE);
+			log.setLogFileMode(ImportLogFileMode.UNIQUE);
 		} else {
-			log.setLogMode(truncateLogFile.isSelected() ?
-					ImportLogMode.TRUNCATE :
-					ImportLogMode.APPEND);
+			log.setLogFileMode(truncateLogFile.isSelected() ?
+					ImportLogFileMode.TRUNCATE :
+					ImportLogFileMode.APPEND);
 		}
 	}
 	

--- a/impexp-config/src/main/java/org/citydb/config/project/importer/ImportLog.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/importer/ImportLog.java
@@ -32,11 +32,13 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlType(name = "ImportLogType", propOrder = {
         "logImportedFeatures",
+        "logMode",
         "logFile"
 })
 public class ImportLog {
     @XmlElement(required = true, defaultValue = "false")
     private Boolean logImportedFeatures = false;
+    private ImportLogMode logMode;
     private String logFile;
 
     public boolean isSetLogImportedFeatures() {
@@ -49,6 +51,14 @@ public class ImportLog {
 
     public void setLogImportedFeatures(Boolean logImportedFeatures) {
         this.logImportedFeatures = logImportedFeatures;
+    }
+
+    public ImportLogMode getLogMode() {
+        return logMode != null ? logMode : ImportLogMode.UNIQUE;
+    }
+
+    public void setLogMode(ImportLogMode logMode) {
+        this.logMode = logMode;
     }
 
     public boolean isSetLogFile() {

--- a/impexp-config/src/main/java/org/citydb/config/project/importer/ImportLog.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/importer/ImportLog.java
@@ -32,13 +32,13 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlType(name = "ImportLogType", propOrder = {
         "logImportedFeatures",
-        "logMode",
+        "logFileMode",
         "logFile"
 })
 public class ImportLog {
     @XmlElement(required = true, defaultValue = "false")
     private Boolean logImportedFeatures = false;
-    private ImportLogMode logMode;
+    private ImportLogFileMode logFileMode;
     private String logFile;
 
     public boolean isSetLogImportedFeatures() {
@@ -53,12 +53,12 @@ public class ImportLog {
         this.logImportedFeatures = logImportedFeatures;
     }
 
-    public ImportLogMode getLogMode() {
-        return logMode != null ? logMode : ImportLogMode.UNIQUE;
+    public ImportLogFileMode getLogFileMode() {
+        return logFileMode != null ? logFileMode : ImportLogFileMode.UNIQUE;
     }
 
-    public void setLogMode(ImportLogMode logMode) {
-        this.logMode = logMode;
+    public void setLogFileMode(ImportLogFileMode logFileMode) {
+        this.logFileMode = logFileMode;
     }
 
     public boolean isSetLogFile() {

--- a/impexp-config/src/main/java/org/citydb/config/project/importer/ImportLogFileMode.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/importer/ImportLogFileMode.java
@@ -33,7 +33,7 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlType(name = "ImportLogModeType")
 @XmlEnum
-public enum ImportLogMode {
+public enum ImportLogFileMode {
     @XmlEnumValue("truncate")
     TRUNCATE("truncate"),
     @XmlEnumValue("append")
@@ -43,7 +43,7 @@ public enum ImportLogMode {
 
     private final String value;
 
-    ImportLogMode(String v) {
+    ImportLogFileMode(String v) {
         value = v;
     }
 
@@ -51,8 +51,8 @@ public enum ImportLogMode {
         return value;
     }
 
-    public static ImportLogMode fromValue(String v) {
-        for (ImportLogMode c : ImportLogMode.values()) {
+    public static ImportLogFileMode fromValue(String v) {
+        for (ImportLogFileMode c : ImportLogFileMode.values()) {
             if (c.value.equals(v)) {
                 return c;
             }

--- a/impexp-config/src/main/java/org/citydb/config/project/importer/ImportLogMode.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/importer/ImportLogMode.java
@@ -1,0 +1,63 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2021
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citydb.config.project.importer;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(name = "ImportLogModeType")
+@XmlEnum
+public enum ImportLogMode {
+    @XmlEnumValue("truncate")
+    TRUNCATE("truncate"),
+    @XmlEnumValue("append")
+    APPEND("append"),
+    @XmlEnumValue("unique")
+    UNIQUE("unique");
+
+    private final String value;
+
+    ImportLogMode(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static ImportLogMode fromValue(String v) {
+        for (ImportLogMode c : ImportLogMode.values()) {
+            if (c.value.equals(v)) {
+                return c;
+            }
+        }
+
+        return UNIQUE;
+    }
+}

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -484,7 +484,9 @@ pref.import.index.normal.label.autoActivate=Vor Import deaktivieren und automati
 pref.import.index.normal.label.manuActivate=Vor Import deaktivieren und nicht reaktivieren
 
 pref.import.log.label.useLog=Importierte Top-Level Feature in Logdatei protokollieren
-pref.import.log.label.logFile=Datei oder Ordner
+pref.import.log.label.logFile=Log-Datei
+pref.import.log.label.truncate=Log-Datei vor dem Import leeren
+pref.import.log.label.unique=Eindeutigen Dateinamen durch Anhängen des Zeitstempels erzeugen
 
 pref.import.xmlValidation.label.useXMLValidation=XML-Validierung während des Imports durchführen
 pref.import.xmlValidation.label.useXMLValidation.description=<html>Invalide Top-Level Features werden <b>nicht</b> importiert</html>

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -484,7 +484,9 @@ pref.import.index.normal.label.autoActivate=Deactivate before import and automat
 pref.import.index.normal.label.manuActivate=Deactivate before import and keep deactivated
 
 pref.import.log.label.useLog=Record imported top-level feature in log file
-pref.import.log.label.logFile=File or directory
+pref.import.log.label.logFile=Log file
+pref.import.log.label.truncate=Truncate log file before import
+pref.import.log.label.unique=Append timestamp suffix to create unique file name
 
 pref.import.xmlValidation.label.useXMLValidation=Perform XML validation during database import
 pref.import.xmlValidation.label.useXMLValidation.description=<html>Invalid top-level features will <b>not</b> be imported</html>

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/controller/Importer.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/controller/Importer.java
@@ -77,7 +77,6 @@ import org.citydb.core.plugin.extension.importer.FeatureImportExtension;
 import org.citydb.core.plugin.extension.importer.ImportStatus;
 import org.citydb.core.query.filter.FilterException;
 import org.citydb.core.registry.ObjectRegistry;
-import org.citydb.core.util.CoreConstants;
 import org.citydb.core.util.Util;
 import org.citydb.util.concurrent.PoolSizeAdaptationStrategy;
 import org.citydb.util.concurrent.WorkerPool;
@@ -234,10 +233,9 @@ public class Importer implements EventHandler {
         importLogger = null;
         if (config.getImportConfig().getImportLog().isSetLogImportedFeatures()) {
             try {
-                Path logFile = config.getImportConfig().getImportLog().isSetLogFile() ?
-                        Paths.get(config.getImportConfig().getImportLog().getLogFile()) :
-                        CoreConstants.IMPEXP_DATA_DIR.resolve(CoreConstants.IMPORT_LOG_DIR);
-                importLogger = new ImportLogger(logFile, config.getDatabaseConfig().getActiveConnection());
+                importLogger = new ImportLogger(
+                        config.getImportConfig().getImportLog(),
+                        config.getDatabaseConfig().getActiveConnection());
                 log.info("Log file of imported top-level features: " + importLogger.getLogFilePath().toString());
             } catch (IOException e) {
                 throw new CityGMLImportException("Failed to create log file for imported top-level features.", e);

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/util/ImportLogger.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/util/ImportLogger.java
@@ -29,7 +29,7 @@ package org.citydb.core.operation.importer.util;
 
 import org.citydb.config.project.database.DatabaseConnection;
 import org.citydb.config.project.importer.ImportLog;
-import org.citydb.config.project.importer.ImportLogMode;
+import org.citydb.config.project.importer.ImportLogFileMode;
 import org.citydb.core.util.CoreConstants;
 
 import java.io.BufferedWriter;
@@ -59,20 +59,20 @@ public class ImportLogger {
 			logFile = defaultLogDir.resolve("imported-features.log");
 		}
 
-		if (importLog.getLogMode() == ImportLogMode.UNIQUE) {
+		if (importLog.getLogFileMode() == ImportLogFileMode.UNIQUE) {
 			logFile = logFile.resolveSibling(getUniqueFileName(logFile.getFileName().toString()));
 		}
 
 		boolean writeHeaderLine = true;
 		if (!Files.exists(logFile.getParent())) {
 			Files.createDirectories(logFile.getParent());
-		} else if (importLog.getLogMode() == ImportLogMode.APPEND) {
+		} else if (importLog.getLogFileMode() == ImportLogFileMode.APPEND) {
 			writeHeaderLine = !Files.exists(logFile);
 		}
 
 		writer = Files.newBufferedWriter(logFile, StandardCharsets.UTF_8,
 				StandardOpenOption.CREATE, StandardOpenOption.WRITE,
-				importLog.getLogMode() == ImportLogMode.TRUNCATE ?
+				importLog.getLogFileMode() == ImportLogFileMode.TRUNCATE ?
 						StandardOpenOption.TRUNCATE_EXISTING :
 						StandardOpenOption.APPEND);
 

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/util/ImportLogger.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/util/ImportLogger.java
@@ -28,6 +28,8 @@
 package org.citydb.core.operation.importer.util;
 
 import org.citydb.config.project.database.DatabaseConnection;
+import org.citydb.config.project.importer.ImportLog;
+import org.citydb.config.project.importer.ImportLogMode;
 import org.citydb.core.util.CoreConstants;
 
 import java.io.BufferedWriter;
@@ -35,30 +37,46 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class ImportLogger {
 	private final LocalDateTime date = LocalDateTime.now();
-	private final Path logFile;
 	private final BufferedWriter writer;
+	private Path logFile;
 	private String inputFile = "";
 
-	public ImportLogger(Path logFile, DatabaseConnection connection) throws IOException {
-		Path defaultDir = CoreConstants.IMPEXP_DATA_DIR.resolve(CoreConstants.IMPORT_LOG_DIR);
-		if (logFile.toAbsolutePath().normalize().startsWith(defaultDir)) {
-			Files.createDirectories(defaultDir);
+	public ImportLogger(ImportLog importLog, DatabaseConnection connection) throws IOException {
+		Path defaultLogDir = CoreConstants.IMPEXP_DATA_DIR.resolve(CoreConstants.IMPORT_LOG_DIR);
+		if (importLog.isSetLogFile()) {
+			logFile = Paths.get(importLog.getLogFile());
+			if (logFile.equals(defaultLogDir)) {
+				logFile = logFile.resolve("imported-features.log");
+			}
+		} else {
+			logFile = defaultLogDir.resolve("imported-features.log");
 		}
 
-		if (Files.exists(logFile) && Files.isDirectory(logFile)) {
-			logFile = logFile.resolve(getDefaultLogFileName());
-		} else if (!Files.exists(logFile.getParent())) {
+		if (importLog.getLogMode() == ImportLogMode.UNIQUE) {
+			logFile = logFile.resolveSibling(getUniqueFileName(logFile.getFileName().toString()));
+		}
+
+		boolean writeHeaderLine = true;
+		if (!Files.exists(logFile.getParent())) {
 			Files.createDirectories(logFile.getParent());
+		} else if (importLog.getLogMode() == ImportLogMode.APPEND) {
+			writeHeaderLine = !Files.exists(logFile);
 		}
 
-		this.logFile = logFile;
-		writer = Files.newBufferedWriter(logFile, StandardCharsets.UTF_8);
-		writeHeader(connection);
+		writer = Files.newBufferedWriter(logFile, StandardCharsets.UTF_8,
+				StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+				importLog.getLogMode() == ImportLogMode.TRUNCATE ?
+						StandardOpenOption.TRUNCATE_EXISTING :
+						StandardOpenOption.APPEND);
+
+		writeHeader(connection, writeHeaderLine);
 	}
 
 	public Path getLogFilePath() {
@@ -69,7 +87,7 @@ public class ImportLogger {
 		this.inputFile = inputFile != null ? inputFile.toAbsolutePath().toString() : "";
 	}
 
-	private void writeHeader(DatabaseConnection connection) throws IOException {
+	private void writeHeader(DatabaseConnection connection, boolean writeHeaderLine) throws IOException {
 		writer.write('#' + getClass().getPackage().getImplementationTitle() +
 				", version \"" + getClass().getPackage().getImplementationVersion() + "\"");
 		writer.newLine();
@@ -79,20 +97,28 @@ public class ImportLogger {
 		writer.write("#Timestamp: ");
 		writer.write(date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")));
 		writer.newLine();
-		writer.write("FEATURE_TYPE,CITYOBJECT_ID,GMLID_IN_FILE,INPUT_FILE");
-		writer.newLine();
+
+		if (writeHeaderLine) {
+			writer.write("FEATURE_TYPE,CITYOBJECT_ID,GMLID_IN_FILE,INPUT_FILE");
+			writer.newLine();
+		}
 	}
 
 	private void writeFooter(boolean success) throws IOException {
 		writer.write(success ? "#Import successfully finished." : "#Import aborted.");
+		writer.newLine();
 	}
 	
 	public void write(ImportLogEntry entry) throws IOException {
 		writer.write(entry.type + "," + entry.id + "," + entry.gmlId + "," + inputFile + System.lineSeparator());
 	}
 
-	public String getDefaultLogFileName() {
-		return "imported-features-" + date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS")) + ".log";
+	private String getUniqueFileName(String fileName) {
+		String suffix = date.format(DateTimeFormatter.ofPattern("-yyyy-MM-dd_HH-mm-ss-SSS"));
+		int index = fileName.lastIndexOf('.');
+		return index != -1 ?
+				fileName.substring(0, index) + suffix + fileName.substring(index) :
+				fileName + suffix;
 	}
 
 	public void close(boolean success) throws IOException {


### PR DESCRIPTION
* The user must now provide a path to a file. Providing a directory is not supported anymore.
* Added the three log file modes `append`, `truncate` and `unique`
  * With `append`, multiple import operations can be logged to the same file
  * When choosing `truncate`, the target log file is truncated before every import
  * `unique` creates a unique file name by appending a timestamp as suffix. This mode reflects the previous behavior.

This PR also addresses #223.