### PR TITLE
Fix terminate with delete list

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/operation/common/cache/CacheTableManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/common/cache/CacheTableManager.java
@@ -140,16 +140,29 @@ public class CacheTableManager {
 	}
 
 	public synchronized void dropAll() throws SQLException {
+		// rollback transactions
+		for (Cache cache : caches.values()) {
+			cache.connection.rollback();
+		}
+
+		// drop cache and branch tables in case they have not
+		// been deleted automatically by the previous rollback
 		for (CacheTable cacheTable : cacheTables.values()) {
-			cacheTable.drop();
+			try {
+				cacheTable.drop();
+				cacheTable.connection.commit();
+			} catch (SQLException e) {
+				//
+			}
 		}
 
 		for (BranchCacheTable branchCacheTable : branchCacheTables.values()) {
-			branchCacheTable.drop();
-		}
-
-		for (Cache cache : caches.values()) {
-			cache.connection.rollback();
+			try {
+				branchCacheTable.drop();
+				branchCacheTable.connection.commit();
+			} catch (SQLException e) {
+				//
+			}
 		}
 
 		cacheTables.clear();

--- a/impexp-core/src/main/java/org/citydb/core/operation/deleter/database/DeleteManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/deleter/database/DeleteManager.java
@@ -218,7 +218,7 @@ public class DeleteManager {
 
 			if (config.getDeleteConfig().getMode() == DeleteMode.TERMINATE && !preview) {
 				// commit cache table so that its content can be read from other connections
-				cacheTable.getConnection().commit();
+				connection.commit();
 			}
 		}
 

--- a/impexp-core/src/main/java/org/citydb/core/operation/deleter/database/DeleteManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/deleter/database/DeleteManager.java
@@ -215,6 +215,11 @@ public class DeleteManager {
 			log.debug("Creating indexes on temporary delete list table...");
 			cacheTable.createIndexes();
 			joinDeleteList(select);
+
+			if (config.getDeleteConfig().getMode() == DeleteMode.TERMINATE && !preview) {
+				// commit cache table so that its content can be read from other connections
+				cacheTable.getConnection().commit();
+			}
 		}
 
 		// get affected city objects


### PR DESCRIPTION
When terminating city objects based on a delete list, the current implementation of the `DeleteManager` throws an error because it cannot read from the cache table holding the values from the delete list. The reason is that the cache table is a temporary table whose contents cannot be accessed from the connection that is used to execute the UPDATE statement performing the terminate. This PR fixes this bug.