### PR TITLE
Add UI options to set dataset metadata

### DIFF
--- a/impexp-client-gui/src/main/java/org/citydb/gui/components/popup/AddTokenMenu.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/components/popup/AddTokenMenu.java
@@ -1,0 +1,88 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2023
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.gui.components.popup;
+
+import org.citydb.config.i18n.Language;
+import org.citydb.config.project.exporter.TileTokenValue;
+
+import javax.swing.*;
+
+public class AddTokenMenu extends JPopupMenu {
+    private JTextField textField;
+
+    public static AddTokenMenu newInstance() {
+        return new AddTokenMenu();
+    }
+
+    private AddTokenMenu() {
+        JMenuItem row = new JMenuItem(Language.I18N.getString("pref.export.tiling.label.row"));
+        JMenuItem column = new JMenuItem(Language.I18N.getString("pref.export.tiling.label.column"));
+        JMenuItem xmin = new JMenuItem("<html>x<sub>min</sub></html>");
+        JMenuItem ymin = new JMenuItem("<html>y<sub>min</sub></html>");
+        JMenuItem xmax = new JMenuItem("<html>x<sub>max</sub></html>");
+        JMenuItem ymax = new JMenuItem("<html>y<sub>max</sub></html>");
+
+        add(row);
+        add(column);
+        addSeparator();
+        add(xmin);
+        add(ymin);
+        add(xmax);
+        add(ymax);
+
+        row.addActionListener(e -> addToken(TileTokenValue.ROW_TOKEN));
+        column.addActionListener(e -> addToken(TileTokenValue.COLUMN_TOKEN));
+        xmin.addActionListener(e -> addToken(TileTokenValue.X_MIN_TOKEN));
+        ymin.addActionListener(e -> addToken(TileTokenValue.Y_MIN_TOKEN));
+        xmax.addActionListener(e -> addToken(TileTokenValue.X_MAX_TOKEN));
+        ymax.addActionListener(e -> addToken(TileTokenValue.Y_MAX_TOKEN));
+    }
+
+    public AddTokenMenu withTarget(JTextField textField) {
+        this.textField = textField;
+        return this;
+    }
+
+    private void addToken(String token) {
+        if (textField != null) {
+            String text = textField.getText();
+            int dot = textField.getCaretPosition();
+            int start = textField.getSelectionStart();
+            int end = textField.getSelectionEnd();
+
+            if (start != dot || end != dot) {
+                text = text.substring(0, start) + text.substring(end);
+                dot = start;
+            }
+
+            textField.setText(text.substring(0, dot) + token + text.substring(dot));
+            textField.setCaretPosition(dot + token.length());
+        }
+    }
+}

--- a/impexp-client-gui/src/main/java/org/citydb/gui/components/popup/TokenSettingsMenu.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/components/popup/TokenSettingsMenu.java
@@ -1,0 +1,137 @@
+/*
+ * 3D City Database - The Open Source CityGML Database
+ * https://www.3dcitydb.org/
+ *
+ * Copyright 2013 - 2023
+ * Chair of Geoinformatics
+ * Technical University of Munich, Germany
+ * https://www.lrg.tum.de/gis/
+ *
+ * The 3D City Database is jointly developed with the following
+ * cooperation partners:
+ *
+ * Virtual City Systems, Berlin <https://vc.systems/>
+ * M.O.S.S. Computer Grafik Systeme GmbH, Taufkirchen <http://www.moss.de/>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.citydb.gui.components.popup;
+
+import com.formdev.flatlaf.extras.components.FlatTextField;
+import org.citydb.config.i18n.Language;
+import org.citydb.config.project.exporter.TileTokenValue;
+import org.citydb.gui.util.GuiUtil;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.Locale;
+
+public class TokenSettingsMenu extends AbstractPopupMenu {
+    private final JPanel settingsPanel;
+    private final JLabel rowLabel;
+    private final JLabel columnLabel;
+    private final JTextField rowFormat;
+    private final JTextField columnFormat;
+    private final JTextField xminFormat;
+    private final JTextField yminFormat;
+    private final JTextField xmaxFormat;
+    private final JTextField ymaxFormat;
+
+    public TokenSettingsMenu() {
+        settingsPanel = new JPanel();
+        settingsPanel.setLayout(new GridBagLayout());
+        {
+            rowLabel = new JLabel();
+            columnLabel = new JLabel();
+            rowFormat = createTextField();
+            columnFormat = createTextField();
+            xminFormat = createTextField();
+            yminFormat = createTextField();
+            xmaxFormat = createTextField();
+            ymaxFormat = createTextField();
+
+            JLabel xminLabel = new JLabel("<html>x<sub>min</sub></html>");
+            JLabel yminLabel = new JLabel("<html>y<sub>min</sub></html>");
+            JLabel xmaxLabel = new JLabel("<html>x<sub>max</sub></html>");
+            JLabel ymaxLabel = new JLabel("<html>y<sub>max</sub></html>");
+
+            int separatorHeight = UIManager.getInt("Separator.height");
+            settingsPanel.add(rowLabel, GuiUtil.setConstraints(0, 0, 0, 0, GridBagConstraints.HORIZONTAL, 0, 10, 0, 5));
+            settingsPanel.add(rowFormat, GuiUtil.setConstraints(1, 0, 1, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 10));
+            settingsPanel.add(columnLabel, GuiUtil.setConstraints(0, 1, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
+            settingsPanel.add(columnFormat, GuiUtil.setConstraints(1, 1, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
+            settingsPanel.add(new JSeparator(), GuiUtil.setConstraints(0, 2, 2, 1, 0, 0, GridBagConstraints.HORIZONTAL, 5 + separatorHeight, 0, separatorHeight, 0));
+            settingsPanel.add(xminLabel, GuiUtil.setConstraints(0, 3, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
+            settingsPanel.add(xminFormat, GuiUtil.setConstraints(1, 3, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
+            settingsPanel.add(yminLabel, GuiUtil.setConstraints(0, 4, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
+            settingsPanel.add(yminFormat, GuiUtil.setConstraints(1, 4, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
+            settingsPanel.add(xmaxLabel, GuiUtil.setConstraints(0, 5, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
+            settingsPanel.add(xmaxFormat, GuiUtil.setConstraints(1, 5, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
+            settingsPanel.add(ymaxLabel, GuiUtil.setConstraints(0, 6, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
+            settingsPanel.add(ymaxFormat, GuiUtil.setConstraints(1, 6, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
+        }
+
+        add(settingsPanel);
+    }
+
+    private JTextField createTextField() {
+        FlatTextField textField = new FlatTextField();
+        textField.setColumns(8);
+        textField.setPlaceholderText(TileTokenValue.DEFAULT_TOKEN_FORMAT);
+        return textField;
+    }
+
+    public boolean isModified(TileTokenValue value) {
+        if (!rowFormat.getText().equals(value.getRowFormat())) return true;
+        if (!columnFormat.getText().equals(value.getColumnFormat())) return true;
+        if (!xminFormat.getText().equals(value.getXminFormat())) return true;
+        if (!yminFormat.getText().equals(value.getYminFormat())) return true;
+        if (!xmaxFormat.getText().equals(value.getXmaxFormat())) return true;
+        return !ymaxFormat.getText().equals(value.getYmaxFormat());
+    }
+
+    public void loadSettings(TileTokenValue value) {
+        rowFormat.setText(value.getRowFormat());
+        columnFormat.setText(value.getColumnFormat());
+        xminFormat.setText(value.getXminFormat());
+        yminFormat.setText(value.getYminFormat());
+        xmaxFormat.setText(value.getXmaxFormat());
+        ymaxFormat.setText(value.getYmaxFormat());
+    }
+
+    public void setSettings(TileTokenValue value) {
+        value.setRowFormat(rowFormat.getText());
+        value.setColumnFormat(columnFormat.getText());
+        value.setXminFormat(xminFormat.getText());
+        value.setYminFormat(yminFormat.getText());
+        value.setXmaxFormat(xmaxFormat.getText());
+        value.setYmaxFormat(ymaxFormat.getText());
+        loadSettings(value);
+    }
+
+    @Override
+    public void switchLocale(Locale locale) {
+        rowLabel.setText(Language.I18N.getString("pref.export.tiling.label.row"));
+        columnLabel.setText(Language.I18N.getString("pref.export.tiling.label.column"));
+    }
+
+    @Override
+    public void updateUI() {
+        super.updateUI();
+        if (settingsPanel != null) {
+            SwingUtilities.updateComponentTreeUI(settingsPanel);
+            settingsPanel.setBackground(getBackground());
+        }
+    }
+}

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/GeneralPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/GeneralPanel.java
@@ -27,6 +27,7 @@
  */
 package org.citydb.gui.operation.exporter.preferences;
 
+import com.formdev.flatlaf.extras.FlatSVGIcon;
 import org.citydb.config.Config;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.exporter.FeatureEnvelopeMode;
@@ -36,6 +37,9 @@ import org.citydb.config.project.query.filter.version.CityGMLVersionType;
 import org.citydb.core.registry.ObjectRegistry;
 import org.citydb.core.util.Util;
 import org.citydb.gui.components.TitledPanel;
+import org.citydb.gui.components.popup.AddTokenMenu;
+import org.citydb.gui.components.popup.PopupMenuDecorator;
+import org.citydb.gui.components.popup.TokenSettingsMenu;
 import org.citydb.gui.plugin.internal.InternalPreferencesComponent;
 import org.citydb.gui.util.GuiUtil;
 import org.citydb.util.event.global.PropertyChangeEvent;
@@ -51,12 +55,22 @@ public class GeneralPanel extends InternalPreferencesComponent {
 	private JLabel versionHintLabel;
 	private JCheckBox failFastOnErrors;
 	private JCheckBox computeNumberMatched;
+	private JLabel featureEnvelopeLabel;
+	private JComboBox<FeatureEnvelopeMode> featureEnvelope;
 	private JLabel compressedOutputFormatLabel;
 	private JComboBox<OutputFormat> compressedOutputFormat;
 
-	private TitledPanel envelopePanel;
-	private JLabel featureEnvelopeLabel;
-	private JComboBox<FeatureEnvelopeMode> featureEnvelope;
+	private TitledPanel metadataPanel;
+	private JLabel nameLabel;
+	private JTextField name;
+	private JButton nameTokenButton;
+	private JButton nameTokenSettingsButton;
+	private TokenSettingsMenu nameTokenSettings;
+	private JLabel descriptionLabel;
+	private JTextField description;
+	private JButton descriptionTokenButton;
+	private JButton descriptionTokenSettingsButton;
+	private TokenSettingsMenu descriptionTokenSettings;
 	private JCheckBox cityModelEnvelope;
 	private JCheckBox useTileExtent;
 
@@ -76,6 +90,10 @@ public class GeneralPanel extends InternalPreferencesComponent {
 		if (computeNumberMatched.isSelected() != generalOptions.getComputeNumberMatched().isEnabled()) return true;
 		if (compressedOutputFormat.getSelectedItem() != generalOptions.getCompressedOutputFormat()) return true;
 		if (featureEnvelope.getSelectedItem() != generalOptions.getEnvelope().getFeatureMode()) return true;
+		if (!name.getText().equals(generalOptions.getDatasetName().getValue())) return true;
+		if (nameTokenSettings.isModified(generalOptions.getDatasetName())) return true;
+		if (!description.getText().equals(generalOptions.getDatasetDescription().getValue())) return true;
+		if (descriptionTokenSettings.isModified(generalOptions.getDatasetDescription())) return true;
 		if (cityModelEnvelope.isSelected() != generalOptions.getEnvelope().isUseEnvelopeOnCityModel()) return true;
 		if (useTileExtent.isSelected() != generalOptions.getEnvelope().isUseTileExtentForCityModel()) return true;
 
@@ -95,11 +113,6 @@ public class GeneralPanel extends InternalPreferencesComponent {
 
 		failFastOnErrors = new JCheckBox();
 		computeNumberMatched = new JCheckBox();
-		compressedOutputFormatLabel = new JLabel();
-		compressedOutputFormat = new JComboBox<>();
-		for (OutputFormat outputFormat : OutputFormat.values()) {
-			compressedOutputFormat.addItem(outputFormat);
-		}
 
 		featureEnvelopeLabel = new JLabel();
 		featureEnvelope = new JComboBox<>();
@@ -122,13 +135,53 @@ public class GeneralPanel extends InternalPreferencesComponent {
 			}
 		});
 
+		compressedOutputFormatLabel = new JLabel();
+		compressedOutputFormat = new JComboBox<>();
+		for (OutputFormat outputFormat : OutputFormat.values()) {
+			compressedOutputFormat.addItem(outputFormat);
+		}
+
+		nameLabel = new JLabel();
+		name = new JTextField();
+		nameTokenButton = new JButton();
+		nameTokenButton.setHorizontalTextPosition(SwingConstants.LEFT);
+		nameTokenButton.setIcon(new FlatSVGIcon("org/citydb/gui/icons/expand_more.svg"));
+		nameTokenSettingsButton = new JButton();
+		nameTokenSettingsButton.setIcon(new FlatSVGIcon("org/citydb/gui/icons/settings.svg"));
+		nameTokenSettings = new TokenSettingsMenu();
+
+		descriptionLabel = new JLabel();
+		description = new JTextField();
+		descriptionTokenButton = new JButton();
+		descriptionTokenButton.setHorizontalTextPosition(SwingConstants.LEFT);
+		descriptionTokenButton.setIcon(new FlatSVGIcon("org/citydb/gui/icons/expand_more.svg"));
+		descriptionTokenSettingsButton = new JButton();
+		descriptionTokenSettingsButton.setIcon(new FlatSVGIcon("org/citydb/gui/icons/settings.svg"));
+		descriptionTokenSettings = new TokenSettingsMenu();
+
 		cityModelEnvelope = new JCheckBox();
 		useTileExtent = new JCheckBox();
+
+		PopupMenuDecorator.getInstance().decorate(name);
 
 		setLayout(new GridBagLayout());
 		{
 			JPanel content = new JPanel();
 			content.setLayout(new GridBagLayout());
+
+			JPanel envelopePanel = new JPanel();
+			envelopePanel.setLayout(new GridBagLayout());
+			{
+				envelopePanel.add(featureEnvelopeLabel, GuiUtil.setConstraints(0, 0, 0, 0, GridBagConstraints.HORIZONTAL, 0, 0, 0, 5));
+				envelopePanel.add(featureEnvelope, GuiUtil.setConstraints(1, 0, 1, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 0));
+			}
+
+			JPanel compressedOutputPanel = new JPanel();
+			compressedOutputPanel.setLayout(new GridBagLayout());
+			{
+				compressedOutputPanel.add(compressedOutputFormatLabel, GuiUtil.setConstraints(0, 0, 0, 0, GridBagConstraints.HORIZONTAL, 0, 0, 0, 5));
+				compressedOutputPanel.add(compressedOutputFormat, GuiUtil.setConstraints(1, 0, 1, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 0));
+			}
 
 			int lmargin = GuiUtil.getTextOffset(cityGMLv2);
 			content.add(cityGMLv2, GuiUtil.setConstraints(0, 0, 2, 1, 1, 1, GridBagConstraints.BOTH, 0, 0, 0, 0));
@@ -136,8 +189,8 @@ public class GeneralPanel extends InternalPreferencesComponent {
 			content.add(cityGMLv1, GuiUtil.setConstraints(0, 2, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
 			content.add(failFastOnErrors, GuiUtil.setConstraints(0, 3, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
 			content.add(computeNumberMatched, GuiUtil.setConstraints(0, 4, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
-			content.add(compressedOutputFormatLabel, GuiUtil.setConstraints(0, 5, 0, 0, GridBagConstraints.HORIZONTAL, 5, 0, 0, 5));
-			content.add(compressedOutputFormat, GuiUtil.setConstraints(1, 5, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 0));
+			content.add(envelopePanel, GuiUtil.setConstraints(0, 5, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 0));
+			content.add(compressedOutputPanel, GuiUtil.setConstraints(0, 6, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 0));
 
 			generalPanel = new TitledPanel().build(content);
 		}
@@ -145,19 +198,63 @@ public class GeneralPanel extends InternalPreferencesComponent {
 			JPanel content = new JPanel();
 			content.setLayout(new GridBagLayout());
 
-			int lmargin = GuiUtil.getTextOffset(cityModelEnvelope);
-			content.add(featureEnvelopeLabel, GuiUtil.setConstraints(0, 0, 0, 0, GridBagConstraints.HORIZONTAL, 0, 0, 0, 5));
-			content.add(featureEnvelope, GuiUtil.setConstraints(1, 0, 1, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 0));
-			content.add(cityModelEnvelope, GuiUtil.setConstraints(0, 1, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
-			content.add(useTileExtent, GuiUtil.setConstraints(0, 2, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, lmargin, 0, 0));
+			JToolBar nameToolBar = new JToolBar();
+			nameToolBar.add(nameTokenButton);
+			nameToolBar.addSeparator();
+			nameToolBar.add(nameTokenSettingsButton);
 
-			envelopePanel = new TitledPanel().build(content);
+			JToolBar descriptionToolBar = new JToolBar();
+			descriptionToolBar.add(descriptionTokenButton);
+			descriptionToolBar.addSeparator();
+			descriptionToolBar.add(descriptionTokenSettingsButton);
+
+			int lmargin = GuiUtil.getTextOffset(cityModelEnvelope);
+			content.add(nameLabel, GuiUtil.setConstraints(0, 0, 0, 0, GridBagConstraints.HORIZONTAL, 0, 0, 0, 5));
+			content.add(name, GuiUtil.setConstraints(1, 0, 1, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 5));
+			content.add(nameToolBar, GuiUtil.setConstraints(2, 0, 0, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 0));
+			content.add(descriptionLabel, GuiUtil.setConstraints(0, 1, 0, 0, GridBagConstraints.HORIZONTAL, 0, 0, 0, 5));
+			content.add(description, GuiUtil.setConstraints(1, 1, 1, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 5));
+			content.add(descriptionToolBar, GuiUtil.setConstraints(2, 1, 0, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 0));
+			content.add(cityModelEnvelope, GuiUtil.setConstraints(0, 2, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, 0, 0, 0));
+			content.add(useTileExtent, GuiUtil.setConstraints(0, 3, 2, 1, 1, 1, GridBagConstraints.BOTH, 5, lmargin, 0, 0));
+
+			metadataPanel = new TitledPanel().build(content);
 		}
 
 		add(generalPanel, GuiUtil.setConstraints(0, 0, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
-		add(envelopePanel, GuiUtil.setConstraints(0, 1, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
+		add(metadataPanel, GuiUtil.setConstraints(0, 1, 1, 0, GridBagConstraints.BOTH, 0, 0, 0, 0));
 
 		cityModelEnvelope.addActionListener(e -> setEnabledEnvelopeOptions());
+
+		int x = UIManager.getInsets("Button.toolbar.spacingInsets").left;
+		nameTokenButton.addActionListener(e -> AddTokenMenu.newInstance()
+				.withTarget(name)
+				.show(nameTokenButton, x, nameTokenButton.getHeight()));
+		descriptionTokenButton.addActionListener(e -> AddTokenMenu.newInstance()
+				.withTarget(description)
+				.show(descriptionTokenButton, x, descriptionTokenButton.getHeight()));
+
+		nameTokenSettingsButton.addActionListener(
+				e -> nameTokenSettings.show(nameTokenSettingsButton, x, nameTokenSettingsButton.getHeight()));
+		descriptionTokenSettingsButton.addActionListener(
+				e -> descriptionTokenSettings.show(descriptionTokenSettingsButton, x, descriptionTokenSettingsButton.getHeight()));
+
+		UIManager.addPropertyChangeListener(e -> {
+			if ("lookAndFeel".equals(e.getPropertyName())) {
+				SwingUtilities.invokeLater(this::updateComponentUI);
+			}
+		});
+
+		updateComponentUI();
+	}
+
+	private void setEnabledEnvelopeOptions() {
+		useTileExtent.setEnabled(cityModelEnvelope.isSelected());
+	}
+
+	private void updateComponentUI() {
+		nameTokenSettings.updateUI();
+		descriptionTokenSettings.updateUI();
 	}
 
 	@Override
@@ -168,11 +265,19 @@ public class GeneralPanel extends InternalPreferencesComponent {
 		versionHintLabel.setText(Language.I18N.getString("pref.export.general.label.versionHint"));
 		failFastOnErrors.setText(Language.I18N.getString("pref.export.general.failFastOnError"));
 		computeNumberMatched.setText(Language.I18N.getString("pref.export.general.computeNumberMatched"));
-		compressedOutputFormatLabel.setText(Language.I18N.getString("pref.export.general.label.compressedFormat"));
-		envelopePanel.setTitle(Language.I18N.getString("pref.export.general.border.bbox"));
 		featureEnvelopeLabel.setText(Language.I18N.getString("pref.export.general.label.feature"));
+		compressedOutputFormatLabel.setText(Language.I18N.getString("pref.export.general.label.compressedFormat"));
+
+		metadataPanel.setTitle(Language.I18N.getString("pref.export.general.border.metadata"));
+		nameLabel.setText(Language.I18N.getString("pref.export.general.label.datasetName"));
+		nameTokenButton.setText(Language.I18N.getString("pref.export.tiling.label.token"));
+		descriptionLabel.setText(Language.I18N.getString("pref.export.general.label.datasetDescription"));
+		descriptionTokenButton.setText(Language.I18N.getString("pref.export.tiling.label.token"));
 		cityModelEnvelope.setText(Language.I18N.getString("pref.export.general.label.cityModel"));
 		useTileExtent.setText(Language.I18N.getString("pref.export.general.label.useTileExtent"));
+
+		nameTokenSettings.switchLocale(locale);
+		descriptionTokenSettings.switchLocale(locale);
 	}
 
 	@Override
@@ -189,8 +294,15 @@ public class GeneralPanel extends InternalPreferencesComponent {
 		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
 		failFastOnErrors.setSelected(generalOptions.isFailFastOnErrors());
 		computeNumberMatched.setSelected(generalOptions.getComputeNumberMatched().isEnabled());
-		compressedOutputFormat.setSelectedItem(generalOptions.getCompressedOutputFormat());
 		featureEnvelope.setSelectedItem(generalOptions.getEnvelope().getFeatureMode());
+		compressedOutputFormat.setSelectedItem(generalOptions.getCompressedOutputFormat());
+
+		name.setText(generalOptions.getDatasetName().getValue());
+		name.setCaretPosition(name.getText().length());
+		nameTokenSettings.loadSettings(generalOptions.getDatasetName());
+		description.setText(generalOptions.getDatasetDescription().getValue());
+		description.setCaretPosition(description.getText().length());
+		descriptionTokenSettings.loadSettings(generalOptions.getDatasetDescription());
 		cityModelEnvelope.setSelected(generalOptions.getEnvelope().isUseEnvelopeOnCityModel());
 		useTileExtent.setSelected(generalOptions.getEnvelope().isUseTileExtentForCityModel());
 
@@ -206,14 +318,15 @@ public class GeneralPanel extends InternalPreferencesComponent {
 		GeneralOptions generalOptions = config.getExportConfig().getGeneralOptions();
 		generalOptions.setFailFastOnErrors(failFastOnErrors.isSelected());
 		generalOptions.getComputeNumberMatched().setEnabled(computeNumberMatched.isSelected());
-		generalOptions.setCompressedOutputFormat((OutputFormat) compressedOutputFormat.getSelectedItem());
 		generalOptions.getEnvelope().setFeatureMode((FeatureEnvelopeMode) featureEnvelope.getSelectedItem());
+		generalOptions.setCompressedOutputFormat((OutputFormat) compressedOutputFormat.getSelectedItem());
+
+		generalOptions.getDatasetName().setValue(name.getText());
+		nameTokenSettings.setSettings(generalOptions.getDatasetName());
+		generalOptions.getDatasetDescription().setValue(description.getText());
+		descriptionTokenSettings.setSettings(generalOptions.getDatasetDescription());
 		generalOptions.getEnvelope().setUseEnvelopeOnCityModel(cityModelEnvelope.isSelected());
 		generalOptions.getEnvelope().setUseTileExtentForCityModel(useTileExtent.isSelected());
-	}
-
-	private void setEnabledEnvelopeOptions() {
-		useTileExtent.setEnabled(cityModelEnvelope.isSelected());
 	}
 
 	@Override

--- a/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/TilingOptionsPanel.java
+++ b/impexp-client-gui/src/main/java/org/citydb/gui/operation/exporter/preferences/TilingOptionsPanel.java
@@ -28,14 +28,13 @@
 package org.citydb.gui.operation.exporter.preferences;
 
 import com.formdev.flatlaf.extras.FlatSVGIcon;
-import com.formdev.flatlaf.extras.components.FlatTextField;
 import org.citydb.config.Config;
 import org.citydb.config.i18n.Language;
 import org.citydb.config.project.exporter.SimpleTilingOptions;
-import org.citydb.config.project.exporter.TileTokenValue;
 import org.citydb.gui.components.TitledPanel;
-import org.citydb.gui.components.popup.AbstractPopupMenu;
+import org.citydb.gui.components.popup.AddTokenMenu;
 import org.citydb.gui.components.popup.PopupMenuDecorator;
+import org.citydb.gui.components.popup.TokenSettingsMenu;
 import org.citydb.gui.plugin.internal.InternalPreferencesComponent;
 import org.citydb.gui.util.GuiUtil;
 
@@ -325,158 +324,5 @@ public class TilingOptionsPanel extends InternalPreferencesComponent {
 	@Override
 	public String getLocalizedTitle() {
 		return Language.I18N.getString("pref.tree.export.tiling");
-	}
-
-	private static class AddTokenMenu extends JPopupMenu {
-		private JTextField textField;
-
-		static AddTokenMenu newInstance() {
-			return new AddTokenMenu();
-		}
-
-		private AddTokenMenu() {
-			JMenuItem row = new JMenuItem(Language.I18N.getString("pref.export.tiling.label.row"));
-			JMenuItem column = new JMenuItem(Language.I18N.getString("pref.export.tiling.label.column"));
-			JMenuItem xmin = new JMenuItem("<html>x<sub>min</sub></html>");
-			JMenuItem ymin = new JMenuItem("<html>y<sub>min</sub></html>");
-			JMenuItem xmax = new JMenuItem("<html>x<sub>max</sub></html>");
-			JMenuItem ymax = new JMenuItem("<html>y<sub>max</sub></html>");
-
-			add(row);
-			add(column);
-			addSeparator();
-			add(xmin);
-			add(ymin);
-			add(xmax);
-			add(ymax);
-
-			row.addActionListener(e -> addToken(TileTokenValue.ROW_TOKEN));
-			column.addActionListener(e -> addToken(TileTokenValue.COLUMN_TOKEN));
-			xmin.addActionListener(e -> addToken(TileTokenValue.X_MIN_TOKEN));
-			ymin.addActionListener(e -> addToken(TileTokenValue.Y_MIN_TOKEN));
-			xmax.addActionListener(e -> addToken(TileTokenValue.X_MAX_TOKEN));
-			ymax.addActionListener(e -> addToken(TileTokenValue.Y_MAX_TOKEN));
-		}
-
-		AddTokenMenu withTarget(JTextField textField) {
-			this.textField = textField;
-			return this;
-		}
-
-		private void addToken(String token) {
-			if (textField != null) {
-				String text = textField.getText();
-				int dot = textField.getCaretPosition();
-				int start = textField.getSelectionStart();
-				int end = textField.getSelectionEnd();
-
-				if (start != dot || end != dot) {
-					text = text.substring(0, start) + text.substring(end);
-					dot = start;
-				}
-
-				textField.setText(text.substring(0, dot) + token + text.substring(dot));
-				textField.setCaretPosition(dot + token.length());
-			}
-		}
-	}
-
-	private static class TokenSettingsMenu extends AbstractPopupMenu {
-		private final JPanel settingsPanel;
-		private final JLabel rowLabel;
-		private final JLabel columnLabel;
-		private final JTextField rowFormat;
-		private final JTextField columnFormat;
-		private final JTextField xminFormat;
-		private final JTextField yminFormat;
-		private final JTextField xmaxFormat;
-		private final JTextField ymaxFormat;
-
-		TokenSettingsMenu() {
-			settingsPanel = new JPanel();
-			settingsPanel.setLayout(new GridBagLayout());
-			{
-				rowLabel = new JLabel();
-				columnLabel = new JLabel();
-				rowFormat = createTextField();
-				columnFormat = createTextField();
-				xminFormat = createTextField();
-				yminFormat = createTextField();
-				xmaxFormat = createTextField();
-				ymaxFormat = createTextField();
-
-				JLabel xminLabel = new JLabel("<html>x<sub>min</sub></html>");
-				JLabel yminLabel = new JLabel("<html>y<sub>min</sub></html>");
-				JLabel xmaxLabel = new JLabel("<html>x<sub>max</sub></html>");
-				JLabel ymaxLabel = new JLabel("<html>y<sub>max</sub></html>");
-
-				int separatorHeight = UIManager.getInt("Separator.height");
-				settingsPanel.add(rowLabel, GuiUtil.setConstraints(0, 0, 0, 0, GridBagConstraints.HORIZONTAL, 0, 10, 0, 5));
-				settingsPanel.add(rowFormat, GuiUtil.setConstraints(1, 0, 1, 0, GridBagConstraints.HORIZONTAL, 0, 5, 0, 10));
-				settingsPanel.add(columnLabel, GuiUtil.setConstraints(0, 1, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
-				settingsPanel.add(columnFormat, GuiUtil.setConstraints(1, 1, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
-				settingsPanel.add(new JSeparator(), GuiUtil.setConstraints(0, 2, 2, 1, 0, 0, GridBagConstraints.HORIZONTAL, 5 + separatorHeight, 0, separatorHeight, 0));
-				settingsPanel.add(xminLabel, GuiUtil.setConstraints(0, 3, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
-				settingsPanel.add(xminFormat, GuiUtil.setConstraints(1, 3, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
-				settingsPanel.add(yminLabel, GuiUtil.setConstraints(0, 4, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
-				settingsPanel.add(yminFormat, GuiUtil.setConstraints(1, 4, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
-				settingsPanel.add(xmaxLabel, GuiUtil.setConstraints(0, 5, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
-				settingsPanel.add(xmaxFormat, GuiUtil.setConstraints(1, 5, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
-				settingsPanel.add(ymaxLabel, GuiUtil.setConstraints(0, 6, 0, 0, GridBagConstraints.HORIZONTAL, 5, 10, 0, 5));
-				settingsPanel.add(ymaxFormat, GuiUtil.setConstraints(1, 6, 1, 0, GridBagConstraints.HORIZONTAL, 5, 5, 0, 10));
-			}
-
-			add(settingsPanel);
-		}
-
-		private JTextField createTextField() {
-			FlatTextField textField = new FlatTextField();
-			textField.setColumns(8);
-			textField.setPlaceholderText(TileTokenValue.DEFAULT_TOKEN_FORMAT);
-			return textField;
-		}
-
-		boolean isModified(TileTokenValue value) {
-			if (!rowFormat.getText().equals(value.getRowFormat())) return true;
-			if (!columnFormat.getText().equals(value.getColumnFormat())) return true;
-			if (!xminFormat.getText().equals(value.getXminFormat())) return true;
-			if (!yminFormat.getText().equals(value.getYminFormat())) return true;
-			if (!xmaxFormat.getText().equals(value.getXmaxFormat())) return true;
-			return !ymaxFormat.getText().equals(value.getYmaxFormat());
-		}
-
-		void loadSettings(TileTokenValue value) {
-			rowFormat.setText(value.getRowFormat());
-			columnFormat.setText(value.getColumnFormat());
-			xminFormat.setText(value.getXminFormat());
-			yminFormat.setText(value.getYminFormat());
-			xmaxFormat.setText(value.getXmaxFormat());
-			ymaxFormat.setText(value.getYmaxFormat());
-		}
-
-		void setSettings(TileTokenValue value) {
-			value.setRowFormat(rowFormat.getText());
-			value.setColumnFormat(columnFormat.getText());
-			value.setXminFormat(xminFormat.getText());
-			value.setYminFormat(yminFormat.getText());
-			value.setXmaxFormat(xmaxFormat.getText());
-			value.setYmaxFormat(ymaxFormat.getText());
-			loadSettings(value);
-		}
-
-		@Override
-		public void switchLocale(Locale locale) {
-			rowLabel.setText(Language.I18N.getString("pref.export.tiling.label.row"));
-			columnLabel.setText(Language.I18N.getString("pref.export.tiling.label.column"));
-		}
-
-		@Override
-		public void updateUI() {
-			super.updateUI();
-			if (settingsPanel != null) {
-				SwingUtilities.updateComponentTreeUI(settingsPanel);
-				settingsPanel.setBackground(getBackground());
-			}
-		}
 	}
 }

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/GeneralOptions.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/GeneralOptions.java
@@ -39,10 +39,14 @@ public class GeneralOptions {
     private ComputeNumberMatched computeNumberMatched;
     private String fileEncoding;
     private OutputFormat compressedOutputFormat = OutputFormat.CITYGML;
+    private TileTokenValue datasetName;
+    private TileTokenValue datasetDescription;
     private ExportEnvelope envelope;
 
     public GeneralOptions() {
         computeNumberMatched = new ComputeNumberMatched();
+        datasetName = new TileTokenValue();
+        datasetDescription = new TileTokenValue();
         envelope = new ExportEnvelope();
     }
 
@@ -82,6 +86,26 @@ public class GeneralOptions {
 
     public void setCompressedOutputFormat(OutputFormat compressedOutputFormat) {
         this.compressedOutputFormat = compressedOutputFormat;
+    }
+
+    public TileTokenValue getDatasetName() {
+        return datasetName;
+    }
+
+    public void setDatasetName(TileTokenValue datasetName) {
+        if (datasetName != null) {
+            this.datasetName = datasetName;
+        }
+    }
+
+    public TileTokenValue getDatasetDescription() {
+        return datasetDescription;
+    }
+
+    public void setDatasetDescription(TileTokenValue datasetDescription) {
+        if (datasetDescription != null) {
+            this.datasetDescription = datasetDescription;
+        }
     }
 
     public ExportEnvelope getEnvelope() {

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/SimpleTilingOptions.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/SimpleTilingOptions.java
@@ -55,8 +55,8 @@ public class SimpleTilingOptions extends AbstractTilingOptions {
 
     public SimpleTilingOptions() {
         subDir = new TileTokenValue(getDefaultSubDir());
-        filenameSuffix = new TileTokenValue("");
-        attributeValue = new TileTokenValue("");
+        filenameSuffix = new TileTokenValue();
+        attributeValue = new TileTokenValue();
     }
 
     public boolean isUseSubDir() {

--- a/impexp-config/src/main/java/org/citydb/config/project/exporter/TileTokenValue.java
+++ b/impexp-config/src/main/java/org/citydb/config/project/exporter/TileTokenValue.java
@@ -131,12 +131,14 @@ public class TileTokenValue {
     }
 
     public String formatAndResolveTokens(int row, int column, double xmin, double ymin, double xmax, double ymax) {
-        return value.replaceAll(ROW_TOKEN, getFormattedString(getRowFormat(), row))
-                .replaceAll(COLUMN_TOKEN, getFormattedString(getColumnFormat(), column))
-                .replaceAll(X_MIN_TOKEN, getFormattedString(getXminFormat(), xmin))
-                .replaceAll(Y_MIN_TOKEN, getFormattedString(getYminFormat(), ymin))
-                .replaceAll(X_MAX_TOKEN, getFormattedString(getXmaxFormat(), xmax))
-                .replaceAll(Y_MAX_TOKEN, getFormattedString(getYmaxFormat(), ymax));
+        return value != null ?
+                value.replaceAll(ROW_TOKEN, getFormattedString(getRowFormat(), row))
+                        .replaceAll(COLUMN_TOKEN, getFormattedString(getColumnFormat(), column))
+                        .replaceAll(X_MIN_TOKEN, getFormattedString(getXminFormat(), xmin))
+                        .replaceAll(Y_MIN_TOKEN, getFormattedString(getYminFormat(), ymin))
+                        .replaceAll(X_MAX_TOKEN, getFormattedString(getXmaxFormat(), xmax))
+                        .replaceAll(Y_MAX_TOKEN, getFormattedString(getYmaxFormat(), ymax)) :
+                null;
     }
 
     public String formatAndResolveTokens(int row, int column, BoundingBox extent) {

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_de.properties
@@ -535,11 +535,13 @@ pref.export.general.label.versionHint=Diese Version wird für CityJSON Exporte em
 pref.export.general.failFastOnError=Export bei Fehlern sofort abbrechen
 pref.export.general.computeNumberMatched=Anzahl der Top-Level Objekte berechnen, die die Anfrage erfüllen
 pref.export.general.label.compressedFormat=Ausgabeformat für komprimierte Exporte
-pref.export.general.border.bbox=Bounding Box Optionen
 pref.export.general.label.feature=Bounding Box exportieren
 pref.export.general.feature.topLevel=Nur für Top-Level Objekte
 pref.export.general.feature.all=Für alle Objekte
 pref.export.general.feature.none=Keine Bounding Box für Objekte exportieren
+pref.export.general.border.metadata=Datensatz-Metadaten
+pref.export.general.label.datasetName=Name
+pref.export.general.label.datasetDescription=Beschreibung
 pref.export.general.label.cityModel=Bounding Box für gesamten Datensatz berechnen und exportieren
 pref.export.general.label.useTileExtent=Kachelausdehnung bei gekacheltem Export verwenden
 

--- a/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
+++ b/impexp-config/src/main/resources/org/citydb/config/i18n/language_en.properties
@@ -535,11 +535,13 @@ pref.export.general.label.versionHint=This version is recommended when exporting
 pref.export.general.failFastOnError=Cancel export immediately in case of errors
 pref.export.general.computeNumberMatched=Compute number of matching top-level objects
 pref.export.general.label.compressedFormat=Output format for compressed exports
-pref.export.general.border.bbox=Bounding box options
 pref.export.general.label.feature=Export bounding box
 pref.export.general.feature.topLevel=Only for top-level objects
 pref.export.general.feature.all=For all objects
 pref.export.general.feature.none=Do not export object bounding boxes
+pref.export.general.border.metadata=Dataset metadata
+pref.export.general.label.datasetName=Name
+pref.export.general.label.datasetDescription=Description
 pref.export.general.label.cityModel=Calculate and export bounding box for entire dataset
 pref.export.general.label.useTileExtent=Use tile extent when tiling is enabled
 


### PR DESCRIPTION
This PR adds/rearranges the UI options to set the dataset name, description and bounding box.

The options are available under "Preferences -> Export -> General":

![image](https://user-images.githubusercontent.com/5517439/212271404-569e78e5-811d-40f6-bb63-47254296b96c.png)

Both the dataset name and description support tokens. The tokens are replaced with the following values:
- row/column: If tiling is enabled, row and column are taken from the active tile. Otherwise both are set to 0.
- minx/miny/maxx/maxy: If the option is enabled to calculate the BBOX for the entire dataset, the values are taken from this BBOX. Otherwise, they are set to 0.0