### PR TITLE
Docker java update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='11.0.12-jdk-slim'
-ARG RUNTIME_IMAGE_TAG='11.0.12-jre-slim'
+ARG BUILDER_IMAGE_TAG='17-jdk-slim'
+ARG RUNTIME_IMAGE_TAG='17-slim'
 
 # Base image
 FROM openjdk:${BUILDER_IMAGE_TAG} AS builder

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -5,11 +5,11 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='17-jdk-slim'
-ARG RUNTIME_IMAGE_TAG='17-alpine'
+ARG BUILDER_IMAGE_TAG='17'
+ARG RUNTIME_IMAGE_TAG='17'
 
 # Base image
-FROM openjdk:${BUILDER_IMAGE_TAG} AS builder
+FROM bellsoft/liberica-openjdk-alpine:${BUILDER_IMAGE_TAG} AS builder
 
 # Copy source code
 WORKDIR /build
@@ -20,7 +20,7 @@ RUN chmod u+x ./gradlew && ./gradlew installDockerDist
 
 # Runtime stage ###############################################################
 # Base image
-FROM openjdk:${RUNTIME_IMAGE_TAG} AS runtime
+FROM bellsoft/liberica-openjdk-alpine:${RUNTIME_IMAGE_TAG} AS runtime
 
 # Version info
 ARG IMPEXP_VERSION

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -5,11 +5,11 @@
 
 # Fetch & build stage #########################################################
 # ARGS
-ARG BUILDER_IMAGE_TAG='jdk-11.0.11_9-alpine-slim'
-ARG RUNTIME_IMAGE_TAG='jre-11.0.11_9-alpine'
+ARG BUILDER_IMAGE_TAG='17-jdk-slim'
+ARG RUNTIME_IMAGE_TAG='17-alpine'
 
 # Base image
-FROM adoptopenjdk/openjdk11:${BUILDER_IMAGE_TAG} AS builder
+FROM openjdk:${BUILDER_IMAGE_TAG} AS builder
 
 # Copy source code
 WORKDIR /build
@@ -20,7 +20,7 @@ RUN chmod u+x ./gradlew && ./gradlew installDockerDist
 
 # Runtime stage ###############################################################
 # Base image
-FROM adoptopenjdk/openjdk11:${RUNTIME_IMAGE_TAG} AS runtime
+FROM openjdk:${RUNTIME_IMAGE_TAG} AS runtime
 
 # Version info
 ARG IMPEXP_VERSION

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
+# Copyright Â© 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
-#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
-#         * compound commands having a testable exit status, especially «case»;
-#         * various built-in commands including «command», «set», and «ulimit».
+#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
+#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
+#         * compound commands having a testable exit status, especially Â«caseÂ»;
+#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
 #
 #   Important for patching:
 #

--- a/properties.gradle
+++ b/properties.gradle
@@ -28,5 +28,5 @@ ext {
     appCliName = 'impexp'
 
     // documentation
-    docUrl = 'https://3dcitydb-docs.readthedocs.io/en/version-2022.1/'
+    docUrl = 'https://3dcitydb-docs.readthedocs.io/en/latest/'
 }

--- a/properties.gradle
+++ b/properties.gradle
@@ -28,5 +28,5 @@ ext {
     appCliName = 'impexp'
 
     // documentation
-    docUrl = 'https://3dcitydb-docs.readthedocs.io/en/latest/'
+    docUrl = 'https://3dcitydb-docs.readthedocs.io/en/version-2022.1/'
 }


### PR DESCRIPTION
* Updates the Docker images to Java 17
* Gradle wrapper was updated to 7.2 -> 7.4.2 for compatibility with Java 17, [see this](https://docs.gradle.org/current/userguide/compatibility.html).
* Switched to [`bellsoft/liberica-openjdk-alpine`](https://bell-sw.com/pages/downloads/) for Alpine images to avoid error during `vis-export` with several other Alpine JDK base images (openjdk, amazon correto, ...), see below:

   ```text
   [16:37:57 ERROR] Caused by: java.io.IOException: error=2, No such file or directory
   [16:37:57 ERROR] COLLADA2GLTF failed to convert '/data/temp/glTF/Tiles/0/0/209/GMLID_BUI180021_673_14143.dae'.
   [16:37:57 ERROR] Caused by: java.io.IOException: Cannot run program "/opt/impexp/contribs/collada2gltf/COLLADA2GLTF-v2.1.4-linux/COLLADA2GLTF-bin" (in directory "/data/temp/glTF/Tiles/0/0/209"): error=2, No such file or directory
   [16:37:57 ERROR] Caused by: java.io.IOException: error=2, No such file or directory
   [16:37:58 ERROR] COLLADA2GLTF failed to convert '/data/temp/glTF/Tiles/0/0/228/GMLID_21614432_375009_394.dae'.
   [16:37:58 ERROR] Caused by: java.io.IOException: Cannot run program "/opt/impexp/contribs/collada2gltf/COLLADA2GLT-v2.1.4-linux/COLLADA2GLTF-bin" (in directory "/data/temp/glTF/Tiles/0/0/228"): error=2, No such file or directory
   ```