### PR TITLE
Add option to control whether to compute the number of matching top-level objects

### DIFF
--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/GeneralPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/GeneralPanel.java
@@ -49,6 +49,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 	private JRadioButton cityGMLv1;
 	private JLabel versionHintLabel;
 	private JCheckBox failFastOnErrors;
+	private JCheckBox computeNumberMatched;
 	private JLabel compressedOutputFormatLabel;
 	private JComboBox<OutputFormat> compressedOutputFormat;
 
@@ -71,6 +72,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 
 		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
 		if (failFastOnErrors.isSelected() != generalOptions.isFailFastOnErrors()) return true;
+		if (computeNumberMatched.isSelected() != generalOptions.getComputeNumberMatched().isEnabled()) return true;
 		if (compressedOutputFormat.getSelectedItem() != generalOptions.getCompressedOutputFormat()) return true;
 		if (featureEnvelope.getSelectedItem() != generalOptions.getEnvelope().getFeatureMode()) return true;
 		if (cityModelEnvelope.isSelected() != generalOptions.getEnvelope().isUseEnvelopeOnCityModel()) return true;
@@ -91,6 +93,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 		versionHintLabel.setFont(versionHintLabel.getFont().deriveFont(Font.ITALIC));
 
 		failFastOnErrors = new JCheckBox();
+		computeNumberMatched = new JCheckBox();
 		compressedOutputFormatLabel = new JLabel();
 		compressedOutputFormat = new JComboBox<>();
 		for (OutputFormat outputFormat : OutputFormat.values()) {
@@ -131,8 +134,9 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 			content.add(versionHintLabel, GuiUtil.setConstraints(0, 1, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, lmargin, 0, 0));
 			content.add(cityGMLv1, GuiUtil.setConstraints(0, 2, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
 			content.add(failFastOnErrors, GuiUtil.setConstraints(0, 3, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
-			content.add(compressedOutputFormatLabel, GuiUtil.setConstraints(0, 4, 0, 0, GridBagConstraints.HORIZONTAL, 5, 0, 0, 5));
-			content.add(compressedOutputFormat, GuiUtil.setConstraints(1, 4, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 0));
+			content.add(computeNumberMatched, GuiUtil.setConstraints(0, 4, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
+			content.add(compressedOutputFormatLabel, GuiUtil.setConstraints(0, 5, 0, 0, GridBagConstraints.HORIZONTAL, 5, 0, 0, 5));
+			content.add(compressedOutputFormat, GuiUtil.setConstraints(1, 5, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 0));
 
 			generalPanel = new TitledPanel().build(content);
 		}
@@ -162,6 +166,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 		cityGMLv1.setText(Language.I18N.getString("pref.export.general.label.citygmlv1"));
 		versionHintLabel.setText(Language.I18N.getString("pref.export.general.label.versionHint"));
 		failFastOnErrors.setText(Language.I18N.getString("pref.export.general.failFastOnError"));
+		computeNumberMatched.setText(Language.I18N.getString("pref.export.general.computeNumberMatched"));
 		compressedOutputFormatLabel.setText(Language.I18N.getString("pref.export.general.label.compressedFormat"));
 		envelopePanel.setTitle(Language.I18N.getString("pref.export.general.border.bbox"));
 		featureEnvelopeLabel.setText(Language.I18N.getString("pref.export.general.label.feature"));
@@ -182,6 +187,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 
 		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
 		failFastOnErrors.setSelected(generalOptions.isFailFastOnErrors());
+		computeNumberMatched.setSelected(generalOptions.getComputeNumberMatched().isEnabled());
 		compressedOutputFormat.setSelectedItem(generalOptions.getCompressedOutputFormat());
 		featureEnvelope.setSelectedItem(generalOptions.getEnvelope().getFeatureMode());
 		cityModelEnvelope.setSelected(generalOptions.getEnvelope().isUseEnvelopeOnCityModel());
@@ -198,6 +204,7 @@ public class GeneralPanel extends DefaultPreferencesComponent {
 
 		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
 		generalOptions.setFailFastOnErrors(failFastOnErrors.isSelected());
+		generalOptions.getComputeNumberMatched().setEnabled(computeNumberMatched.isSelected());
 		generalOptions.setCompressedOutputFormat((OutputFormat) compressedOutputFormat.getSelectedItem());
 		generalOptions.getEnvelope().setFeatureMode((FeatureEnvelopeMode) featureEnvelope.getSelectedItem());
 		generalOptions.getEnvelope().setUseEnvelopeOnCityModel(cityModelEnvelope.isSelected());

--- a/impexp-config/src/main/java/org/citydb/config/project/common/ComputeNumberMatched.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/common/ComputeNumberMatched.java
@@ -26,7 +26,7 @@
  * limitations under the License.
  */
 
-package org.citydb.config.project.exporter;
+package org.citydb.config.project.common;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlType;

--- a/impexp-config/src/main/java/org/citydb/config/project/deleter/DeleteConfig.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/deleter/DeleteConfig.java
@@ -28,6 +28,7 @@
 
 package org.citydb.config.project.deleter;
 
+import org.citydb.config.project.common.ComputeNumberMatched;
 import org.citydb.config.project.common.IdList;
 import org.citydb.config.project.exporter.SimpleQuery;
 import org.citydb.config.project.query.QueryConfig;
@@ -44,6 +45,7 @@ import javax.xml.bind.annotation.XmlType;
         "simpleQuery",
         "deleteList",
         "cleanupGlobalAppearances",
+        "computeNumberMatched",
         "continuation",
         "deleteLog"
 })
@@ -58,12 +60,14 @@ public class DeleteConfig {
     private SimpleQuery simpleQuery;
     private IdList deleteList;
     private boolean cleanupGlobalAppearances;
+    private ComputeNumberMatched computeNumberMatched;
     private Continuation continuation;
     private DeleteLog deleteLog;
 
     public DeleteConfig() {
         query = new QueryConfig();
         simpleQuery = new SimpleQuery();
+        computeNumberMatched = new ComputeNumberMatched();
         continuation = new Continuation();
         deleteLog = new DeleteLog();
     }
@@ -128,6 +132,16 @@ public class DeleteConfig {
 
     public void setCleanupGlobalAppearances(boolean cleanupGlobalAppearances) {
         this.cleanupGlobalAppearances = cleanupGlobalAppearances;
+    }
+
+    public ComputeNumberMatched getComputeNumberMatched() {
+        return computeNumberMatched;
+    }
+
+    public void setComputeNumberMatched(ComputeNumberMatched computeNumberMatched) {
+        if (computeNumberMatched != null) {
+            this.computeNumberMatched = computeNumberMatched;
+        }
     }
 
     public Continuation getContinuation() {

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/ComputeNumberMatched.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/ComputeNumberMatched.java
@@ -1,0 +1,57 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2022
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.config.project.exporter;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+
+@XmlType(name="ComputeNumberMatched")
+public class ComputeNumberMatched {
+    @XmlAttribute(required = true)
+    private boolean onlyInGuiMode = true;
+    @XmlValue
+    private Boolean enabled = true;
+
+    public boolean isOnlyInGuiMode() {
+        return onlyInGuiMode;
+    }
+
+    public void setOnlyInGuiMode(boolean onlyInGuiMode) {
+        this.onlyInGuiMode = onlyInGuiMode;
+    }
+
+    public boolean isEnabled() {
+        return enabled != null ? enabled : true;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/GeneralOptions.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/GeneralOptions.java
@@ -34,11 +34,13 @@ import java.nio.charset.StandardCharsets;
 @XmlType(name="GeneralExportOptionsType", propOrder={})
 public class GeneralOptions {
     private Boolean failFastOnErrors = true;
+    private ComputeNumberMatched computeNumberMatched;
     private String fileEncoding;
     private OutputFormat compressedOutputFormat = OutputFormat.CITYGML;
     private ExportEnvelope envelope;
 
     public GeneralOptions() {
+        computeNumberMatched = new ComputeNumberMatched();
         envelope = new ExportEnvelope();
     }
 
@@ -48,6 +50,16 @@ public class GeneralOptions {
 
     public void setFailFastOnErrors(boolean failFastOnErrors) {
         this.failFastOnErrors = failFastOnErrors;
+    }
+
+    public ComputeNumberMatched getComputeNumberMatched() {
+        return computeNumberMatched;
+    }
+
+    public void setComputeNumberMatched(ComputeNumberMatched computeNumberMatched) {
+        if (computeNumberMatched != null) {
+            this.computeNumberMatched = computeNumberMatched;
+        }
     }
 
     public boolean isSetFileEncoding() {

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/GeneralOptions.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/GeneralOptions.java
@@ -28,6 +28,8 @@
 
 package org.citydb.config.project.exporter;
 
+import org.citydb.config.project.common.ComputeNumberMatched;
+
 import javax.xml.bind.annotation.XmlType;
 import java.nio.charset.StandardCharsets;
 

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -516,6 +516,7 @@ pref.export.general.label.citygmlv2=CityGML 2.0 verwenden
 pref.export.general.label.citygmlv1=CityGML 1.0 verwenden
 pref.export.general.label.versionHint=Diese Version wird für CityJSON Exporte empfohlen
 pref.export.general.failFastOnError=Export bei Fehlern sofort abbrechen
+pref.export.general.computeNumberMatched=Anzahl der Top-Level Objekte berechnen, die die Anfrage erfüllen
 pref.export.general.label.compressedFormat=Ausgabeformat für komprimierte Exporte
 pref.export.general.border.bbox=Bounding Box Optionen
 pref.export.general.label.feature=Bounding Box exportieren

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -516,6 +516,7 @@ pref.export.general.label.citygmlv2=Use CityGML 2.0
 pref.export.general.label.citygmlv1=Use CityGML 1.0
 pref.export.general.label.versionHint=This version is recommended when exporting to CityJSON
 pref.export.general.failFastOnError=Cancel export immediately in case of errors
+pref.export.general.computeNumberMatched=Compute number of matching top-level objects
 pref.export.general.label.compressedFormat=Output format for compressed exports
 pref.export.general.border.bbox=Bounding box options
 pref.export.general.label.feature=Export bounding box

--- a/impexp-core/src/main/java/org/citydb/core/operation/deleter/controller/Deleter.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/deleter/controller/Deleter.java
@@ -253,7 +253,6 @@ public class Deleter implements EventHandler {
 						config,
 						eventDispatcher,
 						preview);
-				deleteManager.setCalculateNumberMatched(CoreConstants.IS_GUI_MODE);
 				deleteManager.deleteObjects();
 			} catch (SQLException | IOException | QueryBuildException e) {
 				throw new DeleteException("Failed to execute the " + mode.value() + " operation.", e);

--- a/impexp-core/src/main/java/org/citydb/core/operation/deleter/database/DeleteManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/deleter/database/DeleteManager.java
@@ -53,6 +53,7 @@ import org.citydb.core.query.filter.selection.expression.ValueReference;
 import org.citydb.core.query.filter.selection.operator.comparison.ComparisonFactory;
 import org.citydb.core.query.filter.selection.operator.comparison.NullOperator;
 import org.citydb.core.query.filter.selection.operator.logical.LogicalOperationFactory;
+import org.citydb.core.util.CoreConstants;
 import org.citydb.sqlbuilder.expression.StringLiteral;
 import org.citydb.sqlbuilder.expression.TimestampLiteral;
 import org.citydb.sqlbuilder.schema.Column;
@@ -130,6 +131,10 @@ public class DeleteManager {
 				DatabaseConnectionPool.getInstance().getConnection();
 
 		connection.setAutoCommit(false);
+
+		calculateNumberMatched = config.getDeleteConfig().getComputeNumberMatched().isEnabled()
+				&& (CoreConstants.IS_GUI_MODE
+				|| !config.getDeleteConfig().getComputeNumberMatched().isOnlyInGuiMode());
 
 		builder = new SQLQueryBuilder(
 				schemaMapping, 

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/controller/Exporter.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/controller/Exporter.java
@@ -72,7 +72,6 @@ import org.citydb.core.query.filter.selection.operator.logical.LogicalOperationF
 import org.citydb.core.query.filter.tiling.Tile;
 import org.citydb.core.query.filter.tiling.Tiling;
 import org.citydb.core.registry.ObjectRegistry;
-import org.citydb.core.util.CoreConstants;
 import org.citydb.core.util.Util;
 import org.citydb.util.concurrent.PoolSizeAdaptationStrategy;
 import org.citydb.util.concurrent.WorkerPool;
@@ -527,7 +526,6 @@ public class Exporter implements EventHandler {
 
                         if (shouldRun) {
                             dbSplitter.setMetadataProviders(metadataProviders);
-                            dbSplitter.setCalculateNumberMatched(CoreConstants.IS_GUI_MODE);
                             dbSplitter.startQuery();
                         }
                     } catch (SQLException | QueryBuildException | FilterException e) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBSplitter.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBSplitter.java
@@ -32,6 +32,7 @@ import org.citydb.config.geometry.BoundingBox;
 import org.citydb.config.geometry.GeometryObject;
 import org.citydb.config.geometry.Position;
 import org.citydb.config.i18n.Language;
+import org.citydb.config.project.exporter.GeneralOptions;
 import org.citydb.config.project.global.CacheMode;
 import org.citydb.core.database.adapter.AbstractDatabaseAdapter;
 import org.citydb.core.database.connection.DatabaseConnectionPool;
@@ -57,6 +58,7 @@ import org.citydb.core.query.filter.FilterException;
 import org.citydb.core.query.filter.selection.Predicate;
 import org.citydb.core.query.filter.selection.SelectionFilter;
 import org.citydb.core.query.filter.type.FeatureTypeFilter;
+import org.citydb.core.util.CoreConstants;
 import org.citydb.sqlbuilder.expression.LiteralList;
 import org.citydb.sqlbuilder.schema.Column;
 import org.citydb.sqlbuilder.schema.Table;
@@ -136,7 +138,12 @@ public class DBSplitter {
 		connection = DatabaseConnectionPool.getInstance().getConnection();
 		connection.setAutoCommit(false);
 		schema = databaseAdapter.getConnectionDetails().getSchema();
-		calculateExtent = config.getExportConfig().getGeneralOptions().getEnvelope().isUseEnvelopeOnCityModel();
+
+		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
+		calculateExtent = generalOptions.getEnvelope().isUseEnvelopeOnCityModel();
+		calculateNumberMatched = generalOptions.getComputeNumberMatched().isEnabled()
+				&& (CoreConstants.IS_GUI_MODE
+				|| !generalOptions.getComputeNumberMatched().isOnlyInGuiMode());
 
 		// create temporary table for global appearances if needed
 		if (internalConfig.isExportGlobalAppearances()) {


### PR DESCRIPTION
On large databases, computing the number of top-level objects matching the provided query can take a long time. This PR adds an option to the general export preferences, which allows a user to disable this feature. If disabled, the number of matching top-level objects is no longer recorded in the log and the GUI cannot use a progress bar to indicate the export progress.