### PR TITLE
Fix initialization of GUI extensions

### DIFF
--- a/impexp-client-gui/src/main/java/org/citydb/gui/GuiCommand.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/GuiCommand.java
@@ -127,23 +127,22 @@ public class GuiCommand extends CliCommand implements StartupProgressListener {
     }
 
     private void initializeViewComponents(ImpExpGui impExpGui, Config config) {
-        // create database plugin
-        DatabasePlugin databasePlugin = new DatabasePlugin(impExpGui, config);
-        DatabaseController databaseController = ObjectRegistry.getInstance().getDatabaseController();
-        databaseController.setConnectionViewHandler(databasePlugin.getConnectionViewHandler());
-
         // register predefined internal plugins
-        pluginManager.registerInternalPlugin(new CityGMLImportPlugin(impExpGui, config));
-        pluginManager.registerInternalPlugin(new CityGMLExportPlugin(impExpGui, config));
-        pluginManager.registerInternalPlugin(new VisExportPlugin(impExpGui, config));
+        pluginManager.registerInternalPlugin(new CityGMLImportPlugin());
+        pluginManager.registerInternalPlugin(new CityGMLExportPlugin());
+        pluginManager.registerInternalPlugin(new VisExportPlugin());
+
+        // create and register database plugin
+        DatabasePlugin databasePlugin = new DatabasePlugin();
         pluginManager.registerInternalPlugin(databasePlugin);
 
         // only register plugins settings if external plugins are installed
         if (!pluginManager.getExternalPlugins().isEmpty()) {
-            pluginManager.registerInternalPlugin(new PluginsOverviewPlugin(config));
+            pluginManager.registerInternalPlugin(new PluginsOverviewPlugin());
         }
 
-        pluginManager.registerInternalPlugin(new PreferencesPlugin(impExpGui, config));
+        // create preferences plugin
+        PreferencesPlugin preferencesPlugin = new PreferencesPlugin(impExpGui);
 
         // initialize all GUI plugins
         Locale locale = new Locale(config.getGlobalConfig().getLanguage().value());
@@ -152,6 +151,14 @@ public class GuiCommand extends CliCommand implements StartupProgressListener {
                 ((GuiExtension) plugin).initGuiExtension(impExpGui, locale);
             }
         }
+
+        // initialize and register preferences plugin
+        preferencesPlugin.initGuiExtension(impExpGui, locale);
+        pluginManager.registerInternalPlugin(preferencesPlugin);
+
+        // set view handler for database controller
+        DatabaseController databaseController = ObjectRegistry.getInstance().getDatabaseController();
+        databaseController.setConnectionViewHandler(databasePlugin.getConnectionViewHandler());
     }
 
     @Override

--- a/impexp-client-gui/src/main/java/org/citydb/gui/GuiCommand.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/GuiCommand.java
@@ -141,9 +141,6 @@ public class GuiCommand extends CliCommand implements StartupProgressListener {
             pluginManager.registerInternalPlugin(new PluginsOverviewPlugin());
         }
 
-        // create preferences plugin
-        PreferencesPlugin preferencesPlugin = new PreferencesPlugin(impExpGui);
-
         // initialize all GUI plugins
         Locale locale = new Locale(config.getGlobalConfig().getLanguage().value());
         for (Plugin plugin : pluginManager.getPlugins()) {
@@ -152,7 +149,8 @@ public class GuiCommand extends CliCommand implements StartupProgressListener {
             }
         }
 
-        // initialize and register preferences plugin
+        // register preferences plugin
+        PreferencesPlugin preferencesPlugin = new PreferencesPlugin(impExpGui);
         preferencesPlugin.initGuiExtension(impExpGui, locale);
         pluginManager.registerInternalPlugin(preferencesPlugin);
 

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/database/DatabasePlugin.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/database/DatabasePlugin.java
@@ -30,6 +30,7 @@ package org.citydb.gui.operation.database;
 import org.citydb.config.Config;
 import org.citydb.core.database.connection.ConnectionViewHandler;
 import org.citydb.core.plugin.internal.InternalPlugin;
+import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.gui.operation.database.preferences.DatabasePreferences;
 import org.citydb.gui.operation.database.view.DatabaseView;
 import org.citydb.gui.plugin.preferences.Preferences;
@@ -41,16 +42,14 @@ import org.citydb.gui.plugin.view.ViewExtension;
 import java.util.Locale;
 
 public class DatabasePlugin extends InternalPlugin implements ViewExtension, PreferencesExtension {
-	private final DatabaseView view;
-	private final DatabasePreferences preferences;
-	
-	public DatabasePlugin(ViewController viewController, Config config) {
-		view = new DatabaseView(viewController, config);
-		preferences = new DatabasePreferences(viewController, config);
-	}
+	private DatabaseView view;
+	private DatabasePreferences preferences;
 
 	@Override
 	public void initGuiExtension(ViewController viewController, Locale locale) {
+		Config config = ObjectRegistry.getInstance().getConfig();
+		view = new DatabaseView(viewController, config);
+		preferences = new DatabasePreferences(viewController, config);
 		loadSettings();
 	}
 

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/CityGMLExportPlugin.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/CityGMLExportPlugin.java
@@ -29,6 +29,7 @@ package org.citydb.gui.operation.exporter;
 
 import org.citydb.config.Config;
 import org.citydb.core.plugin.internal.InternalPlugin;
+import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.gui.operation.exporter.preferences.CityGMLExportPreferences;
 import org.citydb.gui.operation.exporter.view.CityGMLExportView;
 import org.citydb.gui.plugin.preferences.Preferences;
@@ -40,16 +41,14 @@ import org.citydb.gui.plugin.view.ViewExtension;
 import java.util.Locale;
 
 public class CityGMLExportPlugin extends InternalPlugin implements ViewExtension, PreferencesExtension {
-	private final CityGMLExportView view;
-	private final CityGMLExportPreferences preferences;
-	
-	public CityGMLExportPlugin(ViewController viewController, Config config) {
-		view = new CityGMLExportView(viewController, config);
-		preferences = new CityGMLExportPreferences(config);
-	}
+	private CityGMLExportView view;
+	private CityGMLExportPreferences preferences;
 
 	@Override
 	public void initGuiExtension(ViewController viewController, Locale locale) {
+		Config config = ObjectRegistry.getInstance().getConfig();
+		view = new CityGMLExportView(viewController, config);
+		preferences = new CityGMLExportPreferences(config);
 		loadSettings();
 	}
 

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/CityGMLImportPlugin.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/importer/CityGMLImportPlugin.java
@@ -29,6 +29,7 @@ package org.citydb.gui.operation.importer;
 
 import org.citydb.config.Config;
 import org.citydb.core.plugin.internal.InternalPlugin;
+import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.gui.operation.importer.preferences.CityGMLImportPreferences;
 import org.citydb.gui.operation.importer.view.CityGMLImportView;
 import org.citydb.gui.plugin.preferences.Preferences;
@@ -40,16 +41,14 @@ import org.citydb.gui.plugin.view.ViewExtension;
 import java.util.Locale;
 
 public class CityGMLImportPlugin extends InternalPlugin implements ViewExtension, PreferencesExtension {
-	private final CityGMLImportView view;
-	private final CityGMLImportPreferences preferences;
-	
-	public CityGMLImportPlugin(ViewController viewController, Config config) {
-		view = new CityGMLImportView(viewController, config);
-		preferences = new CityGMLImportPreferences(config);
-	}
+	private CityGMLImportView view;
+	private CityGMLImportPreferences preferences;
 
 	@Override
 	public void initGuiExtension(ViewController viewController, Locale locale) {
+		Config config = ObjectRegistry.getInstance().getConfig();
+		view = new CityGMLImportView(viewController, config);
+		preferences = new CityGMLImportPreferences(config);
 		loadSettings();
 	}
 

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/preferences/PreferencesPlugin.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/preferences/PreferencesPlugin.java
@@ -29,6 +29,7 @@ package org.citydb.gui.operation.preferences;
 
 import org.citydb.config.Config;
 import org.citydb.core.plugin.internal.InternalPlugin;
+import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.gui.ImpExpGui;
 import org.citydb.gui.operation.preferences.preferences.GeneralPreferences;
 import org.citydb.gui.operation.preferences.view.PreferencesPanel;
@@ -42,16 +43,19 @@ import org.citydb.gui.plugin.view.ViewExtension;
 import java.util.Locale;
 
 public class PreferencesPlugin extends InternalPlugin implements ViewExtension, PreferencesExtension {
-	private final PreferencesView view;
-	private final GeneralPreferences preferences;
-	
-	public PreferencesPlugin(ImpExpGui mainView, Config config) {
-		view = new PreferencesView(mainView, config);
-		preferences = ((PreferencesPanel) view.getViewComponent()).getGeneralPreferences();
+	private final ImpExpGui mainView;
+	private PreferencesView view;
+	private GeneralPreferences preferences;
+
+	public PreferencesPlugin(ImpExpGui mainView) {
+		this.mainView = mainView;
 	}
 		
 	@Override
 	public void initGuiExtension(ViewController viewController, Locale locale) {
+		Config config = ObjectRegistry.getInstance().getConfig();
+		view = new PreferencesView(mainView, config);
+		preferences = ((PreferencesPanel) view.getViewComponent()).getGeneralPreferences();
 		loadSettings();
 	}
 

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/preferences/plugin/PluginsOverviewPlugin.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/preferences/plugin/PluginsOverviewPlugin.java
@@ -2,6 +2,7 @@ package org.citydb.gui.operation.preferences.plugin;
 
 import org.citydb.config.Config;
 import org.citydb.core.plugin.internal.InternalPlugin;
+import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.gui.plugin.preferences.Preferences;
 import org.citydb.gui.plugin.preferences.PreferencesExtension;
 import org.citydb.gui.plugin.view.ViewController;
@@ -9,15 +10,13 @@ import org.citydb.gui.plugin.view.ViewController;
 import java.util.Locale;
 
 public class PluginsOverviewPlugin extends InternalPlugin implements PreferencesExtension {
-    private final PluginsPreferences preferences;
+    private PluginsPreferences preferences;
     private volatile boolean isShuttingDown;
-
-    public PluginsOverviewPlugin(Config config) {
-        preferences = new PluginsPreferences(this, config);
-    }
 
     @Override
     public void initGuiExtension(ViewController viewController, Locale locale) {
+        Config config = ObjectRegistry.getInstance().getConfig();
+        preferences = new PluginsPreferences(this, config);
         loadSettings();
     }
 

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/visExporter/VisExportPlugin.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/visExporter/VisExportPlugin.java
@@ -29,6 +29,7 @@ package org.citydb.gui.operation.visExporter;
 
 import org.citydb.config.Config;
 import org.citydb.core.plugin.internal.InternalPlugin;
+import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.gui.operation.visExporter.preferences.VisExportPreferences;
 import org.citydb.gui.operation.visExporter.view.VisExportView;
 import org.citydb.gui.plugin.preferences.Preferences;
@@ -40,16 +41,14 @@ import org.citydb.gui.plugin.view.ViewExtension;
 import java.util.Locale;
 
 public class VisExportPlugin extends InternalPlugin implements ViewExtension, PreferencesExtension {
-	private final VisExportView view;
-	private final VisExportPreferences preferences;
-	
-	public VisExportPlugin(ViewController viewController, Config config) {
-		view = new VisExportView(viewController, config);
-		preferences = new VisExportPreferences(viewController, config);
-	}
+	private VisExportView view;
+	private VisExportPreferences preferences;
 
 	@Override
 	public void initGuiExtension(ViewController viewController, Locale locale) {
+		Config config = ObjectRegistry.getInstance().getConfig();
+		view = new VisExportView(viewController, config);
+		preferences = new VisExportPreferences(viewController, config);
 		loadSettings();
 	}
 


### PR DESCRIPTION
This PR fixes the initialization of GUI extensions. When using a `PreferencesExtension`,  the `getPreferences` method was invoked _before_ the `initGuiExtension` method. However, the `initGuiExtension` is meant as starting point for a GUI plugin and, thus, should be _invoked first_. The idea is, for example, that the preferences object to be returned by the `getPreferences` method can be created inside the `initGuiExtension` method.