### PR TITLE
Prevent XXE vulnerabilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 5.2.1 -tba
+
+#### Fixes
+*  Fixed XXE vulnerabilities when parsing XML files. [#258](https://github.com/3dcitydb/importer-exporter/pull/258)
+
 ### 5.2.0 - 2022-05-23
 
 ##### Additions

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 apply from: 'properties.gradle'
 
-version '5.2.0'
+version '5.2.1-SNAPSHOT'
 
 subprojects {
     apply plugin: 'java-library'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ subprojects {
         maven {
             url 'https://citydb.jfrog.io/artifactory/maven'
         }
+        maven {
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
         mavenCentral()
     }
 

--- a/impexp-client-cli/src/main/java/org/citydb/cli/ImpExpCli.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/ImpExpCli.java
@@ -38,7 +38,7 @@ import org.citydb.cli.option.StartupProgressListener;
 import org.citydb.cli.util.CliConstants;
 import org.citydb.cli.util.PidFile;
 import org.citydb.config.Config;
-import org.citydb.config.ConfigUtil;
+import org.citydb.util.config.ConfigUtil;
 import org.citydb.config.ProjectConfig;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.global.LanguageType;

--- a/impexp-client-cli/src/main/java/org/citydb/cli/option/XMLQueryOption.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/option/XMLQueryOption.java
@@ -28,9 +28,10 @@
 
 package org.citydb.cli.option;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.util.config.ConfigUtil;
 import org.citydb.config.project.query.QueryConfig;
-import org.citydb.config.util.QueryWrapper;
+import org.citydb.config.util.ConfigConstants;
+import org.citydb.config.project.query.QueryWrapper;
 import org.citygml4j.model.module.Module;
 import org.citygml4j.model.module.ModuleContext;
 import org.citygml4j.model.module.citygml.CityGMLVersion;
@@ -86,7 +87,7 @@ public class XMLQueryOption implements CliOption {
 
     private String wrapQuery(String query) {
         StringBuilder wrapper = new StringBuilder("<wrapper xmlns=\"")
-                .append(ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI)
+                .append(ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI)
                 .append("\" ");
 
         ModuleContext context = new ModuleContext(CityGMLVersion.v2_0_0);

--- a/impexp-client-gui/src/main/java/org/citydb/gui/GuiCommand.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/GuiCommand.java
@@ -35,7 +35,7 @@ import org.citydb.cli.ImpExpException;
 import org.citydb.cli.option.StartupProgressListener;
 import org.citydb.cli.util.CliConstants;
 import org.citydb.config.Config;
-import org.citydb.config.ConfigUtil;
+import org.citydb.util.config.ConfigUtil;
 import org.citydb.config.gui.GuiConfig;
 import org.citydb.config.gui.style.Theme;
 import org.citydb.core.database.DatabaseController;

--- a/impexp-client-gui/src/main/java/org/citydb/gui/ImpExpGui.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/ImpExpGui.java
@@ -33,7 +33,7 @@ import com.formdev.flatlaf.extras.components.FlatTabbedPane;
 import com.formdev.flatlaf.ui.FlatTabbedPaneUI;
 import org.citydb.cli.util.CliConstants;
 import org.citydb.config.Config;
-import org.citydb.config.ConfigUtil;
+import org.citydb.util.config.ConfigUtil;
 import org.citydb.config.gui.style.Theme;
 import org.citydb.config.gui.window.MainWindow;
 import org.citydb.config.gui.window.WindowSize;

--- a/impexp-client-gui/src/main/java/org/citydb/gui/map/geocoder/service/GoogleGeocoder.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/map/geocoder/service/GoogleGeocoder.java
@@ -32,12 +32,12 @@ import org.citydb.config.i18n.Language;
 import org.citydb.gui.map.geocoder.GeocoderResult;
 import org.citydb.gui.map.geocoder.Location;
 import org.citydb.gui.map.geocoder.LocationType;
+import org.citydb.util.xml.SecureXMLProcessors;
 import org.jdesktop.swingx.mapviewer.GeoPosition;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
@@ -84,9 +84,11 @@ public class GoogleGeocoder implements GeocodingService {
         }
 
         try (InputStream stream = new URL(serviceCall).openStream()) {
-            Document response = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stream);
-            XPath xpath = XPathFactory.newInstance().newXPath();
+            Document response = SecureXMLProcessors.newDocumentBuilderFactory()
+                    .newDocumentBuilder()
+                    .parse(stream);
 
+            XPath xpath = XPathFactory.newInstance().newXPath();
             GeocoderResult geocodingResult = new GeocoderResult();
 
             // check the response status

--- a/impexp-client-gui/src/main/java/org/citydb/gui/menu/MenuFile.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/menu/MenuFile.java
@@ -29,7 +29,7 @@ package org.citydb.gui.menu;
 
 import com.formdev.flatlaf.extras.FlatSVGIcon;
 import org.citydb.config.Config;
-import org.citydb.config.ConfigUtil;
+import org.citydb.util.config.ConfigUtil;
 import org.citydb.config.ProjectConfig;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.global.Logging;

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/common/filter/XMLQueryView.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/common/filter/XMLQueryView.java
@@ -31,7 +31,7 @@ package org.citydb.gui.operation.common.filter;
 import com.formdev.flatlaf.extras.FlatSVGIcon;
 import com.github.vertical_blank.sqlformatter.SqlFormatter;
 import com.sun.xml.bind.marshaller.NamespacePrefixMapper;
-import org.citydb.config.ConfigUtil;
+import org.citydb.util.config.ConfigUtil;
 import org.citydb.config.geometry.BoundingBox;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.database.DatabaseSrs;
@@ -54,7 +54,8 @@ import org.citydb.config.project.query.filter.tiling.Tiling;
 import org.citydb.config.project.query.filter.type.FeatureTypeFilter;
 import org.citydb.config.project.query.simple.SimpleAttributeFilter;
 import org.citydb.config.project.query.simple.SimpleFeatureVersionFilter;
-import org.citydb.config.util.QueryWrapper;
+import org.citydb.config.util.ConfigConstants;
+import org.citydb.config.project.query.QueryWrapper;
 import org.citydb.core.database.DatabaseController;
 import org.citydb.core.database.adapter.AbstractSQLAdapter;
 import org.citydb.core.database.schema.mapping.FeatureType;
@@ -197,7 +198,7 @@ public class XMLQueryView extends FilterView<QueryConfig> {
 
         CityGMLNamespaceContext namespaceContext = new CityGMLNamespaceContext();
         namespaceContext.setPrefixes(new ModuleContext(CityGMLVersion.v2_0_0));
-        namespaceContext.setDefaultNamespace(ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI);
+        namespaceContext.setDefaultNamespace(ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI);
 
         xmlText.setText(marshalQuery(query, namespaceContext));
     }
@@ -324,7 +325,7 @@ public class XMLQueryView extends FilterView<QueryConfig> {
 
         CityGMLNamespaceContext namespaceContext = new CityGMLNamespaceContext();
         namespaceContext.setPrefixes(new ModuleContext(version));
-        namespaceContext.setDefaultNamespace(ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI);
+        namespaceContext.setDefaultNamespace(ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI);
 
         xmlText.setText(marshalQuery(query, namespaceContext));
     }
@@ -437,7 +438,7 @@ public class XMLQueryView extends FilterView<QueryConfig> {
 
     private String wrapQuery(String query) {
         StringBuilder wrapper = new StringBuilder("<wrapper xmlns=\"")
-                .append(ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI).append("\" ");
+                .append(ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI).append("\" ");
 
         ModuleContext context = new ModuleContext(CityGMLVersion.v2_0_0);
         for (Module module : context.getModules()) {

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/database/preferences/SrsPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/database/preferences/SrsPanel.java
@@ -29,7 +29,7 @@ package org.citydb.gui.operation.database.preferences;
 
 import org.citydb.cli.util.CliConstants;
 import org.citydb.config.Config;
-import org.citydb.config.ConfigUtil;
+import org.citydb.util.config.ConfigUtil;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.database.DatabaseSrs;
 import org.citydb.config.project.database.DatabaseSrsList;

--- a/impexp-config/build.gradle
+++ b/impexp-config/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    api 'org.citygml4j:citygml4j:2.12.1-SNAPSHOT'
+    api 'org.citygml4j:citygml4j:2.12.1'
 }

--- a/impexp-config/build.gradle
+++ b/impexp-config/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    api 'org.citygml4j:citygml4j:2.12.0'
+    api 'org.citygml4j:citygml4j:2.12.1-SNAPSHOT'
 }

--- a/impexp-config/src/main/java/org/citydb/config/ProjectConfig.java
+++ b/impexp-config/src/main/java/org/citydb/config/ProjectConfig.java
@@ -186,7 +186,7 @@ public class ProjectConfig {
         return namespaceFilter;
     }
 
-    void setNamespaceFilter(ConfigNamespaceFilter namespaceFilter) {
+    public void setNamespaceFilter(ConfigNamespaceFilter namespaceFilter) {
         this.namespaceFilter = namespaceFilter;
     }
 }

--- a/impexp-config/src/main/java/org/citydb/config/geometry/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/geometry/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.geometry;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/components/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/components/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui.components;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/database/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/database/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui.database;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/exporter/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/exporter/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui.exporter;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/importer/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/importer/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui.importer;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/preferences/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/preferences/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui.preferences;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/style/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/style/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui.style;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/visExporter/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/visExporter/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui.visExporter;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/gui/window/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/gui/window/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.gui.window;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/package-info.java
@@ -27,8 +27,9 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
-		xmlns = {@javax.xml.bind.annotation.XmlNs(prefix = "", namespaceURI = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI)},
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
+		xmlns = {@javax.xml.bind.annotation.XmlNs(prefix = "", namespaceURI = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI)},
 		elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config;
 
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/common/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/common/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.common;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/database/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/database/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.database;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/deleter/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/deleter/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.deleter;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.exporter;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/global/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/global/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.global;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/importer/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/importer/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.importer;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/plugin/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/plugin/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.plugin;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/QueryWrapper.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/QueryWrapper.java
@@ -2,7 +2,7 @@
  * 3D City Database - The Open Source CityGML Database
  * https://www.3dcitydb.org/
  *
- * Copyright 2013 - 2021
+ * Copyright 2013 - 2022
  * Chair of Geoinformatics
  * Technical University of Munich, Germany
  * https://www.lrg.tum.de/gis/
@@ -26,9 +26,25 @@
  * limitations under the License.
  */
 
-@javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
-		elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
-package org.citydb.config.util;
+package org.citydb.config.project.query;
 
-import org.citydb.config.ConfigUtil;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlRootElement(name = "wrapper")
+@XmlType(name = "QueryWrapperType", propOrder = {
+        "queryConfig"
+})
+public class QueryWrapper {
+    @XmlElement(name = "query")
+    private QueryConfig queryConfig;
+
+    public QueryConfig getQueryConfig() {
+        return queryConfig;
+    }
+
+    public void setQueryConfig(QueryConfig queryConfig) {
+        this.queryConfig = queryConfig;
+    }
+}

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/appearance/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/appearance/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.appearance;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/counter/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/counter/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.counter;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/lod/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/lod/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.lod;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/projection/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/projection/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.projection;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/comparison/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/comparison/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.selection.comparison;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/id/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/id/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.selection.id;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/logical/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/logical/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.selection.logical;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.selection;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/spatial/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/spatial/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.selection.spatial;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/sql/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/selection/sql/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.selection.sql;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/sorting/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/sorting/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.sorting;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/tiling/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/tiling/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.tiling;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/type/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/type/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.type;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/filter/version/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/filter/version/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.filter.version;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
 		elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/query/simple/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/query/simple/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.query.simple;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/resources/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/resources/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.resources;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/project/visExporter/package-info.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/visExporter/package-info.java
@@ -27,8 +27,8 @@
  */
 
 @javax.xml.bind.annotation.XmlAccessorType(javax.xml.bind.annotation.XmlAccessType.FIELD)
-@javax.xml.bind.annotation.XmlSchema(namespace = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI,
+@javax.xml.bind.annotation.XmlSchema(namespace = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI,
         elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package org.citydb.config.project.visExporter;
 
-import org.citydb.config.ConfigUtil;
+import org.citydb.config.util.ConfigConstants;

--- a/impexp-config/src/main/java/org/citydb/config/util/ConfigConstants.java
+++ b/impexp-config/src/main/java/org/citydb/config/util/ConfigConstants.java
@@ -2,7 +2,7 @@
  * 3D City Database - The Open Source CityGML Database
  * https://www.3dcitydb.org/
  *
- * Copyright 2013 - 2021
+ * Copyright 2013 - 2022
  * Chair of Geoinformatics
  * Technical University of Munich, Germany
  * https://www.lrg.tum.de/gis/
@@ -28,25 +28,6 @@
 
 package org.citydb.config.util;
 
-import org.citydb.config.project.query.QueryConfig;
-
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-
-@XmlRootElement(name = "wrapper")
-@XmlType(name = "QueryWrapperType", propOrder = {
-        "queryConfig"
-})
-public class QueryWrapper {
-    @XmlElement(name = "query")
-    private QueryConfig queryConfig;
-
-    public QueryConfig getQueryConfig() {
-        return queryConfig;
-    }
-
-    public void setQueryConfig(QueryConfig queryConfig) {
-        this.queryConfig = queryConfig;
-    }
+public class ConfigConstants {
+    public static final String CITYDB_CONFIG_NAMESPACE_URI = "http://www.3dcitydb.org/importer-exporter/config";
 }

--- a/impexp-config/src/main/java/org/citydb/config/util/ConfigNamespaceFilter.java
+++ b/impexp-config/src/main/java/org/citydb/config/util/ConfigNamespaceFilter.java
@@ -27,7 +27,6 @@
  */
 package org.citydb.config.util;
 
-import org.citydb.config.ConfigUtil;
 import org.citygml4j.model.module.Module;
 import org.citygml4j.model.module.ModuleContext;
 import org.citygml4j.model.module.citygml.CityGMLVersion;
@@ -112,11 +111,11 @@ public class ConfigNamespaceFilter extends XMLFilterImpl implements NamespaceCon
 	@Override
 	public void startPrefixMapping(String prefix, String uri) throws SAXException {
 		if (uri == null || uri.isEmpty())
-			uri = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI;
+			uri = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI;
 
 		// support config files from previous releases 
 		else if (uri.startsWith(OLD_CITYDB_CONFIG_NAMESPACE_URI))
-			uri = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI;
+			uri = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI;
 
 		super.startPrefixMapping(prefix, uri);
 		bindNamespace(prefix, uri);
@@ -125,11 +124,11 @@ public class ConfigNamespaceFilter extends XMLFilterImpl implements NamespaceCon
 	@Override
 	public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
 		if (uri == null || uri.isEmpty())
-			uri = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI;
+			uri = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI;
 
 		// support config files from previous releases 
 		else if (uri.startsWith(OLD_CITYDB_CONFIG_NAMESPACE_URI))
-			uri = ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI;
+			uri = ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI;
 
 		super.startElement(uri, localName, qName, atts);
 	}

--- a/impexp-config/src/main/java/org/citydb/config/util/QuerySchemaWriter.java
+++ b/impexp-config/src/main/java/org/citydb/config/util/QuerySchemaWriter.java
@@ -26,10 +26,9 @@
  * limitations under the License.
  */
 
-package org.citydb.util.config;
+package org.citydb.config.util;
 
 import org.citydb.config.project.query.QueryWrapper;
-import org.citydb.config.util.ConfigConstants;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.SchemaOutputResolver;
@@ -43,9 +42,9 @@ import java.nio.file.Paths;
 public class QuerySchemaWriter {
 
 	public static void main(String[] args) throws Exception {
-		Path configFile = Paths.get("impexp-config/src/main/resources/org/citydb/config/schema/query.xsd");
-		System.out.print("Generting XML schema in " + configFile.toAbsolutePath() + "... ");
-		
+		Path configFile = Paths.get("src/main/resources/org/citydb/config/schema/query.xsd");
+		System.out.print("Generating XML schema in " + configFile.toAbsolutePath() + "... ");
+
 		JAXBContext context = JAXBContext.newInstance(QueryWrapper.class);
 		context.generateSchema(new SchemaOutputResolver() {
 			@Override
@@ -59,9 +58,8 @@ public class QuerySchemaWriter {
 				} else
 					return null;
 			}
-			
 		});
-		
+
 		System.out.println("finished.");
 	}
 

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/writer/citygml/CityGMLWriterFactory.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/writer/citygml/CityGMLWriterFactory.java
@@ -41,6 +41,7 @@ import org.citydb.core.operation.exporter.writer.FeatureWriterFactory;
 import org.citydb.core.query.Query;
 import org.citydb.core.query.filter.type.FeatureTypeFilter;
 import org.citydb.util.log.Logger;
+import org.citydb.util.xml.SecureXMLProcessors;
 import org.citygml4j.model.module.Module;
 import org.citygml4j.model.module.ModuleContext;
 import org.citygml4j.model.module.Modules;
@@ -55,7 +56,6 @@ import org.citygml4j.util.xml.SAXWriter;
 import javax.xml.XMLConstants;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.stream.StreamSource;
 import java.io.File;
@@ -94,7 +94,7 @@ public class CityGMLWriterFactory implements FeatureWriterFactory {
 				log.info("Applying XSL transformations on export data.");
 
 				List<String> stylesheets = cityGMLOptions.getXSLTransformation().getStylesheets();
-				SAXTransformerFactory factory = (SAXTransformerFactory) TransformerFactory.newInstance();
+				SAXTransformerFactory factory = (SAXTransformerFactory) SecureXMLProcessors.newTransformerFactory();
 				Templates[] templates = new Templates[stylesheets.size()];
 
 				for (int i = 0; i < stylesheets.size(); i++) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/reader/citygml/CityGMLReaderFactory.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/reader/citygml/CityGMLReaderFactory.java
@@ -37,6 +37,7 @@ import org.citydb.core.operation.importer.reader.FeatureReader;
 import org.citydb.core.operation.importer.reader.FeatureReaderFactory;
 import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.util.log.Logger;
+import org.citydb.util.xml.SecureXMLProcessors;
 import org.citygml4j.builder.jaxb.CityGMLBuilderException;
 import org.citygml4j.model.module.Module;
 import org.citygml4j.model.module.Modules;
@@ -49,7 +50,6 @@ import org.citygml4j.xml.io.writer.CityGMLWriteException;
 import javax.xml.namespace.QName;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.stream.StreamSource;
 import java.io.File;
@@ -101,7 +101,7 @@ public class CityGMLReaderFactory implements FeatureReaderFactory {
                 log.info("Applying XSL transformations to CityGML input features.");
 
                 List<String> stylesheets = cityGMLOptions.getXSLTransformation().getStylesheets();
-                SAXTransformerFactory factory = (SAXTransformerFactory) TransformerFactory.newInstance();
+                SAXTransformerFactory factory = (SAXTransformerFactory) SecureXMLProcessors.newTransformerFactory();
                 Templates[] templates = new Templates[stylesheets.size()];
 
                 for (int i = 0; i < stylesheets.size(); i++) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/validator/reader/citygml/CityGMLValidatorFactory.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/validator/reader/citygml/CityGMLValidatorFactory.java
@@ -48,6 +48,7 @@ public class CityGMLValidatorFactory implements ValidatorFactory {
         try {
             SchemaHandler schemaHandler = SchemaHandler.newInstance();
             SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             Schema schema = schemaFactory.newSchema(schemaHandler.getSchemaSources());
             validator = schema.newValidator();
         } catch (SAXException e) {

--- a/impexp-util/src/main/java/org/citydb/util/config/ConfigUtil.java
+++ b/impexp-util/src/main/java/org/citydb/util/config/ConfigUtil.java
@@ -29,8 +29,9 @@ package org.citydb.util.config;
 
 import org.citydb.config.ProjectConfig;
 import org.citydb.config.gui.GuiConfig;
-import org.citydb.config.util.ConfigNamespaceFilter;
 import org.citydb.config.project.query.QueryWrapper;
+import org.citydb.config.util.ConfigNamespaceFilter;
+import org.citydb.util.xml.SecureXMLProcessors;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -95,11 +96,11 @@ public class ConfigUtil {
 	public Object unmarshal(InputStream inputStream) throws JAXBException, IOException {
 		Unmarshaller unmarshaller = createJAXBContext().context.createUnmarshaller();
 		UnmarshallerHandler handler = unmarshaller.getUnmarshallerHandler();
-		SAXParserFactory factory = SAXParserFactory.newInstance();
-		factory.setNamespaceAware(true);
 
 		ConfigNamespaceFilter namespaceFilter;
 		try {
+			SAXParserFactory factory = SecureXMLProcessors.newSAXParserFactory();
+			factory.setNamespaceAware(true);
 			XMLReader reader = factory.newSAXParser().getXMLReader();
 			namespaceFilter = new ConfigNamespaceFilter(reader);	
 			namespaceFilter.setContentHandler(handler);
@@ -107,7 +108,7 @@ public class ConfigUtil {
 		} catch (SAXException e) {
 			throw new JAXBException(e.getMessage());
 		} catch (ParserConfigurationException e) {
-			throw new IOException(e.getMessage());
+			throw new IOException("Failed to create secure XML reader.", e);
 		}
 
 		Object result = handler.getResult();

--- a/impexp-util/src/main/java/org/citydb/util/config/ConfigUtil.java
+++ b/impexp-util/src/main/java/org/citydb/util/config/ConfigUtil.java
@@ -2,7 +2,7 @@
  * 3D City Database - The Open Source CityGML Database
  * https://www.3dcitydb.org/
  *
- * Copyright 2013 - 2021
+ * Copyright 2013 - 2022
  * Chair of Geoinformatics
  * Technical University of Munich, Germany
  * https://www.lrg.tum.de/gis/
@@ -25,12 +25,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.citydb.config;
+package org.citydb.util.config;
 
+import org.citydb.config.ProjectConfig;
 import org.citydb.config.gui.GuiConfig;
 import org.citydb.config.util.ConfigNamespaceFilter;
-import org.citydb.config.util.ProjectSchemaWriter;
-import org.citydb.config.util.QueryWrapper;
+import org.citydb.config.project.query.QueryWrapper;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -47,7 +47,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class ConfigUtil {
-	public static final String CITYDB_CONFIG_NAMESPACE_URI = "http://www.3dcitydb.org/importer-exporter/config";
 	private static ConfigUtil instance;
 
 	private final Set<Class<?>> configClasses = new HashSet<>();

--- a/impexp-util/src/main/java/org/citydb/util/config/ProjectSchemaWriter.java
+++ b/impexp-util/src/main/java/org/citydb/util/config/ProjectSchemaWriter.java
@@ -2,7 +2,7 @@
  * 3D City Database - The Open Source CityGML Database
  * https://www.3dcitydb.org/
  *
- * Copyright 2013 - 2021
+ * Copyright 2013 - 2022
  * Chair of Geoinformatics
  * Technical University of Munich, Germany
  * https://www.lrg.tum.de/gis/
@@ -25,43 +25,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.citydb.util.config;
 
-package org.citydb.config.util;
-
-import org.citydb.config.ConfigUtil;
-
-import javax.xml.bind.JAXBContext;
 import javax.xml.bind.SchemaOutputResolver;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
-public class QuerySchemaWriter {
+public class ProjectSchemaWriter extends SchemaOutputResolver {
+	private final Path targetDir;
 
-	public static void main(String[] args) throws Exception {
-		Path configFile = Paths.get("src/main/resources/org/citydb/config/schema/query.xsd");
-		System.out.print("Generting XML schema in " + configFile.toAbsolutePath() + "... ");
-		
-		JAXBContext context = JAXBContext.newInstance(QueryWrapper.class);
-		context.generateSchema(new SchemaOutputResolver() {
-			@Override
-			public Result createOutput(String namespaceUri, String suggestedFileName) throws IOException {
-				if (ConfigUtil.CITYDB_CONFIG_NAMESPACE_URI.equals(namespaceUri)) {
-					Files.createDirectories(configFile.getParent());
-					StreamResult res = new StreamResult();
-					res.setSystemId(configFile.toUri().toString());
+	public ProjectSchemaWriter(File path) {
+		this.targetDir = path.toPath();
+	}
 
-					return res;
-				} else
-					return null;
-			}
-			
-		});
-		
-		System.out.println("finished.");
+	@Override
+	public Result createOutput(String namespaceUri, String suggestedFileName) throws IOException {
+		Path file = namespaceUri.equals("http://www.3dcitydb.org/importer-exporter/config") ?
+				targetDir.resolve("config.xsd") :
+				targetDir.resolve("plugin_" + suggestedFileName);
+
+		StreamResult res = new StreamResult(file.toFile());
+		res.setSystemId(URLDecoder.decode(file.toUri().toURL().toString(), StandardCharsets.UTF_8.name()));
+
+		return res;
 	}
 
 }

--- a/impexp-util/src/main/java/org/citydb/util/config/QuerySchemaWriter.java
+++ b/impexp-util/src/main/java/org/citydb/util/config/QuerySchemaWriter.java
@@ -2,7 +2,7 @@
  * 3D City Database - The Open Source CityGML Database
  * https://www.3dcitydb.org/
  *
- * Copyright 2013 - 2021
+ * Copyright 2013 - 2022
  * Chair of Geoinformatics
  * Technical University of Munich, Germany
  * https://www.lrg.tum.de/gis/
@@ -25,34 +25,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.citydb.config.util;
 
+package org.citydb.util.config;
+
+import org.citydb.config.project.query.QueryWrapper;
+import org.citydb.config.util.ConfigConstants;
+
+import javax.xml.bind.JAXBContext;
 import javax.xml.bind.SchemaOutputResolver;
 import javax.xml.transform.Result;
 import javax.xml.transform.stream.StreamResult;
-import java.io.File;
 import java.io.IOException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
-public class ProjectSchemaWriter extends SchemaOutputResolver {
-	private final Path targetDir;
+public class QuerySchemaWriter {
 
-	public ProjectSchemaWriter(File path) {
-		this.targetDir = path.toPath();
-	}
+	public static void main(String[] args) throws Exception {
+		Path configFile = Paths.get("impexp-config/src/main/resources/org/citydb/config/schema/query.xsd");
+		System.out.print("Generting XML schema in " + configFile.toAbsolutePath() + "... ");
+		
+		JAXBContext context = JAXBContext.newInstance(QueryWrapper.class);
+		context.generateSchema(new SchemaOutputResolver() {
+			@Override
+			public Result createOutput(String namespaceUri, String suggestedFileName) throws IOException {
+				if (ConfigConstants.CITYDB_CONFIG_NAMESPACE_URI.equals(namespaceUri)) {
+					Files.createDirectories(configFile.getParent());
+					StreamResult res = new StreamResult();
+					res.setSystemId(configFile.toUri().toString());
 
-	@Override
-	public Result createOutput(String namespaceUri, String suggestedFileName) throws IOException {
-		Path file = namespaceUri.equals("http://www.3dcitydb.org/importer-exporter/config") ?
-				targetDir.resolve("config.xsd") :
-				targetDir.resolve("plugin_" + suggestedFileName);
-
-		StreamResult res = new StreamResult(file.toFile());
-		res.setSystemId(URLDecoder.decode(file.toUri().toURL().toString(), StandardCharsets.UTF_8.name()));
-
-		return res;
+					return res;
+				} else
+					return null;
+			}
+			
+		});
+		
+		System.out.println("finished.");
 	}
 
 }

--- a/impexp-util/src/main/java/org/citydb/util/xml/SecureXMLProcessors.java
+++ b/impexp-util/src/main/java/org/citydb/util/xml/SecureXMLProcessors.java
@@ -50,6 +50,8 @@ public class SecureXMLProcessors {
         factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
         return factory;
     }
 

--- a/impexp-util/src/main/java/org/citydb/util/xml/SecureXMLProcessors.java
+++ b/impexp-util/src/main/java/org/citydb/util/xml/SecureXMLProcessors.java
@@ -1,0 +1,75 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2022
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.util.xml;
+
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerFactory;
+
+public class SecureXMLProcessors {
+
+    private SecureXMLProcessors() {
+    }
+
+    public static SAXParserFactory newSAXParserFactory() throws SAXNotSupportedException, SAXNotRecognizedException, ParserConfigurationException {
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setXIncludeAware(false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        return factory;
+    }
+
+    public static DocumentBuilderFactory newDocumentBuilderFactory() throws ParserConfigurationException {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        return factory;
+    }
+
+    public static TransformerFactory newTransformerFactory() throws TransformerConfigurationException {
+        TransformerFactory factory = TransformerFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+        return factory;
+    }
+}

--- a/impexp-vis-plugin/src/main/java/org/citydb/vis/util/ElevationServiceHandler.java
+++ b/impexp-vis-plugin/src/main/java/org/citydb/vis/util/ElevationServiceHandler.java
@@ -29,6 +29,7 @@ package org.citydb.vis.util;
 
 import org.citydb.config.Config;
 import org.citydb.util.log.Logger;
+import org.citydb.util.xml.SecureXMLProcessors;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -84,11 +85,10 @@ public class ElevationServiceHandler {
 
 		if (saxParser == null) {
 			// Use the default (non-validating) parser
-			SAXParserFactory factory = SAXParserFactory.newInstance();
+			SAXParserFactory factory = SecureXMLProcessors.newSAXParserFactory();
 			try {
 				saxParser = factory.newSAXParser();
-			}
-			catch (Throwable t) {
+			} catch (Throwable t) {
 				log.logStackTrace(t);
 			}
 		}


### PR DESCRIPTION
This PR adds necessary code to prevent [XXE vulnerabilities](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html) when parsing XML files.

XML files are not just CityGML input files. But also the config file of the Importer/Exporter, XML query expressions, XSD schema files, and XSLT stylesheets are XML-based. So, various classes are affected by this PR.

- Note 1: The `ConfigUtil` had to be moved from impexp-config to impexp-util to be able to use the new `SecureXMLProcessors` class.
- Note 2: This PR uses the 2.12.1-SNAPSHOT version of citygml4j, which also contains XXE fixes (see [here](https://github.com/citygml4j/citygml4j/commit/246e34a372ed4a8c4082de7170153b3014d55961)).