### PR TITLE
Fixed handling of timestamp literal in XML queries

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/query/builder/config/ComparisonOperatorBuilder.java
+++ b/impexp-core/src/main/java/org/citydb/core/query/builder/config/ComparisonOperatorBuilder.java
@@ -241,7 +241,6 @@ public class ComparisonOperatorBuilder {
 					XMLGregorianCalendar calendar = datatypeFactory.newXMLGregorianCalendar(literalValue);
 					literal = new TimestampLiteral(toInstant(calendar));
 					((TimestampLiteral) literal).setXMLLiteral(literalValue);
-					((TimestampLiteral) literal).setDate(calendar.getXMLSchemaType() == DatatypeConstants.DATE);
 				} catch (IllegalArgumentException e) {
 					//
 				}

--- a/impexp-core/src/main/java/org/citydb/core/query/filter/selection/expression/TimestampLiteral.java
+++ b/impexp-core/src/main/java/org/citydb/core/query/filter/selection/expression/TimestampLiteral.java
@@ -30,7 +30,6 @@ package org.citydb.core.query.filter.selection.expression;
 import org.citydb.core.database.schema.mapping.SimpleType;
 import org.citydb.sqlbuilder.expression.PlaceHolder;
 
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Calendar;
@@ -39,7 +38,7 @@ import java.util.GregorianCalendar;
 public class TimestampLiteral extends AbstractLiteral<Instant> {
 	private String xmlLiteral;
 	private boolean isDate;
-	
+
 	public TimestampLiteral(Instant value) {
 		super(value);
 	}
@@ -60,10 +59,12 @@ public class TimestampLiteral extends AbstractLiteral<Instant> {
 		this.xmlLiteral = xmlLiteral;
 	}
 
+	@Deprecated
 	public boolean isDate() {
 		return isDate;
 	}
 
+	@Deprecated
 	public void setDate(boolean isDate) {
 		this.isDate = isDate;
 	}
@@ -80,9 +81,7 @@ public class TimestampLiteral extends AbstractLiteral<Instant> {
 
 	@Override
 	public PlaceHolder<?> convertToSQLPlaceHolder() {
-		return !isDate ?
-				new PlaceHolder<>(Timestamp.from(value)) :
-				new PlaceHolder<>(new Date(value.toEpochMilli()));
+		return new PlaceHolder<>(Timestamp.from(value));
 	}
 
 	@Override


### PR DESCRIPTION
In case a CityGML building has a generic attribute `CREATION_DATE` and its value is `2019-12-31`, this value will be handled as a UTC time `2019-12-31+00:00` for the DB Import. 

Currently, the following XML query returns the building. This is not correct, because the date literal has a zone offset and the actual UTC date is `2019-12-30` rather than `2019-12-31`.  This PR fixes the issue.

``` xml
<query xmlns="http://www.3dcitydb.org/importer-exporter/config">
  <typeNames>
    <typeName xmlns:core="http://www.opengis.net/citygml/2.0">core:_CityObject</typeName>
  </typeNames>
  <filter>
    <propertyIsEqualTo>
      <valueReference>gen:dateAttribute[@gen:name="CREATION_DATE"]/gen:value</valueReference>
      <literal>2019-12-31+01:00</literal>
    </propertyIsEqualTo>
  </filter>
</query>
```