### PR TITLE
Fix query builder

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/query/builder/sql/PredicateBuilder.java
+++ b/impexp-core/src/main/java/org/citydb/core/query/builder/sql/PredicateBuilder.java
@@ -135,7 +135,7 @@ public class PredicateBuilder {
 
 	private boolean requiresLeftJoins(Predicate predicate) {
 		if (predicate instanceof NotOperator)
-			requiresLeftJoins(((NotOperator) predicate).getOperand());
+			return requiresLeftJoins(((NotOperator) predicate).getOperand());
 		else if (predicate instanceof BinaryLogicalOperator) {
 			BinaryLogicalOperator binaryOperator = (BinaryLogicalOperator) predicate;
 			if (binaryOperator.getOperatorName() == LogicalOperatorName.OR)


### PR DESCRIPTION
This PR fixes the query builder to correctly determine whether to use left joins or inner joins in case `<not>` is used as logical operand.