### PR TITLE
Avoid duplicate implicit geometries

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/database/version/DefaultDatabaseVersionChecker.java
+++ b/impexp-core/src/main/java/org/citydb/core/database/version/DefaultDatabaseVersionChecker.java
@@ -42,7 +42,7 @@ import java.util.List;
 
 public class DefaultDatabaseVersionChecker implements DatabaseVersionChecker {
 	private final DatabaseVersionSupport[] supportedVersions = new DatabaseVersionSupport[]{
-			DatabaseVersionSupport.targetVersion(4, 2, 0).withBackwardsCompatibility(4, 0, 0).withRevisionForwardCompatibility(true),
+			DatabaseVersionSupport.targetVersion(4, 3, 0).withBackwardsCompatibility(4, 0, 0).withRevisionForwardCompatibility(true),
 			DatabaseVersionSupport.targetVersion(3, 3, 1).withBackwardsCompatibility(3, 0, 0).withRevisionForwardCompatibility(true)
 	};
 

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/CityGMLImportManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/CityGMLImportManager.java
@@ -797,7 +797,7 @@ public class CityGMLImportManager implements CityGMLImportHelper {
 			else if (type == DBAddress.class)
 				importer = new DBAddress(connection, config, this);
 			else if (type == DBImplicitGeometry.class)
-				importer = new DBImplicitGeometry(connection, config, this);
+				importer = new DBImplicitGeometry(connection, this);
 
 			// building module
 			else if (type == DBBuilding.class)

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBSurfaceGeometry.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBSurfaceGeometry.java
@@ -77,10 +77,10 @@ public class DBSurfaceGeometry implements DBImporter {
 	private final boolean importAppearance;
 	private final int nullGeometryType;
 	private final String nullGeometryTypeName;
-	private final int isXlinkValue;
 
 	private int dbSrid;
     private boolean applyTransformation;
+    private int isXlinkValue;
     private boolean isImplicit;
     private int batchCounter;
 
@@ -159,16 +159,23 @@ public class DBSurfaceGeometry implements DBImporter {
         // thus, we do not need to apply it to the coordinate values
         boolean _applyTransformation = applyTransformation;
         int _dbSrid = dbSrid;
+        int _isXlinkValue = isXlinkValue;
 
         try {
             isImplicit = true;
             applyTransformation = false;
             dbSrid = 0;
+
+            // force global XLink flag for implicit geometries
+            isXlinkValue = XlinkType.GLOBAL.value();
+            geometry.setLocalProperty(CoreConstants.GEOMETRY_XLINK, true);
+
             return doImport(geometry, 0);
         } finally {
             isImplicit = false;
             applyTransformation = _applyTransformation;
             dbSrid = _dbSrid;
+            isXlinkValue = _isXlinkValue;
         }
     }
 

--- a/impexp-core/src/main/java/org/citydb/core/util/CoreConstants.java
+++ b/impexp-core/src/main/java/org/citydb/core/util/CoreConstants.java
@@ -59,6 +59,7 @@ public class CoreConstants {
     public static final String EXPORT_STUB = "exportStub";
     public static final String EXPORT_AS_ADDITIONAL_OBJECT = "additionalObject";
     public static final String UNIQUE_TEXTURE_FILENAME_PREFIX = "tex_";
+    public static final String UNIQUE_LIBRARY_OBJECT_FILENAME_PREFIX = "library_object_";
 
     public static boolean IS_GUI_MODE = false;
 


### PR DESCRIPTION
This PR proposes to change the way `gml:relativeGeometry` properties of implicit geometries are imported so that duplicate entries are avoided for the `implicit_geometry` table. 

The current importer implementation makes sure that a `gml:relativeGeometry` is only imported once if it is reused within the _same input file_. If, however, the same `gml:relativeGeometry` is also used in another input file, it will be imported again.

With this PR, the importer first checks whether the `gml:relativeGeometry` already exists in the `implicit_geometry` table. If so, it will not be imported again. Like for the current implementation, this check is _only_ based on the `gml:id` of the relative geometry. To be able to check the `gml:id` of previously imported relative geometries, a new `gmlid` column has to be added to the `implicit_geometry` table. This new column is proposed in https://github.com/3dcitydb/3dcitydb/pull/79 and is required for this PR to work.