### PR TITLE
refactor: removed feature envy smell from Tile class and pushed the method to BoundingBox class

### DIFF
--- a/impexp-config/src/main/java/org/citydb/config/geometry/BoundingBox.java
+++ b/impexp-config/src/main/java/org/citydb/config/geometry/BoundingBox.java
@@ -139,4 +139,10 @@ public class BoundingBox extends AbstractGeometry {
         return GeometryType.ENVELOPE;
     }
 
+    public boolean containsPoint(Position point) {
+        boolean containsX = point.getX() > this.lowerCorner.getX() && point.getX() <= this.upperCorner.getX();
+        boolean containsY = point.getY() > this.lowerCorner.getY() && point.getY() <= this.upperCorner.getY();
+        return containsX && containsY;
+    }
+
 }

--- a/impexp-core/src/main/java/org/citydb/core/query/filter/tiling/Tile.java
+++ b/impexp-core/src/main/java/org/citydb/core/query/filter/tiling/Tile.java
@@ -114,10 +114,7 @@ public class Tile {
             pos = point.getPos();
         }
 
-        return pos.getX() > extent.getLowerCorner().getX()
-                && pos.getX() <= extent.getUpperCorner().getX()
-                && pos.getY() > extent.getLowerCorner().getY()
-                && pos.getY() <= extent.getUpperCorner().getY();
+        return extent.containsPoint(pos);
     }
 
 }


### PR DESCRIPTION
In this PR I have moved the computation of if a point on a tile is inside the bounding box to the BoundingBox class from the Tile class. I also added some intermediate variables to make things more clear for the developers.

I built the program using command `gradle installDist`, and it built completely without any issues and I was able to run the GUI without any errors.

If you need any further explanation before merging the PR, please let me know.