### PR TITLE
refactor: removed complex conditional statement in toQueryConfig function in QueryOption class

### DIFF
--- a/impexp-client-cli/src/main/java/org/citydb/cli/operation/deleter/QueryOption.java
+++ b/impexp-client-cli/src/main/java/org/citydb/cli/operation/deleter/QueryOption.java
@@ -68,14 +68,20 @@ public class QueryOption implements CliOption {
     @CommandLine.ArgGroup
     private XMLQueryOption xmlQueryOption;
 
+    private boolean canCreateQueryConfig() {
+        return (
+            typeNamesOption != null
+            || featureVersionOption != null
+            || resourceIdOption != null
+            || databaseIdOption != null
+            || boundingBoxOption != null
+            || counterOption != null
+            || sqlSelectOption != null
+        );
+    }
+
     public QueryConfig toQueryConfig() {
-        if (typeNamesOption != null
-                || featureVersionOption != null
-                || resourceIdOption != null
-                || databaseIdOption != null
-                || boundingBoxOption != null
-                || counterOption != null
-                || sqlSelectOption != null) {
+        if (canCreateQueryConfig()) {
             QueryConfig queryConfig = new QueryConfig();
             List<AbstractPredicate> predicates = new ArrayList<>();
 


### PR DESCRIPTION
In this PR I have extracted a complex conditional to a separate function and gave it proper name for removing complex conditional smell in the code base.

I built the program using command `gradle installDist`, and it built completely without any issues and I was able to run the GUI without any errors. 

If you need any further explanation before merging the PR, please let me know.