### PR TITLE
Remove left joins from queries involving many nested child features

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBBridgeConstrElement.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBBridgeConstrElement.java
@@ -57,7 +57,7 @@ import java.sql.SQLException;
 import java.util.*;
 
 public class DBBridgeConstrElement extends AbstractFeatureExporter<BridgeConstructionElement> {
-	private final Map<Long, AbstractBridge> batches;
+	private final Set<Long> batches;
 	private final DBSurfaceGeometry geometryExporter;
 	private final DBCityObject cityObjectExporter;
 	private final DBBridgeThematicSurface thematicSurfaceExporter;
@@ -80,7 +80,7 @@ public class DBBridgeConstrElement extends AbstractFeatureExporter<BridgeConstru
 	public DBBridgeConstrElement(Connection connection, CityGMLExportManager exporter) throws CityGMLExportException, SQLException {
 		super(BridgeConstructionElement.class, connection, exporter);
 
-		batches = new LinkedHashMap<>();
+		batches = new HashSet<>();
 		batchSize = exporter.getFeatureBatchSize();
 		cityObjectExporter = exporter.getExporter(DBCityObject.class);
 		thematicSurfaceExporter = exporter.getExporter(DBBridgeThematicSurface.class);
@@ -99,7 +99,7 @@ public class DBBridgeConstrElement extends AbstractFeatureExporter<BridgeConstru
 		String schema = exporter.getDatabaseAdapter().getConnectionDetails().getSchema();
 
 		table = new Table(TableEnum.BRIDGE_CONSTR_ELEMENT.getName(), schema);
-		select = new Select().addProjection(table.getColumn("id"));
+		select = new Select().addProjection(table.getColumn("id"), table.getColumn("bridge_id"));
 		if (hasObjectClassIdColumn) select.addProjection(table.getColumn("objectclass_id"));
 		if (projectionFilter.containsProperty("class", bridgeModule)) select.addProjection(table.getColumn("class"), table.getColumn("class_codespace"));
 		if (projectionFilter.containsProperty("function", bridgeModule)) select.addProjection(table.getColumn("function"), table.getColumn("function_codespace"));
@@ -154,36 +154,35 @@ public class DBBridgeConstrElement extends AbstractFeatureExporter<BridgeConstru
 		constructionElementADEHookTables = addJoinsToADEHookTables(TableEnum.BRIDGE_CONSTR_ELEMENT, table);
 	}
 
-	protected void addBatch(long id, AbstractBridge parent) throws CityGMLExportException, SQLException {
-		batches.put(id, parent);
+	private void addBatch(long id, Map<Long, Collection<BridgeConstructionElement>> elements) throws CityGMLExportException, SQLException {
+		batches.add(id);
 		if (batches.size() == batchSize)
-			executeBatch();
+			executeBatch(elements);
 	}
 
-	protected void executeBatch() throws CityGMLExportException, SQLException {
+	private void executeBatch(Map<Long, Collection<BridgeConstructionElement>> elements) throws CityGMLExportException, SQLException {
 		if (batches.isEmpty())
 			return;
 
 		try {
 			PreparedStatement ps;
 			if (batches.size() == 1) {
-				ps = getOrCreateStatement("id");
-				ps.setLong(1, batches.keySet().iterator().next());
+				ps = getOrCreateStatement("bridge_id");
+				ps.setLong(1, batches.iterator().next());
 			} else {
-				ps = getOrCreateBulkStatement(batchSize);
-				prepareBulkStatement(ps, batches.keySet().toArray(new Long[0]), batchSize);
+				ps = getOrCreateBulkStatement("bridge_id", batchSize);
+				prepareBulkStatement(ps, batches.toArray(new Long[0]), batchSize);
 			}
 
 			try (ResultSet rs = ps.executeQuery()) {
-				Map<Long, BridgeConstructionElement> constructionElements = doExport(0, null, null, rs);
-				for (Map.Entry<Long, BridgeConstructionElement> entry : constructionElements.entrySet()) {
-					AbstractBridge bridge = batches.get(entry.getKey());
-					if (bridge == null) {
+				for (Map.Entry<Long, BridgeConstructionElement> entry : doExport(0, null, null, rs).entrySet()) {
+					Long bridgeId = (Long) entry.getValue().getLocalProperty("bridge_id");
+					if (bridgeId == null) {
 						exporter.logOrThrowErrorMessage("Failed to assign bridge construction element with id " + entry.getKey() + " to a bridge.");
 						continue;
 					}
 
-					bridge.addOuterBridgeConstructionElement(new BridgeConstructionElementProperty(entry.getValue()));
+					elements.computeIfAbsent(bridgeId, v -> new ArrayList<>()).add(entry.getValue());
 				}
 			}
 		} finally {
@@ -191,8 +190,22 @@ public class DBBridgeConstrElement extends AbstractFeatureExporter<BridgeConstru
 		}
 	}
 
-	protected Collection<BridgeConstructionElement> doExport(AbstractBridge parent, long parentId) throws CityGMLExportException, SQLException {
-		return doExport(parentId, null, null, getOrCreateStatement("bridge_id"));
+	protected Collection<BridgeConstructionElement> doExport(long bridgeId) throws CityGMLExportException, SQLException {
+		return doExport(bridgeId, null, null, getOrCreateStatement("bridge_id"));
+	}
+
+	protected Map<Long, Collection<BridgeConstructionElement>> doExport(Set<Long> bridgeIds) throws CityGMLExportException, SQLException {
+		if (bridgeIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Long, Collection<BridgeConstructionElement>> elements = new HashMap<>();
+		for (Long bridgeId : bridgeIds) {
+			addBatch(bridgeId, elements);
+		}
+
+		executeBatch(elements);
+		return elements;
 	}
 
 	@Override
@@ -409,6 +422,7 @@ public class DBBridgeConstrElement extends AbstractFeatureExporter<BridgeConstru
 						}
 					}
 
+					constructionElement.setLocalProperty("bridge_id", rs.getLong("bridge_id"));
 					constructionElement.setLocalProperty("projection", projectionFilter);
 					constructionElements.put(constructionElementId, constructionElement);
 				} else

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBBridgeFurniture.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBBridgeFurniture.java
@@ -40,7 +40,6 @@ import org.citydb.core.query.filter.projection.ProjectionFilter;
 import org.citydb.sqlbuilder.schema.Table;
 import org.citydb.sqlbuilder.select.Select;
 import org.citygml4j.model.citygml.bridge.BridgeFurniture;
-import org.citygml4j.model.citygml.bridge.BridgeRoom;
 import org.citygml4j.model.citygml.core.ImplicitGeometry;
 import org.citygml4j.model.citygml.core.ImplicitRepresentationProperty;
 import org.citygml4j.model.gml.basicTypes.Code;
@@ -52,16 +51,16 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 public class DBBridgeFurniture extends AbstractFeatureExporter<BridgeFurniture> {
+	private final Set<Long> batches;
 	private final DBSurfaceGeometry geometryExporter;
 	private final DBCityObject cityObjectExporter;
 	private final DBImplicitGeometry implicitGeometryExporter;
 	private final GMLConverter gmlConverter;
 
+	private final int batchSize;
 	private final String bridgeModule;
 	private final LodFilter lodFilter;
 	private final AttributeValueSplitter valueSplitter;
@@ -71,6 +70,9 @@ public class DBBridgeFurniture extends AbstractFeatureExporter<BridgeFurniture> 
 	public DBBridgeFurniture(Connection connection, CityGMLExportManager exporter) throws CityGMLExportException, SQLException {
 		super(BridgeFurniture.class, connection, exporter);
 
+		batches = new HashSet<>();
+		batchSize = exporter.getFeatureBatchSize();
+
 		CombinedProjectionFilter projectionFilter = exporter.getCombinedProjectionFilter(TableEnum.BRIDGE_FURNITURE.getName());
 		bridgeModule = exporter.getTargetCityGMLVersion().getCityGMLModule(CityGMLModuleType.BRIDGE).getNamespaceURI();
 		lodFilter = exporter.getLodFilter();
@@ -78,7 +80,23 @@ public class DBBridgeFurniture extends AbstractFeatureExporter<BridgeFurniture> 
 		String schema = exporter.getDatabaseAdapter().getConnectionDetails().getSchema();
 
 		table = new Table(TableEnum.BRIDGE_FURNITURE.getName(), schema);
-		select = addProjection(new Select(), table, projectionFilter, "");
+		select = new Select().addProjection(table.getColumn("id"), table.getColumn("bridge_room_id"));
+		if (hasObjectClassIdColumn) select.addProjection(table.getColumn("objectclass_id"));
+		if (projectionFilter.containsProperty("class", bridgeModule))
+			select.addProjection(table.getColumn("class"), table.getColumn("class_codespace"));
+		if (projectionFilter.containsProperty("function", bridgeModule))
+			select.addProjection(table.getColumn("function"), table.getColumn("function_codespace"));
+		if (projectionFilter.containsProperty("usage", bridgeModule))
+			select.addProjection(table.getColumn("usage"), table.getColumn("usage_codespace"));
+		if (lodFilter.isEnabled(4)) {
+			if (projectionFilter.containsProperty("lod4Geometry", bridgeModule))
+				select.addProjection(table.getColumn("lod4_brep_id"), exporter.getGeometryColumn(table.getColumn("lod4_other_geom")));
+			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", bridgeModule)) {
+				select.addProjection(table.getColumn("lod4_implicit_rep_id"),
+						exporter.getGeometryColumn(table.getColumn("lod4_implicit_ref_point")),
+						table.getColumn("lod4_implicit_transformation"));
+			}
+		}
 		adeHookTables = addJoinsToADEHookTables(TableEnum.BRIDGE_FURNITURE, table);
 		
 		cityObjectExporter = exporter.getExporter(DBCityObject.class);
@@ -88,30 +106,58 @@ public class DBBridgeFurniture extends AbstractFeatureExporter<BridgeFurniture> 
 		valueSplitter = exporter.getAttributeValueSplitter();
 	}
 
-	protected Select addProjection(Select select, Table table, CombinedProjectionFilter projectionFilter, String prefix) {
-		select.addProjection(table.getColumn("id", prefix + "id"));
-		if (hasObjectClassIdColumn) select.addProjection(table.getColumn("objectclass_id", prefix + "objectclass_id"));
-		if (projectionFilter.containsProperty("class", bridgeModule))
-			select.addProjection(table.getColumn("class", prefix + "class"), table.getColumn("class_codespace", prefix + "class_codespace"));
-		if (projectionFilter.containsProperty("function", bridgeModule))
-			select.addProjection(table.getColumn("function", prefix + "function"), table.getColumn("function_codespace", prefix + "function_codespace"));
-		if (projectionFilter.containsProperty("usage", bridgeModule))
-			select.addProjection(table.getColumn("usage", prefix + "usage"), table.getColumn("usage_codespace", prefix + "usage_codespace"));
-		if (lodFilter.isEnabled(4)) {
-			if (projectionFilter.containsProperty("lod4Geometry", bridgeModule))
-				select.addProjection(table.getColumn("lod4_brep_id", prefix + "lod4_brep_id"), exporter.getGeometryColumn(table.getColumn("lod4_other_geom"), prefix + "lod4_other_geom"));
-			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", bridgeModule)) {
-				select.addProjection(table.getColumn("lod4_implicit_rep_id", prefix + "lod4_implicit_rep_id"),
-						exporter.getGeometryColumn(table.getColumn("lod4_implicit_ref_point"), prefix + "lod4_implicit_ref_point"),
-						table.getColumn("lod4_implicit_transformation", prefix + "lod4_implicit_transformation"));
-			}
-		}
-
-		return select;
+	private void addBatch(long id, Map<Long, Collection<BridgeFurniture>> bridgeFurnitures) throws CityGMLExportException, SQLException {
+		batches.add(id);
+		if (batches.size() == batchSize)
+			executeBatch(bridgeFurnitures);
 	}
 
-	protected Collection<BridgeFurniture> doExport(BridgeRoom parent, long parentId) throws CityGMLExportException, SQLException {
-		return doExport(parentId, null, null, getOrCreateStatement("bridge_room_id"));
+	private void executeBatch(Map<Long, Collection<BridgeFurniture>> bridgeFurnitures) throws CityGMLExportException, SQLException {
+		if (batches.isEmpty())
+			return;
+
+		try {
+			PreparedStatement ps;
+			if (batches.size() == 1) {
+				ps = getOrCreateStatement("bridge_room_id");
+				ps.setLong(1, batches.iterator().next());
+			} else {
+				ps = getOrCreateBulkStatement("bridge_room_id", batchSize);
+				prepareBulkStatement(ps, batches.toArray(new Long[0]), batchSize);
+			}
+
+			try (ResultSet rs = ps.executeQuery()) {
+				for (Map.Entry<Long, BridgeFurniture> entry : doExport(0, null, null, rs).entrySet()) {
+					Long bridgeRoomId = (Long) entry.getValue().getLocalProperty("bridge_room_id");
+					if (bridgeRoomId == null) {
+						exporter.logOrThrowErrorMessage("Failed to assign bridge furniture with id " + entry.getKey() + " to a bridge room.");
+						continue;
+					}
+
+					bridgeFurnitures.computeIfAbsent(bridgeRoomId, v -> new ArrayList<>()).add(entry.getValue());
+				}
+			}
+		} finally {
+			batches.clear();
+		}
+	}
+
+	protected Collection<BridgeFurniture> doExport(long bridgeRoomId) throws CityGMLExportException, SQLException {
+		return doExport(bridgeRoomId, null, null, getOrCreateStatement("bridge_room_id"));
+	}
+
+	protected Map<Long, Collection<BridgeFurniture>> doExport(Set<Long> bridgeRoomIds) throws CityGMLExportException, SQLException {
+		if (bridgeRoomIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Long, Collection<BridgeFurniture>> bridgeFurnitures = new HashMap<>();
+		for (Long bridgeRoomId : bridgeRoomIds) {
+			addBatch(bridgeRoomId, bridgeFurnitures);
+		}
+
+		executeBatch(bridgeFurnitures);
+		return bridgeFurnitures;
 	}
 	
 	@Override
@@ -119,126 +165,117 @@ public class DBBridgeFurniture extends AbstractFeatureExporter<BridgeFurniture> 
 		ps.setLong(1, id);
 
 		try (ResultSet rs = ps.executeQuery()) {
-			List<BridgeFurniture> bridgeFurnitures = new ArrayList<>();
-			
-			while (rs.next()) {
-				long bridgeFurnitureId = rs.getLong("id");
-				BridgeFurniture bridgeFurniture;
-				FeatureType featureType;
-				
-				if (bridgeFurnitureId == id && root != null) {
-					bridgeFurniture = root;
-					featureType = rootType;
+			return doExport(id, root, rootType, rs).values();
+		}
+	}
+
+	private Map<Long, BridgeFurniture> doExport(long id, BridgeFurniture root, FeatureType rootType, ResultSet rs) throws CityGMLExportException, SQLException {
+		Map<Long, BridgeFurniture> bridgeFurnitures = new HashMap<>();
+
+		while (rs.next()) {
+			long bridgeFurnitureId = rs.getLong("id");
+			BridgeFurniture bridgeFurniture;
+			FeatureType featureType;
+
+			if (bridgeFurnitureId == id && root != null) {
+				bridgeFurniture = root;
+				featureType = rootType;
+			} else {
+				if (hasObjectClassIdColumn) {
+					// create bridge furniture object
+					int objectClassId = rs.getInt("objectclass_id");
+					bridgeFurniture = exporter.createObject(objectClassId, BridgeFurniture.class);
+					if (bridgeFurniture == null) {
+						exporter.logOrThrowErrorMessage("Failed to instantiate " + exporter.getObjectSignature(objectClassId, bridgeFurnitureId) + " as bridge furniture object.");
+						continue;
+					}
+
+					featureType = exporter.getFeatureType(objectClassId);
 				} else {
-					if (hasObjectClassIdColumn) {
-						// create bridge furniture object
-						int objectClassId = rs.getInt("objectclass_id");
-						bridgeFurniture = exporter.createObject(objectClassId, BridgeFurniture.class);
-						if (bridgeFurniture == null) {
-							exporter.logOrThrowErrorMessage("Failed to instantiate " + exporter.getObjectSignature(objectClassId, bridgeFurnitureId) + " as bridge furniture object.");
-							continue;
-						}
-
-						featureType = exporter.getFeatureType(objectClassId);
-					} else {
-						bridgeFurniture = new BridgeFurniture();
-						featureType = exporter.getFeatureType(bridgeFurniture);
-					}
-				}
-				
-				// get projection filter
-				ProjectionFilter projectionFilter = exporter.getProjectionFilter(featureType);
-
-				doExport(bridgeFurniture, bridgeFurnitureId, featureType, projectionFilter, "", adeHookTables, rs);
-				bridgeFurnitures.add(bridgeFurniture);
-			}
-			
-			return bridgeFurnitures;
-		}
-	}
-
-	protected BridgeFurniture doExport(long id, FeatureType featureType, String prefix, List<Table> adeHookTables, ResultSet rs) throws CityGMLExportException, SQLException {
-		BridgeFurniture bridgeFurniture = null;
-		if (featureType != null) {
-			bridgeFurniture = exporter.createObject(featureType.getObjectClassId(), BridgeFurniture.class);
-			if (bridgeFurniture != null)
-				doExport(bridgeFurniture, id, featureType, exporter.getProjectionFilter(featureType), prefix, adeHookTables, rs);
-		}
-
-		return bridgeFurniture;
-	}
-
-	private void doExport(BridgeFurniture object, long id, FeatureType featureType, ProjectionFilter projectionFilter, String prefix, List<Table> adeHookTables, ResultSet rs) throws CityGMLExportException, SQLException {
-		// export city object information
-		cityObjectExporter.addBatch(object, id, featureType, projectionFilter);
-
-		if (projectionFilter.containsProperty("class", bridgeModule)) {
-			String clazz = rs.getString("class");
-			if (!rs.wasNull()) {
-				Code code = new Code(clazz);
-				code.setCodeSpace(rs.getString(prefix + "class_codespace"));
-				object.setClazz(code);
-			}
-		}
-
-		if (projectionFilter.containsProperty("function", bridgeModule)) {
-			for (SplitValue splitValue : valueSplitter.split(rs.getString(prefix + "function"), rs.getString(prefix + "function_codespace"))) {
-				Code function = new Code(splitValue.result(0));
-				function.setCodeSpace(splitValue.result(1));
-				object.addFunction(function);
-			}
-		}
-
-		if (projectionFilter.containsProperty("usage", bridgeModule)) {
-			for (SplitValue splitValue : valueSplitter.split(rs.getString(prefix + "usage"), rs.getString(prefix + "usage_codespace"))) {
-				Code usage = new Code(splitValue.result(0));
-				usage.setCodeSpace(splitValue.result(1));
-				object.addUsage(usage);
-			}
-		}
-
-		if (lodFilter.isEnabled(4)) {
-			if (projectionFilter.containsProperty("lod4Geometry", bridgeModule)) {
-				long geometryId = rs.getLong(prefix + "lod4_brep_id");
-				if (!rs.wasNull())
-					geometryExporter.addBatch(geometryId, (GeometrySetter.AbstractGeometry) object::setLod4Geometry);
-				else {
-					Object geometryObj = rs.getObject(prefix + "lod4_other_geom");
-					if (!rs.wasNull()) {
-						GeometryObject geometry = exporter.getDatabaseAdapter().getGeometryConverter().getGeometry(geometryObj);
-						if (geometry != null) {
-							GeometryProperty<AbstractGeometry> property = new GeometryProperty<>(gmlConverter.getPointOrCurveGeometry(geometry, true));
-							object.setLod4Geometry(property);
-						}
-					}
+					bridgeFurniture = new BridgeFurniture();
+					featureType = exporter.getFeatureType(bridgeFurniture);
 				}
 			}
 
-			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", bridgeModule)) {
-				long implicitGeometryId = rs.getLong(prefix + "lod4_implicit_rep_id");
+			// get projection filter
+			ProjectionFilter projectionFilter = exporter.getProjectionFilter(featureType);
+
+			// export city object information
+			cityObjectExporter.addBatch(bridgeFurniture, id, featureType, projectionFilter);
+
+			if (projectionFilter.containsProperty("class", bridgeModule)) {
+				String clazz = rs.getString("class");
 				if (!rs.wasNull()) {
-					GeometryObject referencePoint = null;
-					Object referencePointObj = rs.getObject(prefix + "lod4_implicit_ref_point");
+					Code code = new Code(clazz);
+					code.setCodeSpace(rs.getString("class_codespace"));
+					bridgeFurniture.setClazz(code);
+				}
+			}
+
+			if (projectionFilter.containsProperty("function", bridgeModule)) {
+				for (SplitValue splitValue : valueSplitter.split(rs.getString("function"), rs.getString("function_codespace"))) {
+					Code function = new Code(splitValue.result(0));
+					function.setCodeSpace(splitValue.result(1));
+					bridgeFurniture.addFunction(function);
+				}
+			}
+
+			if (projectionFilter.containsProperty("usage", bridgeModule)) {
+				for (SplitValue splitValue : valueSplitter.split(rs.getString("usage"), rs.getString("usage_codespace"))) {
+					Code usage = new Code(splitValue.result(0));
+					usage.setCodeSpace(splitValue.result(1));
+					bridgeFurniture.addUsage(usage);
+				}
+			}
+
+			if (lodFilter.isEnabled(4)) {
+				if (projectionFilter.containsProperty("lod4Geometry", bridgeModule)) {
+					long geometryId = rs.getLong("lod4_brep_id");
 					if (!rs.wasNull())
-						referencePoint = exporter.getDatabaseAdapter().getGeometryConverter().getPoint(referencePointObj);
+						geometryExporter.addBatch(geometryId, (GeometrySetter.AbstractGeometry) bridgeFurniture::setLod4Geometry);
+					else {
+						Object geometryObj = rs.getObject("lod4_other_geom");
+						if (!rs.wasNull()) {
+							GeometryObject geometry = exporter.getDatabaseAdapter().getGeometryConverter().getGeometry(geometryObj);
+							if (geometry != null) {
+								GeometryProperty<AbstractGeometry> property = new GeometryProperty<>(gmlConverter.getPointOrCurveGeometry(geometry, true));
+								bridgeFurniture.setLod4Geometry(property);
+							}
+						}
+					}
+				}
 
-					String transformationMatrix = rs.getString(prefix + "lod4_implicit_transformation");
+				if (projectionFilter.containsProperty("lod4ImplicitRepresentation", bridgeModule)) {
+					long implicitGeometryId = rs.getLong("lod4_implicit_rep_id");
+					if (!rs.wasNull()) {
+						GeometryObject referencePoint = null;
+						Object referencePointObj = rs.getObject("lod4_implicit_ref_point");
+						if (!rs.wasNull())
+							referencePoint = exporter.getDatabaseAdapter().getGeometryConverter().getPoint(referencePointObj);
 
-					ImplicitGeometry implicit = implicitGeometryExporter.doExport(implicitGeometryId, referencePoint, transformationMatrix);
-					if (implicit != null) {
-						ImplicitRepresentationProperty implicitProperty = new ImplicitRepresentationProperty();
-						implicitProperty.setObject(implicit);
-						object.setLod4ImplicitRepresentation(implicitProperty);
+						String transformationMatrix = rs.getString("lod4_implicit_transformation");
+
+						ImplicitGeometry implicit = implicitGeometryExporter.doExport(implicitGeometryId, referencePoint, transformationMatrix);
+						if (implicit != null) {
+							ImplicitRepresentationProperty implicitProperty = new ImplicitRepresentationProperty();
+							implicitProperty.setObject(implicit);
+							bridgeFurniture.setLod4ImplicitRepresentation(implicitProperty);
+						}
 					}
 				}
 			}
+
+			// delegate export of generic ADE properties
+			if (adeHookTables != null) {
+				List<String> tableNames = retrieveADEHookTables(adeHookTables, rs);
+				if (tableNames != null)
+					exporter.delegateToADEExporter(tableNames, bridgeFurniture, id, featureType, projectionFilter);
+			}
+
+			bridgeFurniture.setLocalProperty("bridge_room_id", rs.getLong("bridge_room_id"));
+			bridgeFurnitures.put(bridgeFurnitureId, bridgeFurniture);
 		}
 
-		// delegate export of generic ADE properties
-		if (adeHookTables != null) {
-			List<String> tableNames = retrieveADEHookTables(adeHookTables, rs);
-			if (tableNames != null)
-				exporter.delegateToADEExporter(tableNames, object, id, featureType, projectionFilter);
-		}
+		return bridgeFurnitures;
 	}
 }

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBBridgeRoom.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBBridgeRoom.java
@@ -38,10 +38,14 @@ import org.citydb.core.query.filter.lod.LodFilter;
 import org.citydb.core.query.filter.projection.CombinedProjectionFilter;
 import org.citydb.core.query.filter.projection.ProjectionFilter;
 import org.citydb.sqlbuilder.schema.Table;
+import org.citydb.sqlbuilder.select.FetchToken;
 import org.citydb.sqlbuilder.select.Select;
 import org.citydb.sqlbuilder.select.join.JoinFactory;
+import org.citydb.sqlbuilder.select.operator.comparison.ComparisonFactory;
 import org.citydb.sqlbuilder.select.operator.comparison.ComparisonName;
+import org.citydb.sqlbuilder.select.projection.ColumnExpression;
 import org.citygml4j.model.citygml.bridge.*;
+import org.citygml4j.model.citygml.core.AbstractCityObject;
 import org.citygml4j.model.citygml.core.AddressProperty;
 import org.citygml4j.model.gml.basicTypes.Code;
 import org.citygml4j.model.module.citygml.CityGMLModuleType;
@@ -53,7 +57,7 @@ import java.sql.SQLException;
 import java.util.*;
 
 public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
-	private final Map<Long, AbstractBridge> batches;
+	private final Set<Long> batches;
 	private final DBSurfaceGeometry geometryExporter;
 	private final DBCityObject cityObjectExporter;
 	private final DBBridgeInstallation bridgeInstallationExporter;
@@ -72,12 +76,11 @@ public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
 	private List<Table> surfaceADEHookTables;
 	private List<Table> openingADEHookTables;
 	private List<Table> addressADEHookTables;
-	private List<Table> bridgeFurnitureADEHookTables;
 
 	public DBBridgeRoom(Connection connection, CityGMLExportManager exporter) throws CityGMLExportException, SQLException {
 		super(BridgeRoom.class, connection, exporter);
 
-		batches = new LinkedHashMap<>();
+		batches = new HashSet<>();
 		batchSize = exporter.getFeatureBatchSize();
 		cityObjectExporter = exporter.getExporter(DBCityObject.class);
 		bridgeInstallationExporter = exporter.getExporter(DBBridgeInstallation.class);
@@ -96,7 +99,7 @@ public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
 		String schema = exporter.getDatabaseAdapter().getConnectionDetails().getSchema();
 
 		table = new Table(TableEnum.BRIDGE_ROOM.getName(), schema);
-		select = new Select().addProjection(table.getColumn("id"));
+		select = new Select().addProjection(table.getColumn("id"), table.getColumn("bridge_id"));
 		if (hasObjectClassIdColumn) select.addProjection(table.getColumn("objectclass_id"));
 		if (projectionFilter.containsProperty("class", bridgeModule)) select.addProjection(table.getColumn("class"), table.getColumn("class_codespace"));
 		if (projectionFilter.containsProperty("function", bridgeModule)) select.addProjection(table.getColumn("function"), table.getColumn("function_codespace"));
@@ -129,52 +132,53 @@ public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
 				}
 				surfaceADEHookTables = addJoinsToADEHookTables(TableEnum.BRIDGE_THEMATIC_SURFACE, thematicSurface);
 			}
-			if (projectionFilter.containsProperty("interiorFurniture", bridgeModule)) {
-				CombinedProjectionFilter bridgeFurnitureProjectionFilter = exporter.getCombinedProjectionFilter(TableEnum.BRIDGE_FURNITURE.getName());
-				Table bridgeFurniture = new Table(TableEnum.BRIDGE_FURNITURE.getName(), schema);
-				bridgeFurnitureExporter.addProjection(select, bridgeFurniture, bridgeFurnitureProjectionFilter, "bf")
-						.addJoin(JoinFactory.left(bridgeFurniture, "bridge_room_id", ComparisonName.EQUAL_TO, table.getColumn("id")));
-				bridgeFurnitureADEHookTables = addJoinsToADEHookTables(TableEnum.BRIDGE_FURNITURE, bridgeFurniture);
-			}
 			if (projectionFilter.containsProperty("bridgeRoomInstallation", bridgeModule)) {
 				Table installation = new Table(TableEnum.BRIDGE_INSTALLATION.getName(), schema);
-				select.addProjection(installation.getColumn("id", "inid"))
-						.addJoin(JoinFactory.left(installation, "bridge_room_id", ComparisonName.EQUAL_TO, table.getColumn("id")));
+				select.addProjection(new ColumnExpression(new Select()
+						.addProjection(installation.getColumn("id"))
+						.addSelection(ComparisonFactory.equalTo(installation.getColumn("bridge_room_id"), table.getColumn("id")))
+						.withFetch(new FetchToken(1)), "inid"));
+			}
+			if (projectionFilter.containsProperty("interiorFurniture", bridgeModule)) {
+				Table bridgeFurniture = new Table(TableEnum.BRIDGE_FURNITURE.getName(), schema);
+				select.addProjection(new ColumnExpression(new Select()
+						.addProjection(bridgeFurniture.getColumn("id"))
+						.addSelection(ComparisonFactory.equalTo(bridgeFurniture.getColumn("bridge_room_id"), table.getColumn("id")))
+						.withFetch(new FetchToken(1)), "bfid"));
 			}
 		}
 		bridgeRoomADEHookTables = addJoinsToADEHookTables(TableEnum.BRIDGE_ROOM, table);
 	}
 
-	protected void addBatch(long id, AbstractBridge parent) throws CityGMLExportException, SQLException {
-		batches.put(id, parent);
+	private void addBatch(long id, Map<Long, Collection<BridgeRoom>> bridgeRooms) throws CityGMLExportException, SQLException {
+		batches.add(id);
 		if (batches.size() == batchSize)
-			executeBatch();
+			executeBatch(bridgeRooms);
 	}
 
-	protected void executeBatch() throws CityGMLExportException, SQLException {
+	private void executeBatch(Map<Long, Collection<BridgeRoom>> bridgeRooms) throws CityGMLExportException, SQLException {
 		if (batches.isEmpty())
 			return;
 
 		try {
 			PreparedStatement ps;
 			if (batches.size() == 1) {
-				ps = getOrCreateStatement("id");
-				ps.setLong(1, batches.keySet().iterator().next());
+				ps = getOrCreateStatement("bridge_id");
+				ps.setLong(1, batches.iterator().next());
 			} else {
-				ps = getOrCreateBulkStatement(batchSize);
-				prepareBulkStatement(ps, batches.keySet().toArray(new Long[0]), batchSize);
+				ps = getOrCreateBulkStatement("bridge_id", batchSize);
+				prepareBulkStatement(ps, batches.toArray(new Long[0]), batchSize);
 			}
 
 			try (ResultSet rs = ps.executeQuery()) {
-				Map<Long, BridgeRoom> bridgeRooms = doExport(0, null, null, rs);
-				for (Map.Entry<Long, BridgeRoom> entry : bridgeRooms.entrySet()) {
-					AbstractBridge bridge = batches.get(entry.getKey());
-					if (bridge == null) {
+				for (Map.Entry<Long, BridgeRoom> entry : doExport(0, null, null, rs).entrySet()) {
+					Long bridgeId = (Long) entry.getValue().getLocalProperty("bridge_id");
+					if (bridgeId == null) {
 						exporter.logOrThrowErrorMessage("Failed to assign bridge room with id " + entry.getKey() + " to a building.");
 						continue;
 					}
 
-					bridge.addInteriorBridgeRoom(new InteriorBridgeRoomProperty(entry.getValue()));
+					bridgeRooms.computeIfAbsent(bridgeId, v -> new ArrayList<>()).add(entry.getValue());
 				}
 			}
 		} finally {
@@ -182,8 +186,22 @@ public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
 		}
 	}
 
-	protected Collection<BridgeRoom> doExport(AbstractBridge parent, long parentId) throws CityGMLExportException, SQLException {
-		return doExport(parentId, null, null, getOrCreateStatement("bridge_id"));
+	protected Collection<BridgeRoom> doExport(long bridgeId) throws CityGMLExportException, SQLException {
+		return doExport(bridgeId, null, null, getOrCreateStatement("bridge_id"));
+	}
+
+	protected Map<Long, Collection<BridgeRoom>> doExport(Set<Long> bridgeIds) throws CityGMLExportException, SQLException {
+		if (bridgeIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Long, Collection<BridgeRoom>> bridgeRooms = new HashMap<>();
+		for (Long bridgeId : bridgeIds) {
+			addBatch(bridgeId, bridgeRooms);
+		}
+
+		executeBatch(bridgeRooms);
+		return bridgeRooms;
 	}
 	
 	@Override
@@ -213,8 +231,8 @@ public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
 		ProjectionFilter openingProjectionFilter = null;
 		Map<String, OpeningProperty> openingProperties = new HashMap<>();
 
-		Set<Long> bridgeFurnitures = new HashSet<>();
 		Set<Long> installations = new HashSet<>();
+		Set<Long> bridgeFurnitures = new HashSet<>();
 		Set<String> addresses = new HashSet<>();
 
 		while (rs.next()) {
@@ -293,6 +311,22 @@ public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
 						}
 					}
 
+					// brid:bridgeRoomInstallation
+					if (lodFilter.isEnabled(4)
+							&& projectionFilter.containsProperty("bridgeRoomInstallation", bridgeModule)) {
+						if (rs.getLong("inid") != 0) {
+							installations.add(bridgeRoomId);
+						}
+					}
+
+					// brid:interiorFurniture
+					if (lodFilter.isEnabled(4)
+							&& projectionFilter.containsProperty("interiorFurniture", bridgeModule)) {
+						if (rs.getLong("bfid") != 0) {
+							bridgeFurnitures.add(bridgeRoomId);
+						}
+					}
+
 					// get tables of ADE hook properties
 					if (bridgeRoomADEHookTables != null) {
 						List<String> tables = retrieveADEHookTables(bridgeRoomADEHookTables, rs);
@@ -302,36 +336,11 @@ public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
 						}
 					}
 
+					bridgeRoom.setLocalProperty("bridge_id", rs.getLong("bridge_id"));
 					bridgeRoom.setLocalProperty("projection", projectionFilter);
 					bridgeRooms.put(bridgeRoomId, bridgeRoom);
 				} else
 					projectionFilter = (ProjectionFilter) bridgeRoom.getLocalProperty("projection");
-			}
-
-			// brid:bridgeRoomInstallation
-			if (lodFilter.isEnabled(4)
-					&& projectionFilter.containsProperty("bridgeRoomInstallation", bridgeModule)) {
-				long installationId = rs.getLong("inid");
-				if (!rs.wasNull() && installations.add(installationId))
-					bridgeInstallationExporter.addBatch(installationId, bridgeRoom);
-			}
-
-			// brid:interiorFurniture
-			if (lodFilter.isEnabled(4)
-					&& projectionFilter.containsProperty("interiorFurniture", bridgeModule)) {
-				long bridgeFurnitureId = rs.getLong("bfid");
-				if (!rs.wasNull() && bridgeFurnitures.add(bridgeFurnitureId)) {
-					int objectClassId = rs.getInt("bfobjectclass_id");
-					FeatureType featureType = exporter.getFeatureType(objectClassId);
-
-					BridgeFurniture bridgeFurniture = bridgeFurnitureExporter.doExport(bridgeFurnitureId, featureType, "bf", bridgeFurnitureADEHookTables, rs);
-					if (bridgeFurniture == null) {
-						exporter.logOrThrowErrorMessage("Failed to instantiate " + exporter.getObjectSignature(objectClassId, bridgeFurnitureId) + " as bridge furniture object.");
-						continue;
-					}
-
-					bridgeRoom.getInteriorFurniture().add(new InteriorFurnitureProperty(bridgeFurniture));
-				}
 			}
 
 			if (!lodFilter.isEnabled(4)
@@ -436,7 +445,27 @@ public class DBBridgeRoom extends AbstractFeatureExporter<BridgeRoom> {
 			}
 		}
 
-		bridgeInstallationExporter.executeBatch();
+		// export installations
+		for (Map.Entry<Long, Collection<AbstractCityObject>> entry : bridgeInstallationExporter.doExportForBridgeRooms(installations).entrySet()) {
+			bridgeRoom = bridgeRooms.get(entry.getKey());
+			if (bridgeRoom != null) {
+				for (AbstractCityObject installation : entry.getValue()) {
+					if (installation instanceof IntBridgeInstallation) {
+						bridgeRoom.addBridgeRoomInstallation(new IntBridgeInstallationProperty((IntBridgeInstallation) installation));
+					}
+				}
+			}
+		}
+
+		// export furniture
+		for (Map.Entry<Long, Collection<BridgeFurniture>> entry : bridgeFurnitureExporter.doExport(bridgeFurnitures).entrySet()) {
+			bridgeRoom = bridgeRooms.get(entry.getKey());
+			if (bridgeRoom != null) {
+				for (BridgeFurniture bridgeFurniture : entry.getValue()) {
+					bridgeRoom.addInteriorFurniture(new InteriorFurnitureProperty(bridgeFurniture));
+				}
+			}
+		}
 
 		// export postponed geometries
 		for (Map.Entry<Long, GeometrySetterHandler> entry : geometries.entrySet())

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBBuildingFurniture.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBBuildingFurniture.java
@@ -40,7 +40,6 @@ import org.citydb.core.query.filter.projection.ProjectionFilter;
 import org.citydb.sqlbuilder.schema.Table;
 import org.citydb.sqlbuilder.select.Select;
 import org.citygml4j.model.citygml.building.BuildingFurniture;
-import org.citygml4j.model.citygml.building.Room;
 import org.citygml4j.model.citygml.core.ImplicitGeometry;
 import org.citygml4j.model.citygml.core.ImplicitRepresentationProperty;
 import org.citygml4j.model.gml.basicTypes.Code;
@@ -52,16 +51,16 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 public class DBBuildingFurniture extends AbstractFeatureExporter<BuildingFurniture> {
+	private final Set<Long> batches;
 	private final DBSurfaceGeometry geometryExporter;
 	private final DBCityObject cityObjectExporter;
 	private final DBImplicitGeometry implicitGeometryExporter;
 	private final GMLConverter gmlConverter;
 
+	private final int batchSize;
 	private final String buildingModule;
 	private final LodFilter lodFilter;
 	private final AttributeValueSplitter valueSplitter;
@@ -71,6 +70,9 @@ public class DBBuildingFurniture extends AbstractFeatureExporter<BuildingFurnitu
 	public DBBuildingFurniture(Connection connection, CityGMLExportManager exporter) throws CityGMLExportException, SQLException {
 		super(BuildingFurniture.class, connection, exporter);
 
+		batches = new HashSet<>();
+		batchSize = exporter.getFeatureBatchSize();
+
 		CombinedProjectionFilter projectionFilter = exporter.getCombinedProjectionFilter(TableEnum.BUILDING_FURNITURE.getName());
 		buildingModule = exporter.getTargetCityGMLVersion().getCityGMLModule(CityGMLModuleType.BUILDING).getNamespaceURI();
 		lodFilter = exporter.getLodFilter();
@@ -78,7 +80,23 @@ public class DBBuildingFurniture extends AbstractFeatureExporter<BuildingFurnitu
 		String schema = exporter.getDatabaseAdapter().getConnectionDetails().getSchema();
 
 		table = new Table(TableEnum.BUILDING_FURNITURE.getName(), schema);
-		select = addProjection(new Select(), table, projectionFilter, "");
+		select = new Select().addProjection(table.getColumn("id"), table.getColumn("room_id"));
+		if (hasObjectClassIdColumn) select.addProjection(table.getColumn("objectclass_id"));
+		if (projectionFilter.containsProperty("class", buildingModule))
+			select.addProjection(table.getColumn("class"), table.getColumn("class_codespace"));
+		if (projectionFilter.containsProperty("function", buildingModule))
+			select.addProjection(table.getColumn("function"), table.getColumn("function_codespace"));
+		if (projectionFilter.containsProperty("usage", buildingModule))
+			select.addProjection(table.getColumn("usage"), table.getColumn("usage_codespace"));
+		if (lodFilter.isEnabled(4)) {
+			if (projectionFilter.containsProperty("lod4Geometry", buildingModule))
+				select.addProjection(table.getColumn("lod4_brep_id"), exporter.getGeometryColumn(table.getColumn("lod4_other_geom")));
+			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", buildingModule)) {
+				select.addProjection(table.getColumn("lod4_implicit_rep_id"),
+						exporter.getGeometryColumn(table.getColumn("lod4_implicit_ref_point")),
+						table.getColumn("lod4_implicit_transformation"));
+			}
+		}
 		adeHookTables = addJoinsToADEHookTables(TableEnum.BUILDING_FURNITURE, table);
 
 		cityObjectExporter = exporter.getExporter(DBCityObject.class);
@@ -88,30 +106,58 @@ public class DBBuildingFurniture extends AbstractFeatureExporter<BuildingFurnitu
 		valueSplitter = exporter.getAttributeValueSplitter();
 	}
 
-	protected Select addProjection(Select select, Table table, CombinedProjectionFilter projectionFilter, String prefix) {
-		select.addProjection(table.getColumn("id", prefix + "id"));
-		if (hasObjectClassIdColumn) select.addProjection(table.getColumn("objectclass_id", prefix + "objectclass_id"));
-		if (projectionFilter.containsProperty("class", buildingModule))
-			select.addProjection(table.getColumn("class", prefix + "class"), table.getColumn("class_codespace", prefix + "class_codespace"));
-		if (projectionFilter.containsProperty("function", buildingModule))
-			select.addProjection(table.getColumn("function", prefix + "function"), table.getColumn("function_codespace", prefix + "function_codespace"));
-		if (projectionFilter.containsProperty("usage", buildingModule))
-			select.addProjection(table.getColumn("usage", prefix + "usage"), table.getColumn("usage_codespace", prefix + "usage_codespace"));
-		if (lodFilter.isEnabled(4)) {
-			if (projectionFilter.containsProperty("lod4Geometry", buildingModule))
-				select.addProjection(table.getColumn("lod4_brep_id", prefix + "lod4_brep_id"), exporter.getGeometryColumn(table.getColumn("lod4_other_geom"), prefix + "lod4_other_geom"));
-			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", buildingModule)) {
-				select.addProjection(table.getColumn("lod4_implicit_rep_id", prefix + "lod4_implicit_rep_id"),
-						exporter.getGeometryColumn(table.getColumn("lod4_implicit_ref_point"), prefix + "lod4_implicit_ref_point"),
-						table.getColumn("lod4_implicit_transformation", prefix + "lod4_implicit_transformation"));
-			}
-		}
-
-		return select;
+	private void addBatch(long id, Map<Long, Collection<BuildingFurniture>> buildingFurnitures) throws CityGMLExportException, SQLException {
+		batches.add(id);
+		if (batches.size() == batchSize)
+			executeBatch(buildingFurnitures);
 	}
 
-	protected Collection<BuildingFurniture> doExport(Room parent, long parentId) throws CityGMLExportException, SQLException {
-		return doExport(parentId, null, null, getOrCreateStatement("room_id"));
+	private void executeBatch(Map<Long, Collection<BuildingFurniture>> buildingFurnitures) throws CityGMLExportException, SQLException {
+		if (batches.isEmpty())
+			return;
+
+		try {
+			PreparedStatement ps;
+			if (batches.size() == 1) {
+				ps = getOrCreateStatement("room_id");
+				ps.setLong(1, batches.iterator().next());
+			} else {
+				ps = getOrCreateBulkStatement("room_id", batchSize);
+				prepareBulkStatement(ps, batches.toArray(new Long[0]), batchSize);
+			}
+
+			try (ResultSet rs = ps.executeQuery()) {
+				for (Map.Entry<Long, BuildingFurniture> entry : doExport(0, null, null, rs).entrySet()) {
+					Long roomId = (Long) entry.getValue().getLocalProperty("room_id");
+					if (roomId == null) {
+						exporter.logOrThrowErrorMessage("Failed to assign furniture with id " + entry.getKey() + " to a building room.");
+						continue;
+					}
+
+					buildingFurnitures.computeIfAbsent(roomId, v -> new ArrayList<>()).add(entry.getValue());
+				}
+			}
+		} finally {
+			batches.clear();
+		}
+	}
+
+	protected Collection<BuildingFurniture> doExport(long roomId) throws CityGMLExportException, SQLException {
+		return doExport(roomId, null, null, getOrCreateStatement("room_id"));
+	}
+
+	protected Map<Long, Collection<BuildingFurniture>> doExport(Set<Long> roomIds) throws CityGMLExportException, SQLException {
+		if (roomIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Long, Collection<BuildingFurniture>> buildingFurnitures = new HashMap<>();
+		for (Long roomId : roomIds) {
+			addBatch(roomId, buildingFurnitures);
+		}
+
+		executeBatch(buildingFurnitures);
+		return buildingFurnitures;
 	}
 	
 	@Override
@@ -119,126 +165,117 @@ public class DBBuildingFurniture extends AbstractFeatureExporter<BuildingFurnitu
 		ps.setLong(1, id);
 
 		try (ResultSet rs = ps.executeQuery()) {
-			List<BuildingFurniture> buildingFurnitures = new ArrayList<>();
+			return doExport(id, root, rootType, rs).values();
+		}
+	}
 
-			while (rs.next()) {
-				long buildingFurnitureId = rs.getLong("id");
-				BuildingFurniture buildingFurniture;
-				FeatureType featureType;
-				
-				if (buildingFurnitureId == id && root != null) {
-					buildingFurniture = root;
-					featureType = rootType;
+	private Map<Long, BuildingFurniture> doExport(long id, BuildingFurniture root, FeatureType rootType, ResultSet rs) throws CityGMLExportException, SQLException {
+		Map<Long, BuildingFurniture> buildingFurnitures = new HashMap<>();
+
+		while (rs.next()) {
+			long buildingFurnitureId = rs.getLong("id");
+			BuildingFurniture buildingFurniture;
+			FeatureType featureType;
+
+			if (buildingFurnitureId == id && root != null) {
+				buildingFurniture = root;
+				featureType = rootType;
+			} else {
+				if (hasObjectClassIdColumn) {
+					// create building furniture object
+					int objectClassId = rs.getInt("objectclass_id");
+					buildingFurniture = exporter.createObject(objectClassId, BuildingFurniture.class);
+					if (buildingFurniture == null) {
+						exporter.logOrThrowErrorMessage("Failed to instantiate " + exporter.getObjectSignature(objectClassId, buildingFurnitureId) + " as building furniture object.");
+						continue;
+					}
+
+					featureType = exporter.getFeatureType(objectClassId);
 				} else {
-					if (hasObjectClassIdColumn) {
-						// create building furniture object
-						int objectClassId = rs.getInt("objectclass_id");
-						buildingFurniture = exporter.createObject(objectClassId, BuildingFurniture.class);
-						if (buildingFurniture == null) {
-							exporter.logOrThrowErrorMessage("Failed to instantiate " + exporter.getObjectSignature(objectClassId, buildingFurnitureId) + " as building furniture object.");
-							continue;
-						}
-
-						featureType = exporter.getFeatureType(objectClassId);
-					} else {
-						buildingFurniture = new BuildingFurniture();
-						featureType = exporter.getFeatureType(buildingFurniture);
-					}
-				}
-				
-				// get projection filter
-				ProjectionFilter projectionFilter = exporter.getProjectionFilter(featureType);
-				
-				doExport(buildingFurniture, buildingFurnitureId, featureType, projectionFilter, "", adeHookTables, rs);
-				buildingFurnitures.add(buildingFurniture);
-			}
-			
-			return buildingFurnitures;
-		}
-	}
-
-	protected BuildingFurniture doExport(long id, FeatureType featureType, String prefix, List<Table> adeHookTables, ResultSet rs) throws CityGMLExportException, SQLException {
-		BuildingFurniture buildingFurniture = null;
-		if (featureType != null) {
-			buildingFurniture = exporter.createObject(featureType.getObjectClassId(), BuildingFurniture.class);
-			if (buildingFurniture != null)
-				doExport(buildingFurniture, id, featureType, exporter.getProjectionFilter(featureType), prefix, adeHookTables, rs);
-		}
-
-		return buildingFurniture;
-	}
-
-	private void doExport(BuildingFurniture object, long id, FeatureType featureType, ProjectionFilter projectionFilter, String prefix, List<Table> adeHookTables, ResultSet rs) throws CityGMLExportException, SQLException {
-		// export city object information
-		cityObjectExporter.addBatch(object, id, featureType, projectionFilter);
-
-		if (projectionFilter.containsProperty("class", buildingModule)) {
-			String clazz = rs.getString(prefix + "class");
-			if (!rs.wasNull()) {
-				Code code = new Code(clazz);
-				code.setCodeSpace(rs.getString(prefix + "class_codespace"));
-				object.setClazz(code);
-			}
-		}
-
-		if (projectionFilter.containsProperty("function", buildingModule)) {
-			for (SplitValue splitValue : valueSplitter.split(rs.getString(prefix + "function"), rs.getString(prefix + "function_codespace"))) {
-				Code function = new Code(splitValue.result(0));
-				function.setCodeSpace(splitValue.result(1));
-				object.addFunction(function);
-			}
-		}
-
-		if (projectionFilter.containsProperty("usage", buildingModule)) {
-			for (SplitValue splitValue : valueSplitter.split(rs.getString(prefix + "usage"), rs.getString(prefix + "usage_codespace"))) {
-				Code usage = new Code(splitValue.result(0));
-				usage.setCodeSpace(splitValue.result(1));
-				object.addUsage(usage);
-			}
-		}
-
-		if (lodFilter.isEnabled(4)) {
-			if (projectionFilter.containsProperty("lod4Geometry", buildingModule)) {
-				long geometryId = rs.getLong(prefix + "lod4_brep_id");
-				if (!rs.wasNull())
-					geometryExporter.addBatch(geometryId, (GeometrySetter.AbstractGeometry) object::setLod4Geometry);
-				else {
-					Object geometryObj = rs.getObject(prefix + "lod4_other_geom");
-					if (!rs.wasNull()) {
-						GeometryObject geometry = exporter.getDatabaseAdapter().getGeometryConverter().getGeometry(geometryObj);
-						if (geometry != null) {
-							GeometryProperty<AbstractGeometry> property = new GeometryProperty<>(gmlConverter.getPointOrCurveGeometry(geometry, true));
-							object.setLod4Geometry(property);
-						}
-					}
+					buildingFurniture = new BuildingFurniture();
+					featureType = exporter.getFeatureType(buildingFurniture);
 				}
 			}
 
-			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", buildingModule)) {
-				long implicitGeometryId = rs.getLong(prefix + "lod4_implicit_rep_id");
+			// get projection filter
+			ProjectionFilter projectionFilter = exporter.getProjectionFilter(featureType);
+
+			// export city object information
+			cityObjectExporter.addBatch(buildingFurniture, id, featureType, projectionFilter);
+
+			if (projectionFilter.containsProperty("class", buildingModule)) {
+				String clazz = rs.getString("class");
 				if (!rs.wasNull()) {
-					GeometryObject referencePoint = null;
-					Object referencePointObj = rs.getObject(prefix + "lod4_implicit_ref_point");
+					Code code = new Code(clazz);
+					code.setCodeSpace(rs.getString("class_codespace"));
+					buildingFurniture.setClazz(code);
+				}
+			}
+
+			if (projectionFilter.containsProperty("function", buildingModule)) {
+				for (SplitValue splitValue : valueSplitter.split(rs.getString("function"), rs.getString("function_codespace"))) {
+					Code function = new Code(splitValue.result(0));
+					function.setCodeSpace(splitValue.result(1));
+					buildingFurniture.addFunction(function);
+				}
+			}
+
+			if (projectionFilter.containsProperty("usage", buildingModule)) {
+				for (SplitValue splitValue : valueSplitter.split(rs.getString("usage"), rs.getString("usage_codespace"))) {
+					Code usage = new Code(splitValue.result(0));
+					usage.setCodeSpace(splitValue.result(1));
+					buildingFurniture.addUsage(usage);
+				}
+			}
+
+			if (lodFilter.isEnabled(4)) {
+				if (projectionFilter.containsProperty("lod4Geometry", buildingModule)) {
+					long geometryId = rs.getLong("lod4_brep_id");
 					if (!rs.wasNull())
-						referencePoint = exporter.getDatabaseAdapter().getGeometryConverter().getPoint(referencePointObj);
+						geometryExporter.addBatch(geometryId, (GeometrySetter.AbstractGeometry) buildingFurniture::setLod4Geometry);
+					else {
+						Object geometryObj = rs.getObject("lod4_other_geom");
+						if (!rs.wasNull()) {
+							GeometryObject geometry = exporter.getDatabaseAdapter().getGeometryConverter().getGeometry(geometryObj);
+							if (geometry != null) {
+								GeometryProperty<AbstractGeometry> property = new GeometryProperty<>(gmlConverter.getPointOrCurveGeometry(geometry, true));
+								buildingFurniture.setLod4Geometry(property);
+							}
+						}
+					}
+				}
 
-					String transformationMatrix = rs.getString(prefix + "lod4_implicit_transformation");
+				if (projectionFilter.containsProperty("lod4ImplicitRepresentation", buildingModule)) {
+					long implicitGeometryId = rs.getLong("lod4_implicit_rep_id");
+					if (!rs.wasNull()) {
+						GeometryObject referencePoint = null;
+						Object referencePointObj = rs.getObject("lod4_implicit_ref_point");
+						if (!rs.wasNull())
+							referencePoint = exporter.getDatabaseAdapter().getGeometryConverter().getPoint(referencePointObj);
 
-					ImplicitGeometry implicit = implicitGeometryExporter.doExport(implicitGeometryId, referencePoint, transformationMatrix);
-					if (implicit != null) {
-						ImplicitRepresentationProperty implicitProperty = new ImplicitRepresentationProperty();
-						implicitProperty.setObject(implicit);
-						object.setLod4ImplicitRepresentation(implicitProperty);
+						String transformationMatrix = rs.getString("lod4_implicit_transformation");
+
+						ImplicitGeometry implicit = implicitGeometryExporter.doExport(implicitGeometryId, referencePoint, transformationMatrix);
+						if (implicit != null) {
+							ImplicitRepresentationProperty implicitProperty = new ImplicitRepresentationProperty();
+							implicitProperty.setObject(implicit);
+							buildingFurniture.setLod4ImplicitRepresentation(implicitProperty);
+						}
 					}
 				}
 			}
+
+			// delegate export of generic ADE properties
+			if (adeHookTables != null) {
+				List<String> tableNames = retrieveADEHookTables(adeHookTables, rs);
+				if (tableNames != null)
+					exporter.delegateToADEExporter(tableNames, buildingFurniture, id, featureType, projectionFilter);
+			}
+
+			buildingFurniture.setLocalProperty("room_id", rs.getLong("room_id"));
+			buildingFurnitures.put(buildingFurnitureId, buildingFurniture);
 		}
 
-		// delegate export of generic ADE properties
-		if (adeHookTables != null) {
-			List<String> tableNames = retrieveADEHookTables(adeHookTables, rs);
-			if (tableNames != null)
-				exporter.delegateToADEExporter(tableNames, object, id, featureType, projectionFilter);
-		}
+		return buildingFurnitures;
 	}
  }

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBCityObjectGenericAttrib.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBCityObjectGenericAttrib.java
@@ -37,7 +37,10 @@ import org.citygml4j.model.citygml.core.AbstractCityObject;
 import org.citygml4j.model.citygml.generics.*;
 import org.citygml4j.model.gml.basicTypes.Measure;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBReliefFeature.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBReliefFeature.java
@@ -61,7 +61,7 @@ public class DBReliefFeature extends AbstractFeatureExporter<ReliefFeature> {
 	private final boolean useXLink;
 
 	private final List<Table> reliefADEHookTables;
-	private List<Table> componentADEHookTables;
+	private final List<Table> componentADEHookTables;
 
 	public DBReliefFeature(Connection connection, CityGMLExportManager exporter) throws CityGMLExportException, SQLException {
 		super(ReliefFeature.class, connection, exporter);
@@ -69,7 +69,6 @@ public class DBReliefFeature extends AbstractFeatureExporter<ReliefFeature> {
 		cityObjectExporter = exporter.getExporter(DBCityObject.class);
 		componentExporter = exporter.getExporter(DBReliefComponent.class);
 
-		CombinedProjectionFilter projectionFilter = exporter.getCombinedProjectionFilter(TableEnum.RELIEF_FEATURE.getName());
 		CombinedProjectionFilter componentProjectionFilter = exporter.getCombinedProjectionFilter(TableEnum.RELIEF_COMPONENT.getName());
 		reliefModule = exporter.getTargetCityGMLVersion().getCityGMLModule(CityGMLModuleType.RELIEF).getNamespaceURI();
 		lodFilter = exporter.getLodFilter();

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBTunnelFurniture.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBTunnelFurniture.java
@@ -41,7 +41,6 @@ import org.citydb.sqlbuilder.schema.Table;
 import org.citydb.sqlbuilder.select.Select;
 import org.citygml4j.model.citygml.core.ImplicitGeometry;
 import org.citygml4j.model.citygml.core.ImplicitRepresentationProperty;
-import org.citygml4j.model.citygml.tunnel.HollowSpace;
 import org.citygml4j.model.citygml.tunnel.TunnelFurniture;
 import org.citygml4j.model.gml.basicTypes.Code;
 import org.citygml4j.model.gml.geometry.AbstractGeometry;
@@ -52,16 +51,16 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 public class DBTunnelFurniture extends AbstractFeatureExporter<TunnelFurniture> {
+	private final Set<Long> batches;
 	private final DBSurfaceGeometry geometryExporter;
 	private final DBCityObject cityObjectExporter;
 	private final DBImplicitGeometry implicitGeometryExporter;
 	private final GMLConverter gmlConverter;
 
+	private final int batchSize;
 	private final String tunnelModule;
 	private final LodFilter lodFilter;
 	private final AttributeValueSplitter valueSplitter;
@@ -71,6 +70,9 @@ public class DBTunnelFurniture extends AbstractFeatureExporter<TunnelFurniture> 
 	public DBTunnelFurniture(Connection connection, CityGMLExportManager exporter) throws CityGMLExportException, SQLException {
 		super(TunnelFurniture.class, connection, exporter);
 
+		batches = new HashSet<>();
+		batchSize = exporter.getFeatureBatchSize();
+
 		CombinedProjectionFilter projectionFilter = exporter.getCombinedProjectionFilter(TableEnum.TUNNEL_FURNITURE.getName());
 		tunnelModule = exporter.getTargetCityGMLVersion().getCityGMLModule(CityGMLModuleType.TUNNEL).getNamespaceURI();
 		lodFilter = exporter.getLodFilter();
@@ -78,7 +80,23 @@ public class DBTunnelFurniture extends AbstractFeatureExporter<TunnelFurniture> 
 		String schema = exporter.getDatabaseAdapter().getConnectionDetails().getSchema();
 
 		table = new Table(TableEnum.TUNNEL_FURNITURE.getName(), schema);
-		select = addProjection(new Select(), table, projectionFilter, "");
+		select = new Select().addProjection(table.getColumn("id"), table.getColumn("tunnel_hollow_space_id"));
+		if (hasObjectClassIdColumn) select.addProjection(table.getColumn("objectclass_id"));
+		if (projectionFilter.containsProperty("class", tunnelModule))
+			select.addProjection(table.getColumn("class"), table.getColumn("class_codespace"));
+		if (projectionFilter.containsProperty("function", tunnelModule))
+			select.addProjection(table.getColumn("function"), table.getColumn("function_codespace"));
+		if (projectionFilter.containsProperty("usage", tunnelModule))
+			select.addProjection(table.getColumn("usage"), table.getColumn("usage_codespace"));
+		if (lodFilter.isEnabled(4)) {
+			if (projectionFilter.containsProperty("lod4Geometry", tunnelModule))
+				select.addProjection(table.getColumn("lod4_brep_id"), exporter.getGeometryColumn(table.getColumn("lod4_other_geom")));
+			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", tunnelModule)) {
+				select.addProjection(table.getColumn("lod4_implicit_rep_id"),
+						exporter.getGeometryColumn(table.getColumn("lod4_implicit_ref_point")),
+						table.getColumn("lod4_implicit_transformation"));
+			}
+		}
 		adeHookTables = addJoinsToADEHookTables(TableEnum.TUNNEL_FURNITURE, table);
 
 		cityObjectExporter = exporter.getExporter(DBCityObject.class);
@@ -88,30 +106,58 @@ public class DBTunnelFurniture extends AbstractFeatureExporter<TunnelFurniture> 
 		valueSplitter = exporter.getAttributeValueSplitter();
 	}
 
-	protected Select addProjection(Select select, Table table, CombinedProjectionFilter projectionFilter, String prefix) {
-		select.addProjection(table.getColumn("id", prefix + "id"));
-		if (hasObjectClassIdColumn) select.addProjection(table.getColumn("objectclass_id", prefix + "objectclass_id"));
-		if (projectionFilter.containsProperty("class", tunnelModule))
-			select.addProjection(table.getColumn("class", prefix + "class"), table.getColumn("class_codespace", prefix + "class_codespace"));
-		if (projectionFilter.containsProperty("function", tunnelModule))
-			select.addProjection(table.getColumn("function", prefix + "function"), table.getColumn("function_codespace", prefix + "function_codespace"));
-		if (projectionFilter.containsProperty("usage", tunnelModule))
-			select.addProjection(table.getColumn("usage", prefix + "usage"), table.getColumn("usage_codespace", prefix + "usage_codespace"));
-		if (lodFilter.isEnabled(4)) {
-			if (projectionFilter.containsProperty("lod4Geometry", tunnelModule))
-				select.addProjection(table.getColumn("lod4_brep_id", prefix + "lod4_brep_id"), exporter.getGeometryColumn(table.getColumn("lod4_other_geom"), prefix + "lod4_other_geom"));
-			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", tunnelModule)) {
-				select.addProjection(table.getColumn("lod4_implicit_rep_id", prefix + "lod4_implicit_rep_id"),
-						exporter.getGeometryColumn(table.getColumn("lod4_implicit_ref_point"), prefix + "lod4_implicit_ref_point"),
-						table.getColumn("lod4_implicit_transformation", prefix + "lod4_implicit_transformation"));
-			}
-		}
-
-		return select;
+	private void addBatch(long id, Map<Long, Collection<TunnelFurniture>> tunnelFurnitures) throws CityGMLExportException, SQLException {
+		batches.add(id);
+		if (batches.size() == batchSize)
+			executeBatch(tunnelFurnitures);
 	}
 
-	protected Collection<TunnelFurniture> doExport(HollowSpace parent, long parentId) throws CityGMLExportException, SQLException {
-		return doExport(parentId, null, null, getOrCreateStatement("tunnel_hollow_space_id"));
+	private void executeBatch(Map<Long, Collection<TunnelFurniture>> tunnelFurnitures) throws CityGMLExportException, SQLException {
+		if (batches.isEmpty())
+			return;
+
+		try {
+			PreparedStatement ps;
+			if (batches.size() == 1) {
+				ps = getOrCreateStatement("tunnel_hollow_space_id");
+				ps.setLong(1, batches.iterator().next());
+			} else {
+				ps = getOrCreateBulkStatement("tunnel_hollow_space_id", batchSize);
+				prepareBulkStatement(ps, batches.toArray(new Long[0]), batchSize);
+			}
+
+			try (ResultSet rs = ps.executeQuery()) {
+				for (Map.Entry<Long, TunnelFurniture> entry : doExport(0, null, null, rs).entrySet()) {
+					Long hollowSpaceId = (Long) entry.getValue().getLocalProperty("tunnel_hollow_space_id");
+					if (hollowSpaceId == null) {
+						exporter.logOrThrowErrorMessage("Failed to assign tunnel furniture with id " + entry.getKey() + " to a hollow space.");
+						continue;
+					}
+
+					tunnelFurnitures.computeIfAbsent(hollowSpaceId, v -> new ArrayList<>()).add(entry.getValue());
+				}
+			}
+		} finally {
+			batches.clear();
+		}
+	}
+
+	protected Collection<TunnelFurniture> doExport(long hollowSpaceId) throws CityGMLExportException, SQLException {
+		return doExport(hollowSpaceId, null, null, getOrCreateStatement("tunnel_hollow_space_id"));
+	}
+
+	protected Map<Long, Collection<TunnelFurniture>> doExport(Set<Long> hollowSpaceIds) throws CityGMLExportException, SQLException {
+		if (hollowSpaceIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<Long, Collection<TunnelFurniture>> tunnelFurnitures = new HashMap<>();
+		for (Long roomId : hollowSpaceIds) {
+			addBatch(roomId, tunnelFurnitures);
+		}
+
+		executeBatch(tunnelFurnitures);
+		return tunnelFurnitures;
 	}
 
 	@Override
@@ -119,126 +165,117 @@ public class DBTunnelFurniture extends AbstractFeatureExporter<TunnelFurniture> 
 		ps.setLong(1, id);
 
 		try (ResultSet rs = ps.executeQuery()) {
-			List<TunnelFurniture> tunnelFurnitures = new ArrayList<>();
+			return doExport(id, root, rootType, rs).values();
+		}
+	}
 
-			while (rs.next()) {
-				long tunnelFurnitureId = rs.getLong("id");
-				TunnelFurniture tunnelFurniture;
-				FeatureType featureType;
+	private Map<Long, TunnelFurniture> doExport(long id, TunnelFurniture root, FeatureType rootType, ResultSet rs) throws CityGMLExportException, SQLException {
+		Map<Long, TunnelFurniture> tunnelFurnitures = new HashMap<>();
 
-				if (tunnelFurnitureId == id && root != null) {
-					tunnelFurniture = root;
-					featureType = rootType;
+		while (rs.next()) {
+			long tunnelFurnitureId = rs.getLong("id");
+			TunnelFurniture tunnelFurniture;
+			FeatureType featureType;
+
+			if (tunnelFurnitureId == id && root != null) {
+				tunnelFurniture = root;
+				featureType = rootType;
+			} else {
+				if (hasObjectClassIdColumn) {
+					// create tunnel furniture object
+					int objectClassId = rs.getInt("objectclass_id");
+					tunnelFurniture = exporter.createObject(objectClassId, TunnelFurniture.class);
+					if (tunnelFurniture == null) {
+						exporter.logOrThrowErrorMessage("Failed to instantiate " + exporter.getObjectSignature(objectClassId, tunnelFurnitureId) + " as tunnel furniture object.");
+						continue;
+					}
+
+					featureType = exporter.getFeatureType(objectClassId);
 				} else {
-					if (hasObjectClassIdColumn) {
-						// create tunnel furniture object
-						int objectClassId = rs.getInt("objectclass_id");
-						tunnelFurniture = exporter.createObject(objectClassId, TunnelFurniture.class);
-						if (tunnelFurniture == null) {
-							exporter.logOrThrowErrorMessage("Failed to instantiate " + exporter.getObjectSignature(objectClassId, tunnelFurnitureId) + " as tunnel furniture object.");
-							continue;
-						}
-
-						featureType = exporter.getFeatureType(objectClassId);
-					} else {
-						tunnelFurniture = new TunnelFurniture();
-						featureType = exporter.getFeatureType(tunnelFurniture);
-					}
-				}
-
-				// get projection filter
-				ProjectionFilter projectionFilter = exporter.getProjectionFilter(featureType);
-
-				doExport(tunnelFurniture, tunnelFurnitureId, featureType, projectionFilter, "", adeHookTables, rs);
-				tunnelFurnitures.add(tunnelFurniture);
-			}
-
-			return tunnelFurnitures;
-		}
-	}
-
-	protected TunnelFurniture doExport(long id, FeatureType featureType, String prefix, List<Table> adeHookTables, ResultSet rs) throws CityGMLExportException, SQLException {
-		TunnelFurniture tunnelFurniture = null;
-		if (featureType != null) {
-			tunnelFurniture = exporter.createObject(featureType.getObjectClassId(), TunnelFurniture.class);
-			if (tunnelFurniture != null)
-				doExport(tunnelFurniture, id, featureType, exporter.getProjectionFilter(featureType), prefix, adeHookTables, rs);
-		}
-
-		return tunnelFurniture;
-	}
-
-	private void doExport(TunnelFurniture object, long id, FeatureType featureType, ProjectionFilter projectionFilter, String prefix, List<Table> adeHookTables, ResultSet rs) throws CityGMLExportException, SQLException {
-		// export city object information
-		cityObjectExporter.addBatch(object, id, featureType, projectionFilter);
-
-		if (projectionFilter.containsProperty("class", tunnelModule)) {
-			String clazz = rs.getString(prefix + "class");
-			if (!rs.wasNull()) {
-				Code code = new Code(clazz);
-				code.setCodeSpace(rs.getString(prefix + "class_codespace"));
-				object.setClazz(code);
-			}
-		}
-
-		if (projectionFilter.containsProperty("function", tunnelModule)) {
-			for (SplitValue splitValue : valueSplitter.split(rs.getString(prefix + "function"), rs.getString(prefix + "function_codespace"))) {
-				Code function = new Code(splitValue.result(0));
-				function.setCodeSpace(splitValue.result(1));
-				object.addFunction(function);
-			}
-		}
-
-		if (projectionFilter.containsProperty("usage", tunnelModule)) {
-			for (SplitValue splitValue : valueSplitter.split(rs.getString(prefix + "usage"), rs.getString(prefix + "usage_codespace"))) {
-				Code usage = new Code(splitValue.result(0));
-				usage.setCodeSpace(splitValue.result(1));
-				object.addUsage(usage);
-			}
-		}
-
-		if (lodFilter.isEnabled(4)) {
-			if (projectionFilter.containsProperty("lod4Geometry", tunnelModule)) {
-				long geometryId = rs.getLong(prefix + "lod4_brep_id");
-				if (!rs.wasNull())
-					geometryExporter.addBatch(geometryId, (GeometrySetter.AbstractGeometry) object::setLod4Geometry);
-				else {
-					Object geometryObj = rs.getObject(prefix + "lod4_other_geom");
-					if (!rs.wasNull()) {
-						GeometryObject geometry = exporter.getDatabaseAdapter().getGeometryConverter().getGeometry(geometryObj);
-						if (geometry != null) {
-							GeometryProperty<AbstractGeometry> property = new GeometryProperty<>(gmlConverter.getPointOrCurveGeometry(geometry, true));
-							object.setLod4Geometry(property);
-						}
-					}
+					tunnelFurniture = new TunnelFurniture();
+					featureType = exporter.getFeatureType(tunnelFurniture);
 				}
 			}
 
-			if (projectionFilter.containsProperty("lod4ImplicitRepresentation", tunnelModule)) {
-				long implicitGeometryId = rs.getLong(prefix + "lod4_implicit_rep_id");
+			// get projection filter
+			ProjectionFilter projectionFilter = exporter.getProjectionFilter(featureType);
+
+			// export city object information
+			cityObjectExporter.addBatch(tunnelFurniture, id, featureType, projectionFilter);
+
+			if (projectionFilter.containsProperty("class", tunnelModule)) {
+				String clazz = rs.getString("class");
 				if (!rs.wasNull()) {
-					GeometryObject referencePoint = null;
-					Object referencePointObj = rs.getObject(prefix + "lod4_implicit_ref_point");
+					Code code = new Code(clazz);
+					code.setCodeSpace(rs.getString("class_codespace"));
+					tunnelFurniture.setClazz(code);
+				}
+			}
+
+			if (projectionFilter.containsProperty("function", tunnelModule)) {
+				for (SplitValue splitValue : valueSplitter.split(rs.getString("function"), rs.getString("function_codespace"))) {
+					Code function = new Code(splitValue.result(0));
+					function.setCodeSpace(splitValue.result(1));
+					tunnelFurniture.addFunction(function);
+				}
+			}
+
+			if (projectionFilter.containsProperty("usage", tunnelModule)) {
+				for (SplitValue splitValue : valueSplitter.split(rs.getString("usage"), rs.getString("usage_codespace"))) {
+					Code usage = new Code(splitValue.result(0));
+					usage.setCodeSpace(splitValue.result(1));
+					tunnelFurniture.addUsage(usage);
+				}
+			}
+
+			if (lodFilter.isEnabled(4)) {
+				if (projectionFilter.containsProperty("lod4Geometry", tunnelModule)) {
+					long geometryId = rs.getLong("lod4_brep_id");
 					if (!rs.wasNull())
-						referencePoint = exporter.getDatabaseAdapter().getGeometryConverter().getPoint(referencePointObj);
+						geometryExporter.addBatch(geometryId, (GeometrySetter.AbstractGeometry) tunnelFurniture::setLod4Geometry);
+					else {
+						Object geometryObj = rs.getObject("lod4_other_geom");
+						if (!rs.wasNull()) {
+							GeometryObject geometry = exporter.getDatabaseAdapter().getGeometryConverter().getGeometry(geometryObj);
+							if (geometry != null) {
+								GeometryProperty<AbstractGeometry> property = new GeometryProperty<>(gmlConverter.getPointOrCurveGeometry(geometry, true));
+								tunnelFurniture.setLod4Geometry(property);
+							}
+						}
+					}
+				}
 
-					String transformationMatrix = rs.getString(prefix + "lod4_implicit_transformation");
+				if (projectionFilter.containsProperty("lod4ImplicitRepresentation", tunnelModule)) {
+					long implicitGeometryId = rs.getLong("lod4_implicit_rep_id");
+					if (!rs.wasNull()) {
+						GeometryObject referencePoint = null;
+						Object referencePointObj = rs.getObject("lod4_implicit_ref_point");
+						if (!rs.wasNull())
+							referencePoint = exporter.getDatabaseAdapter().getGeometryConverter().getPoint(referencePointObj);
 
-					ImplicitGeometry implicit = implicitGeometryExporter.doExport(implicitGeometryId, referencePoint, transformationMatrix);
-					if (implicit != null) {
-						ImplicitRepresentationProperty implicitProperty = new ImplicitRepresentationProperty();
-						implicitProperty.setObject(implicit);
-						object.setLod4ImplicitRepresentation(implicitProperty);
+						String transformationMatrix = rs.getString("lod4_implicit_transformation");
+
+						ImplicitGeometry implicit = implicitGeometryExporter.doExport(implicitGeometryId, referencePoint, transformationMatrix);
+						if (implicit != null) {
+							ImplicitRepresentationProperty implicitProperty = new ImplicitRepresentationProperty();
+							implicitProperty.setObject(implicit);
+							tunnelFurniture.setLod4ImplicitRepresentation(implicitProperty);
+						}
 					}
 				}
 			}
+
+			// delegate export of generic ADE properties
+			if (adeHookTables != null) {
+				List<String> tableNames = retrieveADEHookTables(adeHookTables, rs);
+				if (tableNames != null)
+					exporter.delegateToADEExporter(tableNames, tunnelFurniture, id, featureType, projectionFilter);
+			}
+
+			tunnelFurniture.setLocalProperty("tunnel_hollow_space_id", rs.getLong("tunnel_hollow_space_id"));
+			tunnelFurnitures.put(tunnelFurnitureId, tunnelFurniture);
 		}
 
-		// delegate export of generic ADE properties
-		if (adeHookTables != null) {
-			List<String> tableNames = retrieveADEHookTables(adeHookTables, rs);
-			if (tableNames != null)
-				exporter.delegateToADEExporter(tableNames, object, id, featureType, projectionFilter);
-		}
+		return tunnelFurnitures;
 	}
 }

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBTunnelHollowSpace.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBTunnelHollowSpace.java
@@ -123,18 +123,18 @@ public class DBTunnelHollowSpace extends AbstractFeatureExporter<HollowSpace> {
 				surfaceADEHookTables = addJoinsToADEHookTables(TableEnum.THEMATIC_SURFACE, thematicSurface);
 			}
 			if (projectionFilter.containsProperty("hollowSpaceInstallation", tunnelModule)) {
-				Table tunnelFurniture = new Table(TableEnum.TUNNEL_FURNITURE.getName(), schema);
-				select.addProjection(new ColumnExpression(new Select()
-						.addProjection(tunnelFurniture.getColumn("id"))
-						.addSelection(ComparisonFactory.equalTo(tunnelFurniture.getColumn("tunnel_hollow_space_id"), table.getColumn("id")))
-						.withFetch(new FetchToken(1)), "tfid"));
-			}
-			if (projectionFilter.containsProperty("interiorFurniture", tunnelModule)) {
 				Table installation = new Table(TableEnum.TUNNEL_INSTALLATION.getName(), schema);
 				select.addProjection(new ColumnExpression(new Select()
 						.addProjection(installation.getColumn("id"))
 						.addSelection(ComparisonFactory.equalTo(installation.getColumn("tunnel_hollow_space_id"), table.getColumn("id")))
 						.withFetch(new FetchToken(1)), "inid"));
+			}
+			if (projectionFilter.containsProperty("interiorFurniture", tunnelModule)) {
+				Table tunnelFurniture = new Table(TableEnum.TUNNEL_FURNITURE.getName(), schema);
+				select.addProjection(new ColumnExpression(new Select()
+						.addProjection(tunnelFurniture.getColumn("id"))
+						.addSelection(ComparisonFactory.equalTo(tunnelFurniture.getColumn("tunnel_hollow_space_id"), table.getColumn("id")))
+						.withFetch(new FetchToken(1)), "tfid"));
 			}
 		}
 		hollowSpaceADEHookTables = addJoinsToADEHookTables(TableEnum.TUNNEL_HOLLOW_SPACE, table);


### PR DESCRIPTION
This PR removes some of the left joins used in queries for top-level features involving many nested child features, such as building, bridges and tunnels. Left joins quickly increase the number of overall tuples in the result set, so it may take longer to iterate through this result set than querying the nested features in separate queries.