### PR TITLE
Add option to specify default start mode for plugins

### DIFF
--- a/impexp-client-cli/src/main/java/org/citydb/cli/ImpExpCli.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/ImpExpCli.java
@@ -476,7 +476,7 @@ public class ImpExpCli extends CliCommand implements CommandLine.IVersionProvide
             for (Plugin plugin : pluginManager.getExternalPlugins()) {
                 boolean enable = enabledPlugins != null ?
                         enabledPlugins.getOrDefault(plugin.getClass().getName(), false) :
-                        config.isPluginEnabled(plugin.getClass().getName());
+                        config.isPluginEnabled(plugin.getClass().getName(), plugin.getMetadata().isStartEnabled());
 
                 plugins.put(plugin, enable);
             }

--- a/impexp-config/src/main/java/org/citydb/config/Config.java
+++ b/impexp-config/src/main/java/org/citydb/config/Config.java
@@ -112,8 +112,8 @@ public class Config {
 		projectConfig.setGlobalConfig(globalConfig);
 	}
 
-	public boolean isPluginEnabled(String pluginClass) {
-		return projectConfig.isPluginEnabled(pluginClass);
+	public boolean isPluginEnabled(String pluginClass, boolean defaultValue) {
+		return projectConfig.isPluginEnabled(pluginClass, defaultValue);
 	}
 
 	public void setPluginEnabled(String pluginClass, boolean enable) {

--- a/impexp-config/src/main/java/org/citydb/config/ProjectConfig.java
+++ b/impexp-config/src/main/java/org/citydb/config/ProjectConfig.java
@@ -165,8 +165,8 @@ public class ProjectConfig {
         }
     }
 
-    boolean isPluginEnabled(String pluginClass) {
-        return plugins.getOrDefault(pluginClass, true);
+    boolean isPluginEnabled(String pluginClass, boolean defaultValue) {
+        return plugins.getOrDefault(pluginClass, defaultValue);
     }
 
     void setPluginEnabled(String pluginClass, boolean enable) {

--- a/impexp-core/src/main/java/org/citydb/core/plugin/metadata/PluginMetadata.java
+++ b/impexp-core/src/main/java/org/citydb/core/plugin/metadata/PluginMetadata.java
@@ -19,6 +19,7 @@ public class PluginMetadata {
     private PluginVendor vendor;
     @XmlElement(name = "ade-support", defaultValue = "false")
     private Boolean adeSupport;
+    private Boolean startEnabled;
 
     public String getName() {
         return name;
@@ -81,5 +82,13 @@ public class PluginMetadata {
 
     public void setADESupport(boolean adeSupport) {
         this.adeSupport = adeSupport;
+    }
+
+    public boolean isStartEnabled() {
+        return startEnabled != null ? startEnabled : true;
+    }
+
+    public void setStartEnabled(boolean startEnabled) {
+        this.startEnabled = startEnabled;
     }
 }


### PR DESCRIPTION
This PR adds a `<startEnabled>` option to the `plugin.xml` configuration of plugins. The option defines whether the plugin should start in enabled mode (default: true). This option is overriden by the `isEnabled` flag in the general config file of the Importer/Exporter and the `--use-plugin` CLI parameter. 