### PR TITLE
Replace all IDs with UUIDs on export

### DIFF
--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/exporter/ExportCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/exporter/ExportCommand.java
@@ -63,6 +63,14 @@ public class ExportCommand extends CliCommand {
             description = "Output format to use for compressed exports: ${COMPLETION-CANDIDATES}.")
     private CompressedFormat compressedFormat;
 
+    @CommandLine.Option(names = "--replace-ids",
+            description = "Replace all object identifiers with UUIDs.")
+    private Boolean replaceIds;
+
+    @CommandLine.Option(names = "--id-prefix", paramLabel = "<prefix>", defaultValue = "ID_",
+            description = "Prefix to use when replacing object identifiers (default: ${DEFAULT-VALUE}).")
+    private String idPrefix;
+
     @CommandLine.Option(names = "--fail-fast", negatable = true,
             description = "Fail fast on errors (default: true).")
     private Boolean failFast;
@@ -123,6 +131,11 @@ public class ExportCommand extends CliCommand {
             exportConfig.getGeneralOptions().setCompressedOutputFormat(compressedFormat == CompressedFormat.cityjson ?
                     OutputFormat.CITYJSON :
                     OutputFormat.CITYGML);
+        }
+
+        if (replaceIds != null) {
+            exportConfig.getResourceId().setReplaceWithUUIDs(replaceIds);
+            exportConfig.getResourceId().setIdPrefix(idPrefix);
         }
 
         if (failFast != null) {

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/CityGMLExportPreferences.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/CityGMLExportPreferences.java
@@ -39,6 +39,7 @@ public class CityGMLExportPreferences extends DefaultPreferences {
 		super(new CityGMLExportEntry());
 		
 		rootEntry.addChildEntry(new DefaultPreferencesEntry(new GeneralPanel(config)));
+		rootEntry.addChildEntry(new DefaultPreferencesEntry(new ResourceIdPanel(config)));
 		rootEntry.addChildEntry(new DefaultPreferencesEntry(new TilingOptionsPanel(config)));
 		rootEntry.addChildEntry(new DefaultPreferencesEntry(new CityObjectGroupPanel(config)));
 		rootEntry.addChildEntry(new DefaultPreferencesEntry(new AppearancePanel(config)));

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/ResourceIdPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/ResourceIdPanel.java
@@ -1,0 +1,134 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2021
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.citydb.gui.operation.exporter.preferences;
+
+import org.citydb.config.Config;
+import org.citydb.config.i18n.Language;
+import org.citydb.config.project.exporter.ExportResourceId;
+import org.citydb.gui.components.TitledPanel;
+import org.citydb.gui.components.popup.PopupMenuDecorator;
+import org.citydb.gui.plugin.internal.InternalPreferencesComponent;
+import org.citydb.gui.util.GuiUtil;
+import org.citygml4j.util.gmlid.DefaultGMLIdManager;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Locale;
+
+public class ResourceIdPanel extends InternalPreferencesComponent {
+	private TitledPanel resourceIdPanel;
+	private JCheckBox replaceWithUUIDs;
+	private JLabel idPrefixLabel;
+	private JTextField idPrefix;
+
+	public ResourceIdPanel(Config config) {
+		super(config);
+		initGui();
+	}
+
+	@Override
+	public boolean isModified() {
+		ExportResourceId resourceId = config.getExportConfig().getResourceId();
+
+		if (replaceWithUUIDs.isSelected() != resourceId.isReplaceWithUUIDs()) return true;
+		if (!idPrefix.getText().equals(resourceId.getIdPrefix())) return true;
+
+		return false;
+	}
+
+	private void initGui() {
+		replaceWithUUIDs = new JCheckBox();
+		idPrefixLabel = new JLabel();
+		idPrefix = new JTextField();
+
+		PopupMenuDecorator.getInstance().decorate(idPrefix);
+		
+		setLayout(new GridBagLayout());
+		{
+			JPanel content = new JPanel();
+			content.setLayout(new GridBagLayout());
+			{
+				content.add(idPrefixLabel, GuiUtil.setConstraints(0, 0, 0, 0, GridBagConstraints.BOTH, 0, 0, 0, 5));
+				content.add(idPrefix, GuiUtil.setConstraints(1, 0, 1, 0, GridBagConstraints.BOTH, 0, 5, 0, 0));
+			}
+
+			resourceIdPanel = new TitledPanel().withToggleButton(replaceWithUUIDs).build(content);
+		}
+
+		add(resourceIdPanel, GuiUtil.setConstraints(0, 0, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
+
+		replaceWithUUIDs.addActionListener(e -> setEnabledPrefix());
+	}
+	
+	private void setEnabledPrefix() {
+		idPrefixLabel.setEnabled(replaceWithUUIDs.isSelected());
+		idPrefix.setEnabled(replaceWithUUIDs.isSelected());
+	}
+
+	@Override
+	public void switchLocale(Locale locale) {
+		resourceIdPanel.setTitle(Language.I18N.getString("pref.export.id.label.replace"));
+		idPrefixLabel.setText(Language.I18N.getString("pref.import.id.label.prefix"));
+	}
+
+	@Override
+	public void loadSettings() {
+		ExportResourceId resourceId = config.getExportConfig().getResourceId();
+
+		replaceWithUUIDs.setSelected(resourceId.isReplaceWithUUIDs());
+
+		if (resourceId.getIdPrefix() != null && resourceId.getIdPrefix().trim().length() != 0) {
+			idPrefix.setText(resourceId.getIdPrefix());
+		} else {
+			idPrefix.setText(DefaultGMLIdManager.getInstance().getDefaultPrefix());
+			resourceId.setIdPrefix(DefaultGMLIdManager.getInstance().getDefaultPrefix());
+		}
+		
+		setEnabledPrefix();
+	}
+
+	@Override
+	public void setSettings() {
+		ExportResourceId resourceId = config.getExportConfig().getResourceId();
+
+		resourceId.setReplaceWithUUIDs(replaceWithUUIDs.isSelected());
+
+		if (idPrefix.getText() != null && DefaultGMLIdManager.getInstance().isValidPrefix(idPrefix.getText())) {
+			resourceId.setIdPrefix(idPrefix.getText());
+		} else {
+			resourceId.setIdPrefix(DefaultGMLIdManager.getInstance().getDefaultPrefix());
+			idPrefix.setText(DefaultGMLIdManager.getInstance().getDefaultPrefix());
+		}
+	}
+	
+	@Override
+	public String getLocalizedTitle() {
+		return Language.I18N.getString("pref.tree.export.id");
+	}
+
+}

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/ResourceIdPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/ResourceIdPanel.java
@@ -93,7 +93,7 @@ public class ResourceIdPanel extends InternalPreferencesComponent {
 	@Override
 	public void switchLocale(Locale locale) {
 		resourceIdPanel.setTitle(Language.I18N.getString("pref.export.id.label.replace"));
-		idPrefixLabel.setText(Language.I18N.getString("pref.import.id.label.prefix"));
+		idPrefixLabel.setText(Language.I18N.getString("pref.export.id.label.prefix"));
 	}
 
 	@Override

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/ExportConfig.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/ExportConfig.java
@@ -43,6 +43,7 @@ import javax.xml.bind.annotation.XmlType;
         "simpleQuery",
         "path",
         "generalOptions",
+        "resourceId",
         "continuation",
         "cityObjectGroup",
         "appearances",
@@ -59,6 +60,7 @@ public class ExportConfig {
     private Path path;
     @XmlElement(name = "general")
     private GeneralOptions generalOptions;
+    private ExportResourceId resourceId;
     private Continuation continuation;
     private ExportCityObjectGroup cityObjectGroup;
     private ExportAppearance appearances;
@@ -72,6 +74,7 @@ public class ExportConfig {
         simpleQuery = new SimpleQuery();
         path = new Path();
         generalOptions = new GeneralOptions();
+        resourceId = new ExportResourceId();
         continuation = new Continuation();
         cityObjectGroup = new ExportCityObjectGroup();
         appearances = new ExportAppearance();
@@ -126,6 +129,16 @@ public class ExportConfig {
     public void setGeneralOptions(GeneralOptions generalOptions) {
         if (generalOptions != null) {
             this.generalOptions = generalOptions;
+        }
+    }
+
+    public ExportResourceId getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(ExportResourceId resourceId) {
+        if (resourceId != null) {
+            this.resourceId = resourceId;
         }
     }
 

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/ExportResourceId.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/ExportResourceId.java
@@ -1,0 +1,58 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2022
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.config.project.exporter;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlType(name = "ExportResourceIdType", propOrder = {
+        "replaceWithUUIDs",
+        "idPrefix"
+})
+public class ExportResourceId {
+    private boolean replaceWithUUIDs;
+    @XmlElement(defaultValue = "ID_")
+    private String idPrefix = "ID_";
+
+    public boolean isReplaceWithUUIDs() {
+        return replaceWithUUIDs;
+    }
+
+    public void setReplaceWithUUIDs(boolean replaceWithUUIDs) {
+        this.replaceWithUUIDs = replaceWithUUIDs;
+    }
+
+    public String getIdPrefix() {
+        return idPrefix;
+    }
+
+    public void setIdPrefix(String idPrefix) {
+        this.idPrefix = idPrefix;
+    }
+}

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -404,6 +404,7 @@ pref.tree.import.log=Import-Log
 pref.tree.import.xmlValidation=XML-Validierung
 pref.tree.import.resources=Ressourcen
 pref.tree.export.general=Allgemein
+pref.tree.export.id=Objekt-Identifier
 pref.tree.export.group=CityObjectGroup
 pref.tree.export.address=Adressen
 pref.tree.export.appearance=Appearance
@@ -528,6 +529,9 @@ pref.export.general.feature.all=Für alle Objekte
 pref.export.general.feature.none=Keine Bounding Box für Objekte exportieren
 pref.export.general.label.cityModel=Bounding Box für gesamten Datensatz berechnen und exportieren
 pref.export.general.label.useTileExtent=Kachelausdehnung bei gekacheltem Export verwenden
+
+pref.export.id.label.replace=Alle Identifier durch UUIDs ersetzen
+pref.import.id.label.prefix=Präfix
 
 pref.export.group.label.exportMember=Gruppenmitglieder nur als Referenzen exportieren
 pref.export.group.label.exportMember.description=<html>Filtereinstellungen werden <b>nicht</b> angewandt</html>

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -531,7 +531,7 @@ pref.export.general.label.cityModel=Bounding Box für gesamten Datensatz berechne
 pref.export.general.label.useTileExtent=Kachelausdehnung bei gekacheltem Export verwenden
 
 pref.export.id.label.replace=Alle Identifier durch UUIDs ersetzen
-pref.import.id.label.prefix=Präfix
+pref.export.id.label.prefix=Präfix
 
 pref.export.group.label.exportMember=Gruppenmitglieder nur als Referenzen exportieren
 pref.export.group.label.exportMember.description=<html>Filtereinstellungen werden <b>nicht</b> angewandt</html>

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -531,7 +531,7 @@ pref.export.general.label.cityModel=Calculate and export bounding box for entire
 pref.export.general.label.useTileExtent=Use tile extent when tiling is enabled
 
 pref.export.id.label.replace=Replace all identifiers by UUIDs
-pref.import.id.label.prefix=Prefix
+pref.export.id.label.prefix=Prefix
 
 pref.export.group.label.exportMember=Export group members as references only
 pref.export.group.label.exportMember.description=<html>Filter settings are <b>not</b> applied</html>

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -404,6 +404,7 @@ pref.tree.import.log=Import log
 pref.tree.import.xmlValidation=XML validation
 pref.tree.import.resources=Resources
 pref.tree.export.general=General
+pref.tree.export.id=Object identifier
 pref.tree.export.group=CityObjectGroup
 pref.tree.export.address=Address
 pref.tree.export.appearance=Appearance
@@ -528,6 +529,9 @@ pref.export.general.feature.all=For all objects
 pref.export.general.feature.none=Do not export object bounding boxes
 pref.export.general.label.cityModel=Calculate and export bounding box for entire dataset
 pref.export.general.label.useTileExtent=Use tile extent when tiling is enabled
+
+pref.export.id.label.replace=Replace all identifiers by UUIDs
+pref.import.id.label.prefix=Prefix
 
 pref.export.group.label.exportMember=Export group members as references only
 pref.export.group.label.exportMember.description=<html>Filter settings are <b>not</b> applied</html>

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/controller/Exporter.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/controller/Exporter.java
@@ -262,6 +262,11 @@ public class Exporter implements EventHandler {
             }
         }
 
+        // log replacement of object identifiers
+        if (config.getExportConfig().getResourceId().isReplaceWithUUIDs()) {
+            log.info("Replacing object identifiers with UUIDs.");
+        }
+
         // check whether database contains global appearances and set internal flag
         try {
             internalConfig.setExportGlobalAppearances(config.getExportConfig().getAppearances().isSetExportAppearance()

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/CityGMLExportManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/CityGMLExportManager.java
@@ -135,6 +135,7 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 	private LodGeometryChecker lodGeometryChecker;
 	private AppearanceRemover appearanceRemover;
 	private AffineTransformer affineTransformer;
+	private IdReplacer idReplacer;
 	private Document document;
 
 	public CityGMLExportManager(Connection connection,
@@ -178,6 +179,10 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 
 		if (config.getExportConfig().getAffineTransformation().isEnabled()) {
 			this.affineTransformer = affineTransformer;
+		}
+
+		if (config.getExportConfig().getResourceId().isReplaceWithUUIDs()) {
+			idReplacer = new IdReplacer().withPrefix(config.getExportConfig().getResourceId().getIdPrefix());
 		}
 
 		try {
@@ -230,6 +235,10 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 				// trigger export of textures if required
 				if (isLazyTextureExport() && config.getExportConfig().getAppearances().isSetExportAppearance())
 					getExporter(DBLocalAppearance.class).triggerLazyTextureExport(feature);
+
+				if (idReplacer != null) {
+					feature.accept(idReplacer);
+				}
 			}
 
 			return object;

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/CityGMLExportManager.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/CityGMLExportManager.java
@@ -236,6 +236,7 @@ public class CityGMLExportManager implements CityGMLExportHelper {
 				if (isLazyTextureExport() && config.getExportConfig().getAppearances().isSetExportAppearance())
 					getExporter(DBLocalAppearance.class).triggerLazyTextureExport(feature);
 
+				// replace object identifiers
 				if (idReplacer != null) {
 					feature.accept(idReplacer);
 				}

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/util/IdReplacer.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/util/IdReplacer.java
@@ -29,6 +29,7 @@
 package org.citydb.core.operation.exporter.util;
 
 import org.citydb.core.operation.exporter.CityGMLExportException;
+import org.citydb.core.util.CoreConstants;
 import org.citygml4j.model.citygml.appearance.*;
 import org.citygml4j.model.gml.base.AbstractGML;
 import org.citygml4j.model.gml.base.AssociationByRepOrRef;
@@ -64,6 +65,7 @@ public class IdReplacer extends GMLWalker {
     @Override
     public void visit(AbstractGML object) {
         if (object.isSetId()) {
+            object.setLocalProperty(CoreConstants.OBJECT_ORIGINAL_GMLID, object.getId());
             object.setId(replaceId(object.getId()));
         }
 

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/util/IdReplacer.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/util/IdReplacer.java
@@ -1,0 +1,168 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2022
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.core.operation.exporter.util;
+
+import org.citydb.core.operation.exporter.CityGMLExportException;
+import org.citygml4j.model.citygml.appearance.*;
+import org.citygml4j.model.gml.base.AbstractGML;
+import org.citygml4j.model.gml.base.AssociationByRepOrRef;
+import org.citygml4j.model.gml.feature.AbstractFeature;
+import org.citygml4j.model.gml.feature.FeatureProperty;
+import org.citygml4j.model.gml.geometry.AbstractGeometry;
+import org.citygml4j.model.gml.geometry.GeometryProperty;
+import org.citygml4j.util.gmlid.DefaultGMLIdManager;
+import org.citygml4j.util.walker.GMLWalker;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.UUID;
+
+public class IdReplacer extends GMLWalker {
+    private final MessageDigest md5;
+    private String prefix = DefaultGMLIdManager.getInstance().getDefaultPrefix();
+
+    public IdReplacer() throws CityGMLExportException {
+        try {
+            md5 = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new CityGMLExportException("Failed to create ID replacer.", e);
+        }
+    }
+
+    public IdReplacer withPrefix(String prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+
+    @Override
+    public void visit(AbstractGML object) {
+        if (object.isSetId()) {
+            object.setId(replaceId(object.getId()));
+        }
+
+        super.visit(object);
+    }
+
+    @Override
+    public <T extends AbstractFeature> void visit(FeatureProperty<T> property) {
+        process(property);
+        super.visit(property);
+    }
+
+    @Override
+    public <T extends AbstractGeometry> void visit(GeometryProperty<T> property) {
+        process(property);
+        super.visit(property);
+    }
+
+    @Override
+    public <T extends AbstractGML> void visit(AssociationByRepOrRef<T> property) {
+        process(property);
+        super.visit(property);
+    }
+
+    @Override
+    public void visit(ParameterizedTexture texture) {
+        if (texture.isSetTarget()) {
+            for (TextureAssociation association : texture.getTarget()) {
+                visit(association);
+            }
+        }
+
+        super.visit(texture);
+    }
+
+    @Override
+    public void visit(TexCoordList texCoordList) {
+        if (texCoordList.isSetTextureCoordinates()) {
+            for (TextureCoordinates coordinates : texCoordList.getTextureCoordinates()) {
+                if (coordinates.isSetRing()) {
+                    coordinates.setRing(process(coordinates.getRing()));
+                }
+            }
+        }
+
+        super.visit(texCoordList);
+    }
+
+    @Override
+    public void visit(GeoreferencedTexture texture) {
+        if (texture.isSetTarget()) {
+            process(texture.getTarget());
+        }
+
+        super.visit(texture);
+    }
+
+    @Override
+    public void visit(X3DMaterial material) {
+        if (material.isSetTarget()) {
+            process(material.getTarget());
+        }
+
+        super.visit(material);
+    }
+
+    private void visit(TextureAssociation association) {
+        process(association);
+        if (association.isSetUri()) {
+            association.setUri(process(association.getUri()));
+        }
+    }
+
+    private void process(AssociationByRepOrRef<? extends AbstractGML> property) {
+        if (property.isSetHref()) {
+            property.setHref(process(property.getHref()));
+        }
+    }
+
+    private void process(List<String> references) {
+        for (int i = 0; i < references.size(); i++) {
+            references.set(i, process(references.get(i)));
+        }
+    }
+
+    private String process(String reference) {
+        String prefix = "";
+        String id = reference;
+
+        int index = reference.lastIndexOf("#");
+        if (index != -1) {
+            prefix = reference.substring(0, index + 1);
+            id = reference.substring(index + 1);
+        }
+
+        return !id.isEmpty() ? prefix + replaceId(id) : reference;
+    }
+
+    private String replaceId(String id) {
+        return prefix + UUID.nameUUIDFromBytes(md5.digest(id.getBytes()));
+    }
+}


### PR DESCRIPTION
This PR adds an option to replace all identifiers of features and geometries with UUIDs when exporting to CityGML/CityJSON. A possible use case is when you want to share your data but at the same time hide your internal object IDs.

I added a new "Object identifier" entry to the export preferences. However, the settings could also be merged into "General" instead. I thought this way it's more consistent with the import preferences where we also have an "Object identifier" entry. Can be discussed.