### PR TITLE
Remove unsetter from import classes

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBAppearance.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBAppearance.java
@@ -157,7 +157,6 @@ public class DBAppearance implements DBImporter {
 
 				if (surfaceData != null) {
 					surfaceDataImporter.doImport(surfaceData, appearanceId, isLocalAppearance);
-					property.unsetSurfaceData();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridge.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridge.java
@@ -196,7 +196,6 @@ public class DBBridge implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -225,7 +224,6 @@ public class DBBridge implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -258,7 +256,6 @@ public class DBBridge implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), bridgeId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -300,7 +297,6 @@ public class DBBridge implements DBImporter {
 			if (solidProperty != null) {
 				if (solidProperty.isSetSolid()) {
 					solidGeometryId = surfaceGeometryImporter.doImport(solidProperty.getSolid(), bridgeId);
-					solidProperty.unsetSolid();
 				} else {
 					String href = solidProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -334,7 +330,6 @@ public class DBBridge implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, bridge, bridgeId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -355,7 +350,6 @@ public class DBBridge implements DBImporter {
 
 				if (construction != null) {
 					bridgeConstructionImporter.doImport(construction, bridge, bridgeId);
-					property.unsetBridgeConstructionElement();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -376,7 +370,6 @@ public class DBBridge implements DBImporter {
 
 				if (installation != null) {
 					bridgeInstallationImporter.doImport(installation, bridge, bridgeId);
-					property.unsetBridgeInstallation();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -397,7 +390,6 @@ public class DBBridge implements DBImporter {
 
 				if (installation != null) {
 					bridgeInstallationImporter.doImport(installation, bridge, bridgeId);
-					property.unsetIntBridgeInstallation();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -418,7 +410,6 @@ public class DBBridge implements DBImporter {
 
 				if (room != null) {
 					roomImporter.doImport(room, bridgeId);
-					property.unsetBridgeRoom();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -439,7 +430,6 @@ public class DBBridge implements DBImporter {
 
 				if (bridgePart != null) {
 					doImport(bridgePart, bridgeId, rootId);
-					property.unsetBridgePart();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0)
@@ -455,7 +445,6 @@ public class DBBridge implements DBImporter {
 
 				if (address != null) {
 					addressImporter.importBridgeAddress(address, bridgeId);
-					property.unsetAddress();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeConstrElement.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeConstrElement.java
@@ -174,7 +174,6 @@ public class DBBridgeConstrElement implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -214,8 +213,6 @@ public class DBBridgeConstrElement implements DBImporter {
 						geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 					else 
 						importer.logOrThrowUnsupportedGeometryMessage(bridgeConstruction, abstractGeometry);
-
-					geometryProperty.unsetGeometry();
 				} else {
 					String href = geometryProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -314,7 +311,6 @@ public class DBBridgeConstrElement implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, bridgeConstruction, bridgeConstructionId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeFurniture.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeFurniture.java
@@ -152,8 +152,6 @@ public class DBBridgeFurniture implements DBImporter {
 					geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 				else 
 					importer.logOrThrowUnsupportedGeometryMessage(bridgeFurniture, abstractGeometry);
-
-				geometryProperty.unsetGeometry();
 			} else {
 				String href = geometryProperty.getHref();
 				if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeInstallation.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeInstallation.java
@@ -183,8 +183,6 @@ public class DBBridgeInstallation implements DBImporter {
 						geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 					else
 						importer.logOrThrowUnsupportedGeometryMessage(bridgeInstallation, abstractGeometry);
-
-					geometryProperty.unsetGeometry();
 				} else {
 					String href = geometryProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -276,7 +274,6 @@ public class DBBridgeInstallation implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, bridgeInstallation, bridgeInstallationId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -373,8 +370,6 @@ public class DBBridgeInstallation implements DBImporter {
 					geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 				else 
 					importer.logOrThrowUnsupportedGeometryMessage(intBridgeInstallation, abstractGeometry);
-
-				geometryProperty.unsetGeometry();
 			} else {
 				String href = geometryProperty.getHref();
 				if (href != null && href.length() != 0) {
@@ -459,7 +454,6 @@ public class DBBridgeInstallation implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, intBridgeInstallation, intBridgeInstallationId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeOpening.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeOpening.java
@@ -118,7 +118,6 @@ public class DBBridgeOpening implements DBImporter {
 
 				if (address != null) {
 					addressImporter.doImport(address);
-					property.unsetAddress();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -154,7 +153,6 @@ public class DBBridgeOpening implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiSurfaceId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), openingId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeRoom.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeRoom.java
@@ -137,7 +137,6 @@ public class DBBridgeRoom implements DBImporter {
 
 			if (multiSurfacePropery.isSetMultiSurface()) {
 				geometryId = surfaceGeometryImporter.doImport(multiSurfacePropery.getMultiSurface(), bridgeRoomId);
-				multiSurfacePropery.unsetMultiSurface();
 			} else {
 				String href = multiSurfacePropery.getHref();
 				if (href != null && href.length() != 0) {
@@ -163,7 +162,6 @@ public class DBBridgeRoom implements DBImporter {
 
 			if (solidProperty.isSetSolid()) {
 				geometryId = surfaceGeometryImporter.doImport(solidProperty.getSolid(), bridgeRoomId);
-				solidProperty.unsetSolid();
 			} else {
 				String href = solidProperty.getHref();
 				if (href != null && href.length() != 0) {
@@ -196,7 +194,6 @@ public class DBBridgeRoom implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, bridgeRoom, bridgeRoomId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -217,7 +214,6 @@ public class DBBridgeRoom implements DBImporter {
 
 				if (installation != null) {
 					bridgeInstallationImporter.doImport(installation, bridgeRoom, bridgeRoomId);
-					property.unsetIntBridgeInstallation();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -238,7 +234,6 @@ public class DBBridgeRoom implements DBImporter {
 
 				if (furniture != null) {
 					bridgeFurnitureImporter.doImport(furniture, bridgeRoomId);
-					property.unsetBridgeFurniture();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeThematicSurface.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBridgeThematicSurface.java
@@ -134,7 +134,6 @@ public class DBBridgeThematicSurface implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiSurfaceId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), boundarySurfaceId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -164,7 +163,6 @@ public class DBBridgeThematicSurface implements DBImporter {
 
 				if (opening != null) {
 					openingImporter.doImport(opening, boundarySurface, boundarySurfaceId);
-					property.unsetOpening();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBuilding.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBuilding.java
@@ -245,7 +245,6 @@ public class DBBuilding implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -274,7 +273,6 @@ public class DBBuilding implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -301,7 +299,6 @@ public class DBBuilding implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiSurfaceId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), buildingId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -343,7 +340,6 @@ public class DBBuilding implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), buildingId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -385,7 +381,6 @@ public class DBBuilding implements DBImporter {
 			if (solidProperty != null) {
 				if (solidProperty.isSetSolid()) {
 					solidGeometryId = surfaceGeometryImporter.doImport(solidProperty.getSolid(), buildingId);
-					solidProperty.unsetSolid();
 				} else {
 					String href = solidProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -419,7 +414,6 @@ public class DBBuilding implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, building, buildingId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -440,7 +434,6 @@ public class DBBuilding implements DBImporter {
 
 				if (installation != null) {
 					buildingInstallationImporter.doImport(installation, building, buildingId);
-					property.unsetBuildingInstallation();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -461,7 +454,6 @@ public class DBBuilding implements DBImporter {
 
 				if (installation != null) {
 					buildingInstallationImporter.doImport(installation, building, buildingId);
-					property.unsetIntBuildingInstallation();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -482,7 +474,6 @@ public class DBBuilding implements DBImporter {
 
 				if (room != null) {
 					roomImporter.doImport(room, buildingId);
-					property.unsetRoom();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -503,7 +494,6 @@ public class DBBuilding implements DBImporter {
 
 				if (buildingPart != null) {
 					doImport(buildingPart, buildingId, rootId);
-					property.unsetBuildingPart();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0)
@@ -519,7 +509,6 @@ public class DBBuilding implements DBImporter {
 
 				if (address != null) {
 					addressImporter.importBuildingAddress(address, buildingId);
-					property.unsetAddress();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBuildingFurniture.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBuildingFurniture.java
@@ -152,8 +152,6 @@ public class DBBuildingFurniture implements DBImporter {
 					geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 				else 
 					importer.logOrThrowUnsupportedGeometryMessage(buildingFurniture, abstractGeometry);
-
-				geometryProperty.unsetGeometry();
 			} else {
 				String href = geometryProperty.getHref();
 				if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBuildingInstallation.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBBuildingInstallation.java
@@ -183,8 +183,6 @@ public class DBBuildingInstallation implements DBImporter {
 						geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 					else 
 						importer.logOrThrowUnsupportedGeometryMessage(buildingInstallation, abstractGeometry);
-
-					geometryProperty.unsetGeometry();
 				} else {
 					String href = geometryProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -276,7 +274,6 @@ public class DBBuildingInstallation implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, buildingInstallation, buildingInstallationId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -373,8 +370,6 @@ public class DBBuildingInstallation implements DBImporter {
 					geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 				else 
 					importer.logOrThrowUnsupportedGeometryMessage(intBuildingInstallation, abstractGeometry);
-
-				geometryProperty.unsetGeometry();
 			} else {
 				String href = geometryProperty.getHref();
 				if (href != null && href.length() != 0) {
@@ -459,7 +454,6 @@ public class DBBuildingInstallation implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, intBuildingInstallation, intBuildingInstallationId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBCityFurniture.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBCityFurniture.java
@@ -158,7 +158,6 @@ public class DBCityFurniture implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null)
@@ -197,8 +196,6 @@ public class DBCityFurniture implements DBImporter {
 						geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 					else
 						importer.logOrThrowUnsupportedGeometryMessage(cityFurniture, abstractGeometry);
-
-					geometryProperty.unsetGeometry();
 				} else {
 					String href = geometryProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBCityObjectGroup.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBCityObjectGroup.java
@@ -136,8 +136,6 @@ public class DBCityObjectGroup implements DBImporter {
 					geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 				else 
 					importer.logOrThrowUnsupportedGeometryMessage(cityObjectGroup, abstractGeometry);
-
-				geometryProperty.unsetGeometry();
 			} else {
 				String href = geometryProperty.getHref();
 				if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBGenericCityObject.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBGenericCityObject.java
@@ -161,7 +161,6 @@ public class DBGenericCityObject implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -204,8 +203,6 @@ public class DBGenericCityObject implements DBImporter {
 						geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 					else 
 						importer.logOrThrowUnsupportedGeometryMessage(genericCityObject, abstractGeometry);
-
-					geometryProperty.unsetGeometry();
 				} else {
 					String href = geometryProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBLandUse.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBLandUse.java
@@ -138,7 +138,6 @@ public class DBLandUse implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), landUseId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBOpening.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBOpening.java
@@ -118,7 +118,6 @@ public class DBOpening implements DBImporter {
 
 				if (address != null) {
 					addressId = addressImporter.doImport(address);
-					property.unsetAddress();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -154,7 +153,6 @@ public class DBOpening implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiSurfaceId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), openingId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBPlantCover.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBPlantCover.java
@@ -146,7 +146,6 @@ public class DBPlantCover implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), plantCoverId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -188,7 +187,6 @@ public class DBPlantCover implements DBImporter {
 			if (multiSolidProperty != null) {
 				if (multiSolidProperty.isSetMultiSolid()) {
 					solidGeometryId = surfaceGeometryImporter.doImport(multiSolidProperty.getMultiSolid(), plantCoverId);
-					multiSolidProperty.unsetMultiSolid();
 				} else {
 					String href = multiSolidProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBReliefComponent.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBReliefComponent.java
@@ -178,9 +178,6 @@ public class DBReliefComponent implements DBImporter {
 						if (tin.isSetControlPoint())
 							controlPoints = geometryConverter.getMultiPoint(tin.getControlPoint());
 					}
-
-					tinProperty.unsetTriangulatedSurface();
-
 				} else {
 					String href = tinProperty.getHref();
 					if (href != null && href.length() != 0)
@@ -238,7 +235,6 @@ public class DBReliefComponent implements DBImporter {
 			GeometryObject reliefPoints = null;
 			if (massPointRelief.isSetReliefPoints()) {
 				reliefPoints = geometryConverter.getMultiPoint(massPointRelief.getReliefPoints());
-				massPointRelief.unsetReliefPoints();
 			}
 
 			if (reliefPoints != null)
@@ -265,12 +261,10 @@ public class DBReliefComponent implements DBImporter {
 
 			if (breakLineRelief.isSetRidgeOrValleyLines()) {
 				ridgeOrValleyLines = geometryConverter.getMultiCurve(breakLineRelief.getRidgeOrValleyLines());
-				breakLineRelief.unsetRidgeOrValleyLines();
 			}
 
 			if (breakLineRelief.isSetBreaklines()) {
 				breakLines = geometryConverter.getMultiCurve(breakLineRelief.getBreaklines());
-				breakLineRelief.unsetBreaklines();
 			}
 
 			if (ridgeOrValleyLines != null)

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBReliefFeature.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBReliefFeature.java
@@ -101,8 +101,6 @@ public class DBReliefFeature implements DBImporter {
 								": Raster relief components are not supported.");
 					else
 						reliefComponentImporter.doImport(component, reliefFeature, reliefFeatureId);
-
-					property.unsetReliefComponent();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBRoom.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBRoom.java
@@ -137,7 +137,6 @@ public class DBRoom implements DBImporter {
 
 			if (multiSurfacePropery.isSetMultiSurface()) {
 				geometryId = surfaceGeometryImporter.doImport(multiSurfacePropery.getMultiSurface(), roomId);
-				multiSurfacePropery.unsetMultiSurface();
 			} else {
 				String href = multiSurfacePropery.getHref();
 				if (href != null && href.length() != 0) {
@@ -162,7 +161,6 @@ public class DBRoom implements DBImporter {
 
 			if (solidProperty.isSetSolid()) {
 				geometryId = surfaceGeometryImporter.doImport(solidProperty.getSolid(), roomId);
-				solidProperty.unsetSolid();
 			} else {
 				String href = solidProperty.getHref();
 				if (href != null && href.length() != 0) {
@@ -195,7 +193,6 @@ public class DBRoom implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, room, roomId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -216,7 +213,6 @@ public class DBRoom implements DBImporter {
 
 				if (installation != null) {
 					buildingInstallationImporter.doImport(installation, room, roomId);
-					property.unsetIntBuildingInstallation();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -237,7 +233,6 @@ public class DBRoom implements DBImporter {
 
 				if (furniture != null) {
 					buildingFurnitureImporter.doImport(furniture, roomId);
-					property.unsetBuildingFurniture();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBSolitaryVegetatObject.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBSolitaryVegetatObject.java
@@ -201,8 +201,6 @@ public class DBSolitaryVegetatObject implements DBImporter {
 						geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 					else 
 						importer.logOrThrowUnsupportedGeometryMessage(vegetationObject, abstractGeometry);
-
-					geometryProperty.unsetGeometry();
 				} else {
 					String href = geometryProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBThematicSurface.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBThematicSurface.java
@@ -124,7 +124,6 @@ public class DBThematicSurface implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiSurfaceId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), boundarySurfaceId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -154,7 +153,6 @@ public class DBThematicSurface implements DBImporter {
 
 				if (opening != null) {
 					openingImporter.doImport(opening, boundarySurface, boundarySurfaceId);
-					property.unsetOpening();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTrafficArea.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTrafficArea.java
@@ -149,7 +149,6 @@ public class DBTrafficArea implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), trafficAreaId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -258,7 +257,6 @@ public class DBTrafficArea implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), auxiliaryTrafficAreaId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTransportationComplex.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTransportationComplex.java
@@ -168,9 +168,7 @@ public class DBTransportationComplex implements DBImporter {
 				// we do not support XLinks or further geometry types so far
 			}
 
-			transportationComplex.unsetLod0Network();
-
-			if (aggregate.isSetElement() && !aggregate.getElement().isEmpty())   		
+			if (aggregate.isSetElement() && !aggregate.getElement().isEmpty())
 				multiCurve = geometryConverter.getCurveGeometry(aggregate);
 		}
 
@@ -202,7 +200,6 @@ public class DBTransportationComplex implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), transportationComplexId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -232,7 +229,6 @@ public class DBTransportationComplex implements DBImporter {
 
 				if (trafficArea != null) {
 					trafficAreaImporter.doImport(trafficArea, transportationComplexId);
-					property.unsetAuxiliaryTrafficArea();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -253,7 +249,6 @@ public class DBTransportationComplex implements DBImporter {
 
 				if (trafficArea != null) {
 					trafficAreaImporter.doImport(trafficArea, transportationComplexId);
-					property.unsetTrafficArea();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnel.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnel.java
@@ -184,7 +184,6 @@ public class DBTunnel implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -213,7 +212,6 @@ public class DBTunnel implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -246,7 +244,6 @@ public class DBTunnel implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), tunnelId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -288,7 +285,6 @@ public class DBTunnel implements DBImporter {
 			if (solidProperty != null) {
 				if (solidProperty.isSetSolid()) {
 					solidGeometryId = surfaceGeometryImporter.doImport(solidProperty.getSolid(), tunnelId);
-					solidProperty.unsetSolid();
 				} else {
 					String href = solidProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -322,7 +318,6 @@ public class DBTunnel implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, tunnel, tunnelId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -343,7 +338,6 @@ public class DBTunnel implements DBImporter {
 
 				if (installation != null) {
 					tunnelInstallationImporter.doImport(installation, tunnel, tunnelId);
-					property.unsetTunnelInstallation();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -364,7 +358,6 @@ public class DBTunnel implements DBImporter {
 
 				if (installation != null) {
 					tunnelInstallationImporter.doImport(installation, tunnel, tunnelId);
-					property.unsetIntTunnelInstallation();
 				} else {
 					// xlink
 					String href = property.getHref();
@@ -386,7 +379,6 @@ public class DBTunnel implements DBImporter {
 
 				if (hollowSpace != null) {
 					hollowSpaceImporter.doImport(hollowSpace, tunnelId);
-					property.unsetHollowSpace();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -407,7 +399,6 @@ public class DBTunnel implements DBImporter {
 
 				if (tunnelPart != null) {
 					doImport(tunnelPart, tunnelId, rootId);
-					property.unsetTunnelPart();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0)

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelFurniture.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelFurniture.java
@@ -153,8 +153,6 @@ public class DBTunnelFurniture implements DBImporter {
 					geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 				else 
 					importer.logOrThrowUnsupportedGeometryMessage(tunnelFurniture, abstractGeometry);
-
-				geometryProperty.unsetGeometry();
 			} else {
 				String href = geometryProperty.getHref();
 				if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelHollowSpace.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelHollowSpace.java
@@ -138,7 +138,6 @@ public class DBTunnelHollowSpace implements DBImporter {
 
 			if (multiSurfacePropery.isSetMultiSurface()) {
 				geometryId = surfaceGeometryImporter.doImport(multiSurfacePropery.getMultiSurface(), hollowSpaceId);
-				multiSurfacePropery.unsetMultiSurface();
 			} else {
 				String href = multiSurfacePropery.getHref();
 				if (href != null && href.length() != 0) {
@@ -164,7 +163,6 @@ public class DBTunnelHollowSpace implements DBImporter {
 
 			if (solidProperty.isSetSolid()) {
 				geometryId = surfaceGeometryImporter.doImport(solidProperty.getSolid(), hollowSpaceId);
-				solidProperty.unsetSolid();
 			} else {
 				String href = solidProperty.getHref();
 				if (href != null && href.length() != 0) {
@@ -197,7 +195,6 @@ public class DBTunnelHollowSpace implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, hollowSpace, hollowSpaceId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -218,7 +215,6 @@ public class DBTunnelHollowSpace implements DBImporter {
 
 				if (installation != null) {
 					tunnelInstallationImporter.doImport(installation, hollowSpace, hollowSpaceId);
-					property.unsetIntTunnelInstallation();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -239,7 +235,6 @@ public class DBTunnelHollowSpace implements DBImporter {
 
 				if (furniture != null) {
 					tunnelFurnitureImporter.doImport(furniture, hollowSpaceId);
-					property.unsetTunnelFurniture();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelInstallation.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelInstallation.java
@@ -183,8 +183,6 @@ public class DBTunnelInstallation implements DBImporter {
 						geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 					else 
 						importer.logOrThrowUnsupportedGeometryMessage(tunnelInstallation, abstractGeometry);
-
-					geometryProperty.unsetGeometry();
 				} else {
 					String href = geometryProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -276,7 +274,6 @@ public class DBTunnelInstallation implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, tunnelInstallation, tunnelInstallationId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {
@@ -373,8 +370,6 @@ public class DBTunnelInstallation implements DBImporter {
 					geometryObject = geometryConverter.getPointOrCurveGeometry(abstractGeometry);
 				else 
 					importer.logOrThrowUnsupportedGeometryMessage(intTunnelInstallation, abstractGeometry);
-
-				geometryProperty.unsetGeometry();
 			} else {
 				String href = geometryProperty.getHref();
 				if (href != null && href.length() != 0) {
@@ -459,7 +454,6 @@ public class DBTunnelInstallation implements DBImporter {
 
 				if (boundarySurface != null) {
 					thematicSurfaceImporter.doImport(boundarySurface, intTunnelInstallation, intTunnelInstallationId);
-					property.unsetBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0)

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelOpening.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelOpening.java
@@ -121,7 +121,6 @@ public class DBTunnelOpening implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiSurfaceId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), openingId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelThematicSurface.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBTunnelThematicSurface.java
@@ -125,7 +125,6 @@ public class DBTunnelThematicSurface implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiSurfaceId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), boundarySurfaceId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -155,7 +154,6 @@ public class DBTunnelThematicSurface implements DBImporter {
 
 				if (opening != null) {
 					openingImporter.doImport(opening, boundarySurface, boundarySurfaceId);
-					property.unsetOpening();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBWaterBody.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBWaterBody.java
@@ -146,7 +146,6 @@ public class DBWaterBody implements DBImporter {
 
 			if (multiCurveProperty != null) {
 				multiLine = geometryConverter.getMultiCurve(multiCurveProperty);
-				multiCurveProperty.unsetMultiCurve();
 			}
 
 			if (multiLine != null) {
@@ -173,7 +172,6 @@ public class DBWaterBody implements DBImporter {
 			if (multiSurfaceProperty != null) {
 				if (multiSurfaceProperty.isSetMultiSurface()) {
 					multiGeometryId = surfaceGeometryImporter.doImport(multiSurfaceProperty.getMultiSurface(), waterBodyId);
-					multiSurfaceProperty.unsetMultiSurface();
 				} else {
 					String href = multiSurfaceProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -215,7 +213,6 @@ public class DBWaterBody implements DBImporter {
 			if (solidProperty != null) {
 				if (solidProperty.isSetSolid()) {
 					solidGeometryId = surfaceGeometryImporter.doImport(solidProperty.getSolid(), waterBodyId);
-					solidProperty.unsetSolid();
 				} else {
 					String href = solidProperty.getHref();
 					if (href != null && href.length() != 0) {
@@ -249,7 +246,6 @@ public class DBWaterBody implements DBImporter {
 
 				if (boundarySurface != null) {
 					boundarySurfaceImporter.doImport(boundarySurface, waterBody, waterBodyId);
-					property.unsetWaterBoundarySurface();
 				} else {
 					String href = property.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBWaterBoundarySurface.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/database/content/DBWaterBoundarySurface.java
@@ -116,7 +116,6 @@ public class DBWaterBoundarySurface implements DBImporter {
 			if (surfaceProperty != null) {
 				if (surfaceProperty.isSetSurface()) {
 					surfaceGeometryId = surfaceGeometryImporter.doImport(surfaceProperty.getSurface(), waterBoundarySurfaceId);
-					surfaceProperty.unsetSurface();
 				} else {
 					String href = surfaceProperty.getHref();
 					if (href != null && href.length() != 0) {

--- a/impexp-core/src/main/java/org/citydb/core/operation/importer/util/LocalAppearanceHandler.java
+++ b/impexp-core/src/main/java/org/citydb/core/operation/importer/util/LocalAppearanceHandler.java
@@ -71,8 +71,6 @@ public class LocalAppearanceHandler {
 				Appearance appearance = property.getAppearance();
 				
 				if (appearance != null) {
-					// unlink parent to be able to free memory
-					appearance.unsetParent();
 					appearances.add(appearance);
 
 					// check whether we have to deal with textures


### PR DESCRIPTION
The import classes currently remove geometries and nested objects from the citygml4j objects once they have been imported into the database. The initial reason was to free main memory as soon as possible. A drawback of unsetting geometry and nested objects is, however, that the information is not available in ADE extensions anymore.

This PR proposes to remove the unsetter calls from the import classes. The impact on main memory should really be negligible because the full-blown top-level objects are already kept in parallel on the import worker queue before the import starts.