### PR TITLE
Fix NPE due to duplicate ZIP entries

### DIFF
--- a/impexp-core/src/main/java/org/citydb/core/file/output/ZipOutputFile.java
+++ b/impexp-core/src/main/java/org/citydb/core/file/output/ZipOutputFile.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.zip.ZipEntry;
@@ -130,8 +131,9 @@ public class ZipOutputFile extends AbstractArchiveOutputFile {
 
             // merge scatter screams into final zip
             log.info("Merging temporary files to target ZIP file...");
+            Set<String> entries = new HashSet<>();
             for (ScatterZipOutputStream scatterStream : scatterStreams) {
-                scatterStream.writeTo(out);
+                scatterStream.writeTo(out, entries);
                 scatterStream.close();
             }
         } catch (InterruptedException e) {


### PR DESCRIPTION
When exporting to a ZIP file, the process may fail with a NPE due to duplicate entries in the ZIP directory. This PR proposes a fix by ensuring that no duplicate ZIP entries are created.