### PR TITLE
Fix SQL filter

### DIFF
--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/common/filter/SQLFilterView.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/common/filter/SQLFilterView.java
@@ -183,7 +183,7 @@ public class SQLFilterView extends FilterView<SelectOperator> {
         SelectOperator selectOperator = new SelectOperator();
         String value = sqlText.getText().trim();
         if (!value.isEmpty()) {
-            selectOperator.setValue(value.replaceAll(";", " "));
+            selectOperator.setValue(value);
         }
 
         sqlFilterComponentSupplier.get().setAdditionalRows(additionalRows);

--- a/impexp-core/src/main/java/org/citydb/core/query/builder/util/SQLTokenParser.java
+++ b/impexp-core/src/main/java/org/citydb/core/query/builder/util/SQLTokenParser.java
@@ -39,8 +39,7 @@ public class SQLTokenParser {
     private final String[] invalidTokens = {
             "del_.*?\\(.*?\\)",
             "delete_.*?\\(.*?\\)",
-            "cleanup_.*?\\(.*?\\)",
-            ";"
+            "cleanup_.*?\\(.*?\\)"
     };
 
     public SQLTokenParser() {


### PR DESCRIPTION
The current SQL filter fails if a ";" character is in the filter string. This avoids, for instance, using the SQL filter for expressing spatial filters on PostgreSQL/PostGIS like the following:

`select id from cityobject WHERE ST_Intersects('SRID=28992;POLYGON ((1,1 2,2 ...))' , envelope)`