### PR TITLE
Allow ID lists to be composed of one or more CSV files

### DIFF
--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/deleter/DeleteCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/deleter/DeleteCommand.java
@@ -93,9 +93,7 @@ public class DeleteCommand extends CliCommand {
 
             if (deleteListOption.isPreview()) {
                 try {
-                    IdListPreviewer.of(deleteList)
-                            .withNumberOfRecords(20)
-                            .printToConsole();
+                    IdListPreviewer.of(deleteList.getFiles().get(0), deleteList).printToConsole();
                     log.info("Delete list preview successfully finished.");
                     return 0;
                 } catch (Exception e) {

--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/deleter/DeleteListOption.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/deleter/DeleteListOption.java
@@ -34,14 +34,17 @@ import org.citydb.config.project.common.IdList;
 import picocli.CommandLine;
 
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class DeleteListOption implements CliOption {
-    @CommandLine.Option(names = {"-f", "--delete-list"}, required = true,
-            description = "Name of the CSV file containing the delete list.")
-    private Path file;
+    @CommandLine.Option(names = {"-f", "--delete-list"}, paramLabel = "<file>", required = true, split = ",",
+            description = "One or more CSV files containing the delete list.")
+    private Path[] files;
 
     @CommandLine.Option(names = {"-w", "--delete-list-preview"},
-            description = "Print a preview of the delete list and exit.")
+            description = "Print a preview of the delete list and exit. If more than one CSV file is specified, " +
+                    "the preview is only generated for the first one.")
     private boolean preview;
 
     @CommandLine.ArgGroup(exclusive = false)
@@ -57,7 +60,7 @@ public class DeleteListOption implements CliOption {
         }
 
         IdList deleteList = deleteListOption.toIdList(IdList::new);
-        deleteList.setFile(file.toAbsolutePath().toString());
+        deleteList.setFiles(Arrays.stream(files).map(Path::toString).collect(Collectors.toList()));
         return deleteList;
     }
 

--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportCommand.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportCommand.java
@@ -100,9 +100,7 @@ public class ImportCommand extends CliCommand {
 
             if (importListOption.isPreview()) {
                 try {
-                    IdListPreviewer.of(importList)
-                            .withNumberOfRecords(20)
-                            .printToConsole();
+                    IdListPreviewer.of(importList.getFiles().get(0), importList).printToConsole();
                     log.info("Import list preview successfully finished.");
                     return 0;
                 } catch (Exception e) {

--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportListOption.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/importer/ImportListOption.java
@@ -35,18 +35,21 @@ import org.citydb.config.project.importer.ImportListMode;
 import picocli.CommandLine;
 
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class ImportListOption implements CliOption {
-    @CommandLine.Option(names = {"-f", "--import-list"}, required = true,
-            description = "Name of the CSV file containing the import list.")
-    private Path file;
+    @CommandLine.Option(names = {"-f", "--import-list"}, paramLabel = "<file>", required = true, split = ",",
+            description = "One or more CSV files containing the import list.")
+    private Path[] files;
 
     @CommandLine.Option(names = {"-m", "--import-list-mode"}, paramLabel = "<mode>", defaultValue = "import",
             description = "Import list mode: import, skip (default: ${DEFAULT-VALUE}).")
     private String modeOption;
 
     @CommandLine.Option(names = {"-w", "--import-list-preview"},
-            description = "Print a preview of the import list and exit.")
+            description = "Print a preview of the import list and exit. If more than one CSV file is specified, " +
+                    "the preview is only generated for the first one.")
     private boolean preview;
 
     @CommandLine.ArgGroup(exclusive = false)
@@ -64,7 +67,7 @@ public class ImportListOption implements CliOption {
         }
 
         ImportList importList = resourceIdListOption.toIdList(ImportList::new);
-        importList.setFile(file.toAbsolutePath().toString());
+        importList.setFiles(Arrays.stream(files).map(Path::toString).collect(Collectors.toList()));
         importList.setMode(mode);
         return importList;
     }

--- a/impexp-client-gui/src/main/java/org/citydb/gui/components/FileListTransferHandler.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/components/FileListTransferHandler.java
@@ -160,8 +160,8 @@ public class FileListTransferHandler extends TransferHandler implements DropTarg
     @SuppressWarnings("unchecked")
     @Override
     public void drop(DropTargetDropEvent event) {
-        for (DataFlavor dataFlover : event.getCurrentDataFlavors()) {
-            if (dataFlover.isFlavorJavaFileListType()) {
+        for (DataFlavor dataFlavor : event.getCurrentDataFlavors()) {
+            if (dataFlavor.isFlavorJavaFileListType()) {
                 try {
                     event.acceptDrop(DnDConstants.ACTION_COPY_OR_MOVE);
                     List<File> files = getFiles((List<File>) event.getTransferable().getTransferData(DataFlavor.javaFileListFlavor));

--- a/impexp-client-gui/src/main/java/org/citydb/gui/components/FileListTransferHandler.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/components/FileListTransferHandler.java
@@ -1,0 +1,230 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2022
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.gui.components;
+
+import org.citydb.util.log.Logger;
+
+import javax.swing.*;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.dnd.*;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class FileListTransferHandler extends TransferHandler implements DropTargetListener {
+    private final Logger log = Logger.getInstance();
+    private final JList<File> fileList;
+    private final DefaultListModel<File> model;
+
+    private Mode mode = Mode.FILES_AND_DIRECTORIES;
+    private Consumer<DefaultListModel<File>> filesAddedHandler;
+    private Consumer<DefaultListModel<File>> filesRemovedHandler;
+
+    public enum Mode {
+        FILES_ONLY,
+        FILES_AND_DIRECTORIES
+    }
+
+    public FileListTransferHandler(JList<File> fileList) {
+        this.fileList = fileList;
+        model = (DefaultListModel<File>) fileList.getModel();
+
+        ActionMap actionMap = fileList.getActionMap();
+        actionMap.put(TransferHandler.getCutAction().getValue(Action.NAME), TransferHandler.getCutAction());
+        actionMap.put(TransferHandler.getCopyAction().getValue(Action.NAME), TransferHandler.getCopyAction());
+        actionMap.put(TransferHandler.getPasteAction().getValue(Action.NAME), TransferHandler.getPasteAction());
+
+        InputMap inputMap = fileList.getInputMap();
+        inputMap.put(KeyStroke.getKeyStroke('X', InputEvent.CTRL_DOWN_MASK), TransferHandler.getCutAction().getValue(Action.NAME));
+        inputMap.put(KeyStroke.getKeyStroke('C', InputEvent.CTRL_DOWN_MASK), TransferHandler.getCopyAction().getValue(Action.NAME));
+        inputMap.put(KeyStroke.getKeyStroke('V', InputEvent.CTRL_DOWN_MASK), TransferHandler.getPasteAction().getValue(Action.NAME));
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), TransferHandler.getCutAction().getValue(Action.NAME));
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0), TransferHandler.getCutAction().getValue(Action.NAME));
+
+        fileList.setDropTarget(new DropTarget(fileList, this));
+    }
+
+    public FileListTransferHandler withMode(Mode mode) {
+        this.mode = mode;
+        return this;
+    }
+
+    public FileListTransferHandler withFilesAddedHandler(Consumer<DefaultListModel<File>> filesAddedHandler) {
+        this.filesAddedHandler = filesAddedHandler;
+        return this;
+    }
+
+    public FileListTransferHandler withFilesRemovedHandler(Consumer<DefaultListModel<File>> filesRemovedHandler) {
+        this.filesRemovedHandler = filesRemovedHandler;
+        return this;
+    }
+
+    @Override
+    public boolean importData(TransferSupport info) {
+        if (info.isDataFlavorSupported(DataFlavor.stringFlavor) && !info.isDrop()) {
+            try {
+                String value = (String) info.getTransferable().getTransferData(DataFlavor.stringFlavor);
+                List<File> files = getFiles(value.split(System.lineSeparator()));
+                if (!files.isEmpty()) {
+                    addFiles(files);
+                    return true;
+                }
+            } catch (UnsupportedFlavorException | IOException e) {
+                //
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    protected Transferable createTransferable(JComponent c) {
+        int[] indices = fileList.getSelectedIndices();
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < indices.length; i++) {
+            builder.append(fileList.getModel().getElementAt(indices[i]));
+            if (i < indices.length - 1) {
+                builder.append(System.lineSeparator());
+            }
+        }
+
+        return new StringSelection(builder.toString());
+    }
+
+    @Override
+    public int getSourceActions(JComponent c) {
+        return COPY_OR_MOVE;
+    }
+
+    @Override
+    protected void exportDone(JComponent c, Transferable data, int action) {
+        if (action == MOVE && !fileList.isSelectionEmpty()) {
+            int[] indices = fileList.getSelectedIndices();
+            int first = indices[0];
+
+            for (int i = indices.length - 1; i >= 0; i--) {
+                model.remove(indices[i]);
+            }
+
+            if (!model.isEmpty()) {
+                if (first > model.size() - 1) {
+                    first = model.size() - 1;
+                }
+
+                fileList.setSelectedIndex(first);
+            } else if (filesRemovedHandler != null) {
+                filesRemovedHandler.accept(model);
+            }
+        }
+    }
+
+    @Override
+    public void dragEnter(DropTargetDragEvent event) {
+        event.acceptDrag(DnDConstants.ACTION_COPY_OR_MOVE);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void drop(DropTargetDropEvent event) {
+        for (DataFlavor dataFlover : event.getCurrentDataFlavors()) {
+            if (dataFlover.isFlavorJavaFileListType()) {
+                try {
+                    event.acceptDrop(DnDConstants.ACTION_COPY_OR_MOVE);
+                    List<File> files = getFiles((List<File>) event.getTransferable().getTransferData(DataFlavor.javaFileListFlavor));
+                    if (!files.isEmpty()) {
+                        if (event.getDropAction() != DnDConstants.ACTION_COPY) {
+                            model.clear();
+                        }
+
+                        addFiles(files);
+                    }
+
+                    event.getDropTargetContext().dropComplete(true);
+                } catch (UnsupportedFlavorException | IOException e) {
+                    //
+                }
+            }
+        }
+    }
+
+    private boolean isValidFile(File file) {
+        if (!file.exists()) {
+            log.warn("'" + file.getAbsolutePath() + "' is not a valid file.");
+            return false;
+        } else if (mode == Mode.FILES_ONLY && file.isDirectory()) {
+            log.warn("'" + file.getAbsolutePath() + "' is a directory but directories are not supported.");
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private List<File> getFiles(String[] candidates) {
+        return getFiles(Arrays.stream(candidates)
+                .map(File::new)
+                .collect(Collectors.toList()));
+    }
+
+    private List<File> getFiles(List<File> candidates) {
+        return candidates.stream()
+                .filter(this::isValidFile)
+                .collect(Collectors.toList());
+    }
+
+    private void addFiles(List<File> files) {
+        int index = fileList.getSelectedIndex() + 1;
+        for (File file : files) {
+            model.add(index++, file);
+        }
+
+        if (filesAddedHandler != null) {
+            filesAddedHandler.accept(model);
+        }
+    }
+
+    @Override
+    public void dropActionChanged(DropTargetDragEvent event) {
+    }
+
+    @Override
+    public void dragExit(DropTargetEvent event) {
+    }
+
+    @Override
+    public void dragOver(DropTargetDragEvent event) {
+    }
+}

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/common/filter/IdListFilterView.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/common/filter/IdListFilterView.java
@@ -93,15 +93,17 @@ public class IdListFilterView<T extends IdList> extends FilterView<T> {
         component.setLayout(new GridBagLayout());
 
         idListLabel = new JLabel();
-        idListLabel.setMinimumSize(new JTextField().getPreferredSize());
         idListFiles = new JList<>(new DefaultListModel<>());
         idListFiles.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
-        idListFiles.setLayoutOrientation(JList.HORIZONTAL_WRAP);
-        idListFiles.setVisibleRowCount(-1);
+        idListFiles.setVisibleRowCount(6);
 
         FileListTransferHandler transferHandler = new FileListTransferHandler(idListFiles)
                 .withMode(FileListTransferHandler.Mode.FILES_ONLY);
         idListFiles.setTransferHandler(transferHandler);
+
+        JScrollPane scrollPane = new JScrollPane(idListFiles);
+        scrollPane.setMinimumSize(idListFiles.getPreferredScrollableViewportSize());
+        scrollPane.setPreferredSize(idListFiles.getPreferredScrollableViewportSize());
 
         idListBrowseButton = new JButton();
         idListPreviewButton = new JButton();
@@ -182,7 +184,7 @@ public class IdListFilterView<T extends IdList> extends FilterView<T> {
 
         row = 1;
         component.add(idListLabel, GuiUtil.setConstraints(0, row, 0, 0, GridBagConstraints.NORTH, GridBagConstraints.HORIZONTAL, 0, 0, 0, 10));
-        component.add(idListFiles, GuiUtil.setConstraints(1, row, 2, 1, 0, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
+        component.add(scrollPane, GuiUtil.setConstraints(1, row, 2, 1, 0, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
         component.add(buttonsPanel, GuiUtil.setConstraints(3, row++, 1, 4, 0, 0, GridBagConstraints.VERTICAL, 0, 10, 0, 0));
         component.add(idColumnLabel, GuiUtil.setConstraints(0, row, 0, 0, GridBagConstraints.HORIZONTAL, 5, 0, 0, 10));
         component.add(idColumnNamePanel, GuiUtil.setConstraints(2, row++, 1, 0, GridBagConstraints.HORIZONTAL, 5, 0, 0, 0));
@@ -207,18 +209,6 @@ public class IdListFilterView<T extends IdList> extends FilterView<T> {
                 ((JSpinner.DefaultEditor) idColumnIndex.getEditor()).getTextField(),
                 (JTextField) delimiter.getEditor().getEditorComponent(),
                 (JTextField) encoding.getEditor().getEditorComponent());
-
-        UIManager.addPropertyChangeListener(e -> {
-            if ("lookAndFeel".equals(e.getPropertyName())) {
-                SwingUtilities.invokeLater(this::updateComponentUI);
-            }
-        });
-
-        updateComponentUI();
-    }
-
-    private void updateComponentUI() {
-        idListFiles.setBorder(UIManager.getBorder("ScrollPane.border"));
     }
 
     @Override
@@ -254,10 +244,6 @@ public class IdListFilterView<T extends IdList> extends FilterView<T> {
         quoteLabel.setText(Language.I18N.getString("filter.idList.label.quote"));
         commentLabel.setText(Language.I18N.getString("filter.idList.label.comment"));
         encodingLabel.setText(Language.I18N.getString("filter.idList.label.encoding"));
-
-        idListLabel.setPreferredSize(new Dimension(
-                idListLabel.getPreferredSize().width,
-                idColumnName.getPreferredSize().height));
 
         Object item = delimiter.getSelectedItem();
         delimiter.removeAllItems();

--- a/impexp-config/src/main/java/org/citydb/config/project/common/IdList.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/common/IdList.java
@@ -31,6 +31,8 @@ package org.citydb.config.project.common;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 @XmlType(name = "IdListType")
 public class IdList {
@@ -39,8 +41,8 @@ public class IdList {
     public static final char DEFAULT_COMMENT_CHARACTER = '#';
     public static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-    @XmlElement(required = true)
-    private String file;
+    @XmlElement(name = "file", required = true)
+    private List<String> files;
     private String idColumnName;
     @XmlElement(defaultValue = "1")
     private Integer idColumnIndex;
@@ -62,12 +64,20 @@ public class IdList {
         return this;
     }
 
-    public String getFile() {
-        return file;
+    public List<String> getFiles() {
+        if (files == null) {
+            files = new ArrayList<>();
+        }
+
+        return files;
     }
 
-    public void setFile(String file) {
-        this.file = file;
+    public void setFiles(List<String> files) {
+        this.files = files;
+    }
+
+    public boolean hasFiles() {
+        return files != null && !files.isEmpty();
     }
 
     public String getIdColumnName() {

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -166,7 +166,7 @@ filter.dialog.xml.validate.connect=Die Validierung der XML-Abfrage erfordert ein
 filter.label.xml.generateSQL=SQL-Abfrage generieren
 filter.dialog.xml.generateSQL.connect=Das Erzeugen einer SQL-Abfrage erfordert eine Datenbankverbindung.
 
-filter.idList.label.csvFile=CSV-Datei
+filter.idList.label.csvFile=CSV-Dateien
 filter.idList.label.encoding=Kodierung
 filter.idList.label.idColumn=ID-Spalte
 filter.idList.label.idColumn.name=Spaltenname

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -166,7 +166,7 @@ filter.dialog.xml.validate.connect=Validating the XML query requires a database 
 filter.label.xml.generateSQL=Generate SQL query
 filter.dialog.xml.generateSQL.connect=Generating a SQL query requires a database connection.
 
-filter.idList.label.csvFile=CSV file
+filter.idList.label.csvFile=CSV files
 filter.idList.label.encoding=Encoding
 filter.idList.label.idColumn=ID column
 filter.idList.label.idColumn.name=Column name

--- a/impexp-core/src/main/java/org/citydb/core/operation/common/csv/IdListParser.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/common/csv/IdListParser.java
@@ -47,18 +47,20 @@ public class IdListParser implements AutoCloseable {
     private final CsvParser parser;
     private final ResultIterator<Record, ParsingContext> iterator;
 
-    public IdListParser(IdList idList) throws IOException {
+    public IdListParser(String file, IdList idList) throws IdListException {
         this.idList = idList;
 
         try {
-            BufferedReader reader = Files.newBufferedReader(Paths.get(idList.getFile()),
-                    Charset.forName(idList.getEncoding()));
-
+            BufferedReader reader = Files.newBufferedReader(Paths.get(file), Charset.forName(idList.getEncoding()));
             parser = new CsvParser(defaultParserSettings(idList));
             iterator = parser.iterateRecords(reader).iterator();
-        } catch (Exception e) {
-            throw new IOException("Failed to open ID list file.", e);
+        } catch (IOException e) {
+            throw new IdListException("Failed to open ID list " + file + ".", e);
         }
+    }
+
+    public static IdListParser of(String file, IdList idList) throws IdListException {
+        return new IdListParser(file, idList);
     }
 
     public static CsvParserSettings defaultParserSettings(IdList idList) {
@@ -124,7 +126,11 @@ public class IdListParser implements AutoCloseable {
     }
 
     @Override
-    public void close() throws IOException {
-        parser.stopParsing();
+    public void close() throws IdListException {
+        try {
+            parser.stopParsing();
+        } catch (Throwable e) {
+            throw new IdListException("Failed to close ID list.", e);
+        }
     }
 }

--- a/impexp-core/src/main/java/org/citydb/core/operation/common/csv/IdListPreviewer.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/common/csv/IdListPreviewer.java
@@ -44,15 +44,17 @@ import java.util.stream.IntStream;
 
 public class IdListPreviewer {
     private final Logger log = Logger.getInstance();
+    private final String file;
     private final IdList idList;
     private long numberOfRecords = 20;
 
-    private IdListPreviewer(IdList idList) {
+    private IdListPreviewer(String file, IdList idList) {
+        this.file = file;
         this.idList = idList;
     }
 
-    public static IdListPreviewer of(IdList idList) {
-        return new IdListPreviewer(idList);
+    public static IdListPreviewer of(String file, IdList idList) {
+        return new IdListPreviewer(file, idList);
     }
 
     public IdListPreviewer withNumberOfRecords(long numberOfRecords) {
@@ -65,7 +67,7 @@ public class IdListPreviewer {
     }
 
     public void printToConsole() throws Exception {
-        log.info("Creating preview for the CSV file '" + idList.getFile() + "'.");
+        log.info("Generating preview for the CSV file '" + file + "'.");
         log.info("Printing the first " + numberOfRecords + " records based on the provided CSV settings.");
 
         List<List<String>> records = new ArrayList<>();
@@ -77,8 +79,7 @@ public class IdListPreviewer {
         settings.setEmptyValue("");
 
         CsvParser parser = new CsvParser(settings);
-        parser.beginParsing(Files.newBufferedReader(Paths.get(idList.getFile()),
-                Charset.forName(idList.getEncoding())));
+        parser.beginParsing(Files.newBufferedReader(Paths.get(file), Charset.forName(idList.getEncoding())));
 
         String[] row;
         while ((row = parser.parseNext()) != null) {


### PR DESCRIPTION
This PR allows ID lists to be composed of one or more CSV files. The settings for parsing the CSV content are specified only once and, thus, must be met by all CSV files composing the ID list. The changes are implemented for the import list (GUI + CLI) and the delete list (CLI only).

In GUI mode, the user can select for which of the CSV files a preview should be generated when clicking the `Preview` button. Multi-selection is supported. The default is to generate the preview only for the first CSV file.

In CLI mode, the preview is always just generated for the _first_ CSV files. This behaviour could be changed so that the preview is generated for _all_ files if required. 

Solves #225.