### PR TITLE
Add support for converting global appearances into local ones

### DIFF
--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/CityGMLGeneralPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/CityGMLGeneralPanel.java
@@ -40,6 +40,8 @@ import java.util.Locale;
 public class CityGMLGeneralPanel extends InternalPreferencesComponent {
 	private TitledPanel formatOptionsPanel;
 	private JCheckBox prettyPrint;
+	private JCheckBox convertGlobalAppearances;
+	private JLabel conversionHint;
 
 	public CityGMLGeneralPanel(Config config) {
 		super(config);
@@ -49,17 +51,29 @@ public class CityGMLGeneralPanel extends InternalPreferencesComponent {
 	@Override
 	public boolean isModified() {
 		if (prettyPrint.isSelected() != config.getExportConfig().getCityGMLOptions().isPrettyPrint()) return true;
+		if (convertGlobalAppearances.isSelected() != config.getExportConfig().getCityGMLOptions().isConvertGlobalAppearances()) return true;
 		return false;
 	}
 
 	private void initGui() {
 		prettyPrint = new JCheckBox();
+		convertGlobalAppearances = new JCheckBox();
+		conversionHint = new JLabel();
+		conversionHint.setFont(conversionHint.getFont().deriveFont(Font.ITALIC));
 
 		setLayout(new GridBagLayout());
-		formatOptionsPanel = new TitledPanel()
-				.withToggleButton(prettyPrint)
-				.showSeparator(false)
-				.buildWithoutContent();
+		{
+			JPanel content = new JPanel();
+			content.setLayout(new GridBagLayout());
+			{
+				int lmargin = GuiUtil.getTextOffset(convertGlobalAppearances);
+				content.add(prettyPrint, GuiUtil.setConstraints(0, 0, 1, 1, GridBagConstraints.BOTH, 0, 0, 5, 0));
+				content.add(convertGlobalAppearances, GuiUtil.setConstraints(0, 1, 1, 1, GridBagConstraints.BOTH, 0, 0, 5, 0));
+				content.add(conversionHint, GuiUtil.setConstraints(0, 2, 1, 1, GridBagConstraints.BOTH, 0, lmargin, 0, 0));
+			}
+
+			formatOptionsPanel = new TitledPanel().build(content);
+		}
 
 		add(formatOptionsPanel, GuiUtil.setConstraints(0, 0, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
 	}
@@ -67,20 +81,25 @@ public class CityGMLGeneralPanel extends InternalPreferencesComponent {
 	@Override
 	public void loadSettings() {
 		prettyPrint.setSelected(config.getExportConfig().getCityGMLOptions().isPrettyPrint());
+		convertGlobalAppearances.setSelected(config.getExportConfig().getCityGMLOptions().isConvertGlobalAppearances());
 	}
 
 	@Override
 	public void setSettings() {
 		config.getExportConfig().getCityGMLOptions().setPrettyPrint(prettyPrint.isSelected());
+		config.getExportConfig().getCityGMLOptions().setConvertGlobalAppearances(convertGlobalAppearances.isSelected());
 	}
 
 	@Override
 	public void switchLocale(Locale locale) {
-		formatOptionsPanel.setTitle(Language.I18N.getString("pref.export.common.label.prettyPrint"));
+		formatOptionsPanel.setTitle(Language.I18N.getString("pref.export.citygml.border.general"));
+		prettyPrint.setText(Language.I18N.getString("pref.export.common.label.prettyPrint"));
+		convertGlobalAppearances.setText(Language.I18N.getString("pref.export.citygml.label.convertGlobalAppearances"));
+		conversionHint.setText(Language.I18N.getString("pref.export.citygml.label.conversionHint"));
 	}
 
 	@Override
 	public String getLocalizedTitle() {
-		return Language.I18N.getString("pref.tree.export.cityGML.general");
+		return Language.I18N.getString("pref.tree.export.citygml.general");
 	}
 }

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/CityGMLOptions.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/CityGMLOptions.java
@@ -42,6 +42,7 @@ public class CityGMLOptions {
     private Boolean writeProductHeader;
     @XmlElement(defaultValue = "true")
     private boolean prettyPrint = true;
+    private boolean convertGlobalAppearances = false;
     @XmlJavaTypeAdapter(NamespaceAdapter.class)
     private LinkedHashMap<String, Namespace> namespaces;
     private ExportAddress address;
@@ -68,6 +69,14 @@ public class CityGMLOptions {
 
     public void setPrettyPrint(boolean prettyPrint) {
         this.prettyPrint = prettyPrint;
+    }
+
+    public boolean isConvertGlobalAppearances() {
+        return convertGlobalAppearances;
+    }
+
+    public void setConvertGlobalAppearances(boolean convertGlobalAppearances) {
+        this.convertGlobalAppearances = convertGlobalAppearances;
     }
 
     public boolean isSetNamespaces() {

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -414,7 +414,7 @@ pref.tree.export.appearance=Appearance
 pref.tree.export.tiling=Kachelungsoptionen
 pref.tree.export.xlink=XLinks
 pref.tree.export.cityGMLOptions=CityGML Optionen
-pref.tree.export.cityGML.general=Allgemein
+pref.tree.export.citygml.general=Allgemein
 pref.tree.export.cityJSONOptions=CityJSON Optionen
 pref.tree.export.resources=Ressourcen
 pref.tree.visExport=VIS Export
@@ -573,6 +573,10 @@ pref.export.xlink.label.geometry.copy=Geometrie-Element kopieren (UUID als neue 
 pref.export.xlink.label.copy.prefix=gml:id Präfix
 pref.export.xlink.label.append=Originale gml:id an neue gml:id anhängen
 pref.export.xlink.label.feature.keepId=Originale gml:id als externe Referenz speichern
+
+pref.export.citygml.border.general=Allgemeine Optionen
+pref.export.citygml.label.convertGlobalAppearances=Globale Appearances in lokale Appearances konvertieren
+pref.export.citygml.label.conversionHint=Globale Appearances von impliziten Geometrien können nicht konvertiert werden.
 
 pref.export.cityjson.border.general=Allgemeine Optionen
 pref.export.cityjson.label.geometryCompression=Geometriekomprimierung anwenden

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -414,7 +414,7 @@ pref.tree.export.appearance=Appearance
 pref.tree.export.tiling=Tiling options
 pref.tree.export.xlink=XLinks
 pref.tree.export.cityGMLOptions=CityGML options
-pref.tree.export.cityGML.general=General
+pref.tree.export.citygml.general=General
 pref.tree.export.cityJSONOptions=CityJSON options
 pref.tree.export.resources=Resources
 pref.tree.visExport=VIS Export
@@ -573,6 +573,10 @@ pref.export.xlink.label.geometry.copy=Copy geometry element (use UUID as new gml
 pref.export.xlink.label.copy.prefix=gml:id prefix
 pref.export.xlink.label.append=Append original gml:id to new gml:id
 pref.export.xlink.label.feature.keepId=Store original gml:id as external reference
+
+pref.export.citygml.border.general=General options
+pref.export.citygml.label.convertGlobalAppearances=Convert global appearances into local appearances
+pref.export.citygml.label.conversionHint=Global appearances of implicit geometries cannot be converted.
 
 pref.export.cityjson.border.general=General options
 pref.export.cityjson.label.geometryCompression=Use geometry compression

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/concurrent/DBExportWorker.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/concurrent/DBExportWorker.java
@@ -56,6 +56,7 @@ import org.citydb.util.event.EventDispatcher;
 import org.citydb.util.event.EventHandler;
 import org.citydb.util.event.global.*;
 import org.citygml4j.builder.jaxb.CityGMLBuilder;
+import org.citygml4j.model.citygml.core.AbstractCityObject;
 import org.citygml4j.model.gml.base.AbstractGML;
 import org.citygml4j.model.gml.feature.AbstractFeature;
 import org.citygml4j.model.gml.feature.BoundingShape;
@@ -215,6 +216,15 @@ public class DBExportWorker extends Worker<DBSplittingResult> implements EventHa
 			}
 
 			if (feature != null) {
+				// convert global appearances into local ones
+				if (internalConfig.getGlobalAppearanceMode() == InternalConfig.GlobalAppearanceMode.CONVERT
+						&& feature instanceof AbstractCityObject) {
+					int unconverted = exporter.convertGlobalAppearances((AbstractCityObject) feature);
+					if (unconverted != 0) {
+						eventDispatcher.triggerEvent(new CounterEvent(CounterType.GLOBAL_APPEARANCE, unconverted, this));
+					}
+				}
+
 				// write feature
 				featureWriter.write(feature, work.getSequenceId());
 

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/controller/Exporter.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/controller/Exporter.java
@@ -269,11 +269,15 @@ public class Exporter implements EventHandler {
             log.info("Replacing object identifiers with UUIDs.");
         }
 
-        // check whether database contains global appearances and set internal flag
+        // check if and how to handle global appearances
         try {
-            internalConfig.setExportGlobalAppearances(outputFormat == OutputFormat.CITYGML
-                    && config.getExportConfig().getAppearances().isSetExportAppearance()
-					&& databaseAdapter.getUtil().containsGlobalAppearances());
+            if (config.getExportConfig().getAppearances().isSetExportAppearance()
+                    && databaseAdapter.getUtil().containsGlobalAppearances()) {
+                internalConfig.setGlobalAppearanceMode(outputFormat == OutputFormat.CITYJSON
+                        || config.getExportConfig().getCityGMLOptions().isConvertGlobalAppearances() ?
+                        InternalConfig.GlobalAppearanceMode.CONVERT :
+                        InternalConfig.GlobalAppearanceMode.EXPORT);
+            }
         } catch (SQLException e) {
             throw new CityGMLExportException("Database error while checking for global appearances.", e);
         }

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBGlobalToLocalAppearance.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBGlobalToLocalAppearance.java
@@ -1,0 +1,233 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2022
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.core.operation.exporter.database.content;
+
+import org.citydb.config.Config;
+import org.citydb.config.project.exporter.OutputFormat;
+import org.citydb.core.database.schema.mapping.MappingConstants;
+import org.citydb.core.operation.exporter.CityGMLExportException;
+import org.citydb.core.operation.exporter.util.AppearanceRemover;
+import org.citydb.core.query.Query;
+import org.citydb.core.query.builder.QueryBuildException;
+import org.citydb.core.query.builder.sql.AppearanceFilterBuilder;
+import org.citydb.sqlbuilder.expression.LiteralList;
+import org.citydb.sqlbuilder.expression.LiteralSelectExpression;
+import org.citydb.sqlbuilder.expression.PlaceHolder;
+import org.citydb.sqlbuilder.schema.Table;
+import org.citydb.sqlbuilder.select.PredicateToken;
+import org.citydb.sqlbuilder.select.Select;
+import org.citydb.sqlbuilder.select.join.JoinFactory;
+import org.citydb.sqlbuilder.select.operator.comparison.ComparisonFactory;
+import org.citydb.sqlbuilder.select.operator.comparison.ComparisonName;
+import org.citygml4j.builder.copy.CopyBuilder;
+import org.citygml4j.builder.copy.DeepCopyBuilder;
+import org.citygml4j.model.citygml.appearance.Appearance;
+import org.citygml4j.model.citygml.appearance.AppearanceProperty;
+import org.citygml4j.model.citygml.core.AbstractCityObject;
+import org.citygml4j.model.citygml.core.ImplicitGeometry;
+import org.citygml4j.model.gml.geometry.AbstractGeometry;
+import org.citygml4j.util.child.ChildInfo;
+import org.citygml4j.util.walker.GMLWalker;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+
+public class DBGlobalToLocalAppearance extends AbstractAppearanceExporter {
+    private final Connection connection;
+    private final PreparedStatement psBulk;
+    private final PreparedStatement psSelect;
+    private final Select appearanceQuery;
+    private final Table textureParam;
+
+    private final boolean handleImplicitGeometries;
+    private final AppearanceRemover appearanceRemover;
+    private final Map<Long, AbstractCityObject> batches;
+    private final int batchSize;
+
+    private CopyBuilder copyBuilder;
+    private ChildInfo childInfo;
+
+    private enum GeometryType {
+        GEOMETRY,
+        IMPLICIT_GEOMETRY
+    }
+
+    public DBGlobalToLocalAppearance(Connection connection, Query query, CityGMLExportManager exporter, Config config) throws CityGMLExportException, SQLException {
+        super(false, null, exporter, config);
+        this.connection = connection;
+
+        handleImplicitGeometries = exporter.getInternalConfig().getOutputFormat() == OutputFormat.CITYGML;
+        if (handleImplicitGeometries) {
+            copyBuilder = new DeepCopyBuilder();
+            childInfo = new ChildInfo();
+        }
+
+        appearanceRemover = new AppearanceRemover();
+        batches = new LinkedHashMap<>();
+        batchSize = exporter.getFeatureBatchSize();
+        String schema = exporter.getDatabaseAdapter().getConnectionDetails().getSchema();
+
+        Table appearance = new Table("appearance", schema);
+        Table appearToSurfaceData = new Table("appear_to_surface_data", schema);
+        Table surfaceData = new Table("surface_data", schema);
+        textureParam = new Table("textureparam", schema);
+
+        appearanceQuery = new Select().setDistinct(true)
+                .addProjection(appearance.getColumn(MappingConstants.ID))
+                .addJoin(JoinFactory.inner(appearToSurfaceData, "appearance_id", ComparisonName.EQUAL_TO, appearance.getColumn(MappingConstants.ID)))
+                .addJoin(JoinFactory.inner(surfaceData, MappingConstants.ID, ComparisonName.EQUAL_TO, appearToSurfaceData.getColumn("surface_data_id")))
+                .addJoin(JoinFactory.inner(textureParam, "surface_data_id", ComparisonName.EQUAL_TO, surfaceData.getColumn(MappingConstants.ID)))
+                .addSelection(ComparisonFactory.isNull(appearance.getColumn("cityobject_id")));
+
+        // add appearance theme filter
+        if (query.isSetAppearanceFilter()) {
+            try {
+                PredicateToken predicate = new AppearanceFilterBuilder(exporter.getDatabaseAdapter())
+                        .buildAppearanceFilter(query.getAppearanceFilter(), appearance.getColumn("theme"));
+                appearanceQuery.addSelection(predicate);
+            } catch (QueryBuildException e) {
+                throw new CityGMLExportException("Failed to build appearance filter.", e);
+            }
+        }
+
+        String placeHolders = String.join(",", Collections.nCopies(batchSize, "?"));
+        psBulk = connection.prepareStatement(new Select(select)
+                .addSelection(ComparisonFactory.in(table.getColumn("id"), new LiteralSelectExpression(placeHolders))).toString());
+
+        psSelect = connection.prepareStatement(new Select(select)
+                .addSelection(ComparisonFactory.equalTo(table.getColumn("id"), new PlaceHolder<>())).toString());
+    }
+
+    protected Collection<Appearance> doExport(AbstractCityObject cityObject) throws CityGMLExportException, SQLException {
+        List<Appearance> unconverted = new ArrayList<>();
+        Set<Long> surfaceGeometryIds = new HashSet<>();
+        Map<GeometryType, Set<String>> targets = new EnumMap<>(GeometryType.class);
+
+        cityObject.accept(new GMLWalker() {
+            @Override
+            public void visit(AbstractGeometry geometry) {
+                Long id = (Long) geometry.getLocalProperty("global_app_cache_id");
+                if (id != null) {
+                    surfaceGeometryIds.add(id);
+
+                    GeometryType type = handleImplicitGeometries
+                            && childInfo.getParentCityGML(geometry, ImplicitGeometry.class) != null ?
+                            GeometryType.IMPLICIT_GEOMETRY :
+                            GeometryType.GEOMETRY;
+
+                    targets.computeIfAbsent(type, v -> new HashSet<>()).add("#" + geometry.getId());
+                }
+            }
+        });
+
+        if (!surfaceGeometryIds.isEmpty()) {
+            Select select = new Select(appearanceQuery)
+                    .addSelection(ComparisonFactory.in(textureParam.getColumn("surface_geometry_id"),
+                            new LiteralList(surfaceGeometryIds.toArray(new Long[0]))));
+            try (PreparedStatement stmt = exporter.getDatabaseAdapter().getSQLAdapter().prepareStatement(select, connection);
+                 ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    batches.put(rs.getLong(1), cityObject);
+                    if (batches.size() == batchSize) {
+                        unconverted.addAll(executeBatch(targets));
+                    }
+                }
+
+                if (!batches.isEmpty()) {
+                    unconverted.addAll(executeBatch(targets));
+                }
+            }
+        }
+
+        return unconverted;
+    }
+
+    private List<Appearance> executeBatch(Map<GeometryType, Set<String>> targets) throws CityGMLExportException, SQLException {
+        if (!batches.isEmpty()) {
+            try {
+                Map<Long, Appearance> appearances;
+                if (batches.size() == 1) {
+                    psSelect.setLong(1, batches.entrySet().iterator().next().getKey());
+                    try (ResultSet rs = psSelect.executeQuery()) {
+                        appearances = doExport(rs);
+                    }
+                } else {
+                    int i = 1;
+                    Long[] ids = batches.keySet().toArray(new Long[0]);
+                    for (int j = 0; j < batchSize; j++) {
+                        psBulk.setLong(i + j, j < ids.length ? ids[j] : 0);
+                    }
+
+                    try (ResultSet rs = psBulk.executeQuery()) {
+                        appearances = doExport(rs);
+                    }
+                }
+
+                if (!appearances.isEmpty()) {
+                    return postprocess(appearances, targets);
+                }
+            } finally {
+                batches.clear();
+            }
+        }
+
+        return Collections.emptyList();
+    }
+
+    private List<Appearance> postprocess(Map<Long, Appearance> appearances, Map<GeometryType, Set<String>> targets) {
+        List<Appearance> globalAppearances = new ArrayList<>();
+        Set<String> implicitGeometryTargets = targets.get(GeometryType.IMPLICIT_GEOMETRY);
+        if (implicitGeometryTargets != null) {
+            appearances.values().stream()
+                    .map(appearance -> (Appearance) appearance.copy(copyBuilder))
+                    .forEach(globalAppearances::add);
+            appearanceRemover.cleanupAppearances(globalAppearances, implicitGeometryTargets);
+        }
+
+        Set<String> geometryTargets = targets.get(GeometryType.GEOMETRY);
+        if (geometryTargets != null) {
+            appearanceRemover.cleanupAppearances(appearances.values(), geometryTargets);
+            for (Map.Entry<Long, Appearance> entry : appearances.entrySet()) {
+                AbstractCityObject cityObject = batches.get(entry.getKey());
+                cityObject.addAppearance(new AppearanceProperty(entry.getValue()));
+            }
+        }
+
+        return globalAppearances;
+    }
+
+    @Override
+    public void close() throws SQLException {
+        psBulk.close();
+        psSelect.close();
+    }
+}

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBSplitter.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBSplitter.java
@@ -145,7 +145,7 @@ public class DBSplitter {
 				|| !generalOptions.getComputeNumberMatched().isOnlyInGuiMode());
 
 		// create temporary table for global appearances if needed
-		if (internalConfig.isExportGlobalAppearances()) {
+		if (internalConfig.getGlobalAppearanceMode() == InternalConfig.GlobalAppearanceMode.EXPORT) {
 			cacheTableManager.createCacheTable(CacheTableModel.GLOBAL_APPEARANCE, CacheMode.DATABASE);
 		}
 
@@ -215,9 +215,10 @@ public class DBSplitter {
 				}
 			}
 
-			if (internalConfig.isExportGlobalAppearances() && sequenceId > 0)
+			if (internalConfig.getGlobalAppearanceMode() == InternalConfig.GlobalAppearanceMode.EXPORT
+					&& sequenceId > 0) {
 				queryGlobalAppearance();
-
+			}
 		} finally {
 			if (connection != null) {
 				connectionPool.closeAndRemoveConnection(connection);
@@ -482,8 +483,8 @@ public class DBSplitter {
 		Table textureParam = new Table("textureparam", schema);
 		Table tempTable = new Table(globalAppTempTable.getTableName());
 
-		Select select = new Select()
-				.addProjection(appearance.getColumn(MappingConstants.ID)).setDistinct(true)
+		Select select = new Select().setDistinct(true)
+				.addProjection(appearance.getColumn(MappingConstants.ID))
 				.addJoin(JoinFactory.inner(appearToSurfaceData, "appearance_id", ComparisonName.EQUAL_TO, appearance.getColumn(MappingConstants.ID)))
 				.addJoin(JoinFactory.inner(surfaceData, MappingConstants.ID, ComparisonName.EQUAL_TO, appearToSurfaceData.getColumn("surface_data_id")))
 				.addJoin(JoinFactory.inner(textureParam, "surface_data_id", ComparisonName.EQUAL_TO, surfaceData.getColumn(MappingConstants.ID)))
@@ -492,7 +493,8 @@ public class DBSplitter {
 
 		// add appearance theme filter
 		if (query.isSetAppearanceFilter()) {
-			PredicateToken predicate = new AppearanceFilterBuilder(databaseAdapter).buildAppearanceFilter(query.getAppearanceFilter(), appearance.getColumn("theme"));
+			PredicateToken predicate = new AppearanceFilterBuilder(databaseAdapter)
+					.buildAppearanceFilter(query.getAppearanceFilter(), appearance.getColumn("theme"));
 			select.addSelection(predicate);
 		}
 

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBSurfaceGeometry.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/database/content/DBSurfaceGeometry.java
@@ -34,6 +34,7 @@ import org.citydb.core.operation.exporter.CityGMLExportException;
 import org.citydb.core.operation.exporter.util.DefaultGeometrySetterHandler;
 import org.citydb.core.operation.exporter.util.GeometrySetter;
 import org.citydb.core.operation.exporter.util.GeometrySetterHandler;
+import org.citydb.core.operation.exporter.util.InternalConfig;
 import org.citydb.sqlbuilder.expression.LiteralSelectExpression;
 import org.citydb.sqlbuilder.expression.PlaceHolder;
 import org.citydb.sqlbuilder.schema.Table;
@@ -69,7 +70,7 @@ public class DBSurfaceGeometry implements DBExporter, SurfaceGeometryExporter {
 
 		batches = new ArrayList<>();
 		batchSize = exporter.getGeometryBatchSize();
-		exportAppearance = exporter.getInternalConfig().isExportGlobalAppearances();
+		exportAppearance = exporter.getInternalConfig().getGlobalAppearanceMode() != InternalConfig.GlobalAppearanceMode.SKIP;
 		useXLink = exporter.getInternalConfig().isExportGeometryReferences();
 		affineTransformation = exporter.getExportConfig().getAffineTransformation().isEnabled();
 		String schema = exporter.getDatabaseAdapter().getConnectionDetails().getSchema();

--- a/impexp-core/src/main/java/org/citydb/core/operation/exporter/util/InternalConfig.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/exporter/util/InternalConfig.java
@@ -36,10 +36,16 @@ public class InternalConfig {
     private OutputFormat outputFormat;
     private String exportTextureURI;
     private boolean transformCoordinates = false;
-    private boolean exportGlobalAppearances = false;
+    private GlobalAppearanceMode globalAppearanceMode = GlobalAppearanceMode.SKIP;
     private boolean registerGmlIdInCache = false;
     private boolean exportFeatureReferences = true;
     private boolean exportGeometryReferences = true;
+
+    public enum GlobalAppearanceMode {
+        SKIP,
+        EXPORT,
+        CONVERT
+    }
 
     public OutputFile getOutputFile() {
         return outputFile;
@@ -73,12 +79,12 @@ public class InternalConfig {
         this.transformCoordinates = transformCoordinates;
     }
 
-    public boolean isExportGlobalAppearances() {
-        return exportGlobalAppearances;
+    public GlobalAppearanceMode getGlobalAppearanceMode() {
+        return globalAppearanceMode;
     }
 
-    public void setExportGlobalAppearances(boolean exportGlobalAppearances) {
-        this.exportGlobalAppearances = exportGlobalAppearances;
+    public void setGlobalAppearanceMode(GlobalAppearanceMode globalAppearanceMode) {
+        this.globalAppearanceMode = globalAppearanceMode;
     }
 
     public boolean isRegisterGmlIdInCache() {


### PR DESCRIPTION
This PR fixes #268.

When exporting CityJSON, global appearances are _automatically_ converted into local ones. This is because CityJSON doesn't differentiate between "global" and "local" appearances and, thus, the automatic conversion is needed for a correct export.

For CityGML exports, this PR adds a new preference option in `Export -> CityGML options -> General` that allows _users to choose_ whether global appearances should be converted into local ones. Although not required to fix #268, this option was an easy extension, so I added it to this PR.