### PR TITLE
Fixed handling of date literal in XML queries

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/query/builder/config/ComparisonOperatorBuilder.java
+++ b/impexp-core/src/main/java/org/citydb/core/query/builder/config/ComparisonOperatorBuilder.java
@@ -39,6 +39,7 @@ import org.citydb.core.query.filter.selection.expression.*;
 import org.citydb.core.query.filter.selection.operator.comparison.*;
 import org.citydb.core.registry.ObjectRegistry;
 
+import javax.xml.bind.DatatypeConverter;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -229,8 +230,7 @@ public class ComparisonOperatorBuilder {
 				break;
 			case DATE:
 				try {
-					XMLGregorianCalendar calendar = datatypeFactory.newXMLGregorianCalendar(literalValue);
-					literal = new DateLiteral(toInstant(calendar));
+					literal = new DateLiteral(DatatypeConverter.parseDateTime(literalValue));
 					((DateLiteral) literal).setXMLLiteral(literalValue);
 				} catch (IllegalArgumentException e) {
 					//


### PR DESCRIPTION
In case that a building in the database has a yearOfConstruction attribute with value `2019` and the importer/exporter runs on a computer with a time zone having a minus offset e.g. `(UTC-01:00) Azoren`, the following XML query returns no results. This PR fixes the issue. 

``` xml
<query xmlns="http://www.3dcitydb.org/importer-exporter/config">
  <typeNames>
    <typeName xmlns:bldg="http://www.opengis.net/citygml/building/2.0">bldg:Building</typeName>
  </typeNames>
  <filter>
    <propertyIsEqualTo>
      <valueReference>bldg:yearOfConstruction</valueReference>
      <literal>2019</literal>
    </propertyIsEqualTo>
  </filter>
</query>
```  