### PR TITLE
Alternative hotfix export timeout issue

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/database/connection/DatabaseConnectionPool.java
+++ b/impexp-core/src/main/java/org/citydb/core/database/connection/DatabaseConnectionPool.java
@@ -29,6 +29,7 @@ package org.citydb.core.database.connection;
 
 import org.apache.tomcat.jdbc.pool.DataSource;
 import org.apache.tomcat.jdbc.pool.PoolProperties;
+import org.apache.tomcat.jdbc.pool.PooledConnection;
 import org.citydb.config.Config;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.database.*;
@@ -251,6 +252,14 @@ public class DatabaseConnectionPool implements ConnectionManager {
 	public synchronized void purgeOnReturn() {
 		if (isConnected()) {
 			dataSource.purgeOnReturn();
+		}
+	}
+
+	public void closeAndRemoveConnection(Connection connection) throws SQLException {
+		try {
+			connection.unwrap(PooledConnection.class).setDiscarded(true);
+		} finally {
+			connection.close();
 		}
 	}
 

--- a/impexp-core/src/main/java/org/citydb/core/database/connection/DatabaseConnectionPool.java
+++ b/impexp-core/src/main/java/org/citydb/core/database/connection/DatabaseConnectionPool.java
@@ -248,6 +248,12 @@ public class DatabaseConnectionPool implements ConnectionManager {
 		}
 	}
 
+	public synchronized void purgeOnReturn() {
+		if (isConnected()) {
+			dataSource.purgeOnReturn();
+		}
+	}
+
 	public synchronized void disconnect() {
 		boolean wasConnected = isConnected();
 

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/controller/Exporter.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/controller/Exporter.java
@@ -104,7 +104,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class Exporter implements EventHandler {
     private final Logger log = Logger.getInstance();
     private final CityGMLBuilder cityGMLBuilder;
-    private final DatabaseConnectionPool connectionPool;
+    private final AbstractDatabaseAdapter databaseAdapter;
     private final SchemaMapping schemaMapping;
     private final PluginManager pluginManager;
     private final Config config;
@@ -127,11 +127,11 @@ public class Exporter implements EventHandler {
 
 	public Exporter() {
         cityGMLBuilder = ObjectRegistry.getInstance().getCityGMLBuilder();
-        connectionPool = DatabaseConnectionPool.getInstance();
         schemaMapping = ObjectRegistry.getInstance().getSchemaMapping();
         pluginManager = PluginManager.getInstance();
         config = ObjectRegistry.getInstance().getConfig();
         eventDispatcher = ObjectRegistry.getInstance().getEventDispatcher();
+        databaseAdapter = DatabaseConnectionPool.getInstance().getActiveDatabaseAdapter();
 
         objectCounter = new HashMap<>();
         geometryCounter = new EnumMap<>(GMLClass.class);
@@ -179,7 +179,6 @@ public class Exporter implements EventHandler {
     }
 
     private boolean process(Path outputFile) throws CityGMLExportException {
-        AbstractDatabaseAdapter databaseAdapter = connectionPool.getActiveDatabaseAdapter();
         InternalConfig internalConfig = new InternalConfig();
 
         // set output format and format-specific options
@@ -588,9 +587,6 @@ public class Exporter implements EventHandler {
                             shouldRun = false;
                         }
                     }
-
-                    // remove used connections from pool
-                    connectionPool.purgeOnReturn();
                 }
 
                 // show exported features

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBSplitter.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBSplitter.java
@@ -103,6 +103,7 @@ public class DBSplitter {
 	private final Config config;
 	private final EventDispatcher eventDispatcher;
 
+	private final DatabaseConnectionPool connectionPool;
 	private final AbstractDatabaseAdapter databaseAdapter;
 	private final Connection connection;
 	private final String schema;
@@ -134,8 +135,9 @@ public class DBSplitter {
 		this.internalConfig = internalConfig;
 		this.config = config;
 
-		databaseAdapter = DatabaseConnectionPool.getInstance().getActiveDatabaseAdapter();
-		connection = DatabaseConnectionPool.getInstance().getConnection();
+		connectionPool = DatabaseConnectionPool.getInstance();
+		databaseAdapter = connectionPool.getActiveDatabaseAdapter();
+		connection = connectionPool.getConnection();
 		connection.setAutoCommit(false);
 		schema = databaseAdapter.getConnectionDetails().getSchema();
 
@@ -216,8 +218,9 @@ public class DBSplitter {
 				queryGlobalAppearance();
 
 		} finally {
-			if (connection != null)
-				connection.close();
+			if (connection != null) {
+				connectionPool.closeAndRemoveConnection(connection);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR proposes an alterantive to #261 for fixing #257.

This hotfix purges the connection pool after every CityGML export. This prevents issues due to defect connections as the one reported in #257. A drawback of this approach is that the number of physical connections created by the pool increases especially when exporting in tiles, which undermines the idea of using a pool.

As identified by @yaozhihang in #261, it seems that the reason for #257 is the long `where` clause of the SQL query due to a polygon with a huge number of vertices encoded as WKT. Somehow a connection cannot be reused after sending this query to the database. I couldn't figure out how to identify such a defect connection and only remove it from the pool. This would be a better solution.